### PR TITLE
Change the docker run message to reflect the config folder change in plex meta manager.

### DIFF
--- a/roles/plex_meta_manager/tasks/main.yml
+++ b/roles/plex_meta_manager/tasks/main.yml
@@ -47,4 +47,4 @@
   debug:
     msg:
       - "You should attempt a manual run first to ensure the config is working and to use oAuth for Trakt config etc. To do this run the below command"
-      - "docker run --rm -it --network=saltbox -v {{ plex_meta_manager_paths_location }}/config:/config {{ plex_meta_manager_docker_image }} --run"
+      - "docker run --rm -it --network=saltbox -v {{ plex_meta_manager_paths_location }}:/config {{ plex_meta_manager_docker_image }} --run"


### PR DESCRIPTION
the message after running the Plex-Meta-Manager tag assumed there was still a nested "config" folder, this change gets rid of that. 