### PR TITLE
Role for PlexTraktSync

### DIFF
--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -25,6 +25,10 @@ ombix:
   roles: ["4k"]
 plex_meta_manager:
   time: "03:00"
+plextraktsync: # overrides only
+  plex_url:
+  plex_token:
+  plex_user:
 qbit_manage:
   qbt_run: "false" # Default is "false"
   qbt_schedule: "30" # Default is "30"

--- a/roles/plextraktsync/defaults/main.yml
+++ b/roles/plextraktsync/defaults/main.yml
@@ -38,8 +38,6 @@ plextraktsync_docker_image: "ghcr.io/taxel/plextraktsync:{{ plextraktsync_docker
 # Envs
 plextraktsync_docker_envs_default:
   TZ: "{{ tz }}"
-  PUID: "{{ uid }}"
-  PGID: "{{ gid }}"
   PLEX_BASEURL: "{{ plextraktsync.plex_url|d('http://' + plex_docker_networks_alias + ':' + plex_web_port,true) }}"
   PLEX_TOKEN: "{{ plextraktsync.plex_token|d(plex_auth_token,true) }}"
   PLEX_USERNAME: "{{ plextraktsync.plex_user|d(omit,true) if plex.user is search('@') else plextraktsync.plex_user|d(plex.user,true) }}"

--- a/roles/plextraktsync/defaults/main.yml
+++ b/roles/plextraktsync/defaults/main.yml
@@ -1,5 +1,5 @@
 ##########################################################################
-# Title:         Sandbox: PlexTraktSync | watch                          #
+# Title:         Sandbox: PlexTraktSync | Default Variables              #
 # Author(s):     keldian                                                 #
 # URL:           https://github.com/saltyorg/Sandbox                     #
 # --                                                                     #

--- a/roles/plextraktsync/defaults/main.yml
+++ b/roles/plextraktsync/defaults/main.yml
@@ -42,7 +42,7 @@ plextraktsync_docker_envs_default:
   PGID: "{{ gid }}"
   PLEX_BASEURL: "{{ plextraktsync.plex_url|d('http://' + plex_docker_networks_alias + ':' + plex_web_port,true) }}"
   PLEX_TOKEN: "{{ plextraktsync.plex_token|d(plex_auth_token,true) }}"
-  PLEX_USERNAME: "{{ plextraktsync.plex_username|d(omit,true) if plex.user is search('@') else plextraktsync.plex_username|d(plex.user,true) }}"
+  PLEX_USERNAME: "{{ plextraktsync.plex_user|d(omit,true) if plex.user is search('@') else plextraktsync.plex_user|d(plex.user,true) }}"
 plextraktsync_docker_envs_custom: {}
 plextraktsync_docker_envs: "{{ plextraktsync_docker_envs_default
                            | combine(plextraktsync_docker_envs_custom) }}"

--- a/roles/plextraktsync/defaults/main.yml
+++ b/roles/plextraktsync/defaults/main.yml
@@ -1,0 +1,114 @@
+##########################################################################
+# Title:         Sandbox: PlexTraktSync | watch                          #
+# Author(s):     keldian                                                 #
+# URL:           https://github.com/saltyorg/Sandbox                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+plextraktsync_name: plextraktsync
+
+################################
+# Paths
+################################
+
+plextraktsync_paths_folder: "{{ plextraktsync_name }}"
+plextraktsync_paths_location: "{{ server_appdata_path }}/{{ plextraktsync_paths_folder }}"
+plextraktsync_config_location: "{{ plextraktsync_paths_location }}/config.json"
+plextraktsync_paths_folders_list:
+  - "{{ plextraktsync_paths_location }}"
+
+################################
+# Docker
+################################
+
+# Container
+plextraktsync_docker_container: "{{ plextraktsync_name }}"
+
+# Image
+plextraktsync_docker_image_pull: true
+plextraktsync_docker_image_tag: "latest"
+plextraktsync_docker_image: "ghcr.io/taxel/plextraktsync:{{ plextraktsync_docker_image_tag }}"
+
+# Envs
+plextraktsync_docker_envs_default:
+  TZ: "{{ tz }}"
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  PLEX_BASEURL: "{{ plextraktsync.plex_url|d('http://' + plex_docker_networks_alias + ':' + plex_web_port,true) }}"
+  PLEX_TOKEN: "{{ plextraktsync.plex_token|d(plex_auth_token,true) }}"
+  PLEX_USERNAME: "{{ plextraktsync.plex_username|d(omit,true) if plex.user is search('@') else plextraktsync.plex_username|d(plex.user,true) }}"
+plextraktsync_docker_envs_custom: {}
+plextraktsync_docker_envs: "{{ plextraktsync_docker_envs_default
+                           | combine(plextraktsync_docker_envs_custom) }}"
+
+# Commands
+plextraktsync_docker_commands_default: 
+  - "watch"
+plextraktsync_docker_commands_custom: []
+plextraktsync_docker_commands: "{{ plextraktsync_docker_commands_default
+                               + plextraktsync_docker_commands_custom }}"
+
+# Volumes
+plextraktsync_docker_volumes_default:
+  - "{{ plextraktsync_paths_location }}:/app/config"
+plextraktsync_docker_volumes_custom: []
+plextraktsync_docker_volumes: "{{ plextraktsync_docker_volumes_default
+                              + plextraktsync_docker_volumes_custom }}"
+
+# Devices
+plextraktsync_docker_devices_default: []
+plextraktsync_docker_devices_custom: []
+plextraktsync_docker_devices: "{{ plextraktsync_docker_devices_default
+                              + plextraktsync_docker_devices_custom }}"
+
+# Hosts
+plextraktsync_docker_hosts_default: []
+plextraktsync_docker_hosts_custom: []
+plextraktsync_docker_hosts: "{{ docker_hosts_common
+                            | combine(plextraktsync_docker_hosts_default)
+                            | combine(plextraktsync_docker_hosts_custom) }}"
+
+# Labels
+plextraktsync_docker_labels_default: {}
+plextraktsync_docker_labels_custom: {}
+plextraktsync_docker_labels: "{{ docker_labels_common
+                             | combine(plextraktsync_docker_labels_default)
+                             | combine(plextraktsync_docker_labels_custom) }}"
+
+# Hostname
+plextraktsync_docker_hostname: "{{ plextraktsync_name }}"
+
+# Networks
+plextraktsync_docker_networks_alias: "{{ plextraktsync_name }}"
+plextraktsync_docker_networks_default: []
+plextraktsync_docker_networks_custom: []
+plextraktsync_docker_networks: "{{ docker_networks_common
+                               + plextraktsync_docker_networks_default
+                               + plextraktsync_docker_networks_custom }}"
+
+# Capabilities
+plextraktsync_docker_capabilities_default: []
+plextraktsync_docker_capabilities_custom: []
+plextraktsync_docker_capabilities: "{{ plextraktsync_docker_capabilities_default
+                                  + plextraktsync_docker_capabilities_custom }}"
+
+# Security Opts
+plextraktsync_docker_security_opts_default: []
+plextraktsync_docker_security_opts_custom: []
+plextraktsync_docker_security_opts: "{{ plextraktsync_docker_security_opts_default
+                                    + plextraktsync_docker_security_opts_custom }}"
+
+# Restart Policy
+plextraktsync_docker_restart_policy: unless-stopped
+
+# State
+plextraktsync_docker_state: started
+
+# User
+plextraktsync_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/plextraktsync/defaults/main.yml
+++ b/roles/plextraktsync/defaults/main.yml
@@ -45,41 +45,41 @@ plextraktsync_docker_envs_default:
   PLEX_USERNAME: "{{ plextraktsync.plex_user|d(omit,true) if plex.user is search('@') else plextraktsync.plex_user|d(plex.user,true) }}"
 plextraktsync_docker_envs_custom: {}
 plextraktsync_docker_envs: "{{ plextraktsync_docker_envs_default
-                           | combine(plextraktsync_docker_envs_custom) }}"
+                               | combine(plextraktsync_docker_envs_custom) }}"
 
 # Commands
 plextraktsync_docker_commands_default: 
   - "watch"
 plextraktsync_docker_commands_custom: []
 plextraktsync_docker_commands: "{{ plextraktsync_docker_commands_default
-                               + plextraktsync_docker_commands_custom }}"
+                                   + plextraktsync_docker_commands_custom }}"
 
 # Volumes
 plextraktsync_docker_volumes_default:
   - "{{ plextraktsync_paths_location }}:/app/config"
 plextraktsync_docker_volumes_custom: []
 plextraktsync_docker_volumes: "{{ plextraktsync_docker_volumes_default
-                              + plextraktsync_docker_volumes_custom }}"
+                                  + plextraktsync_docker_volumes_custom }}"
 
 # Devices
 plextraktsync_docker_devices_default: []
 plextraktsync_docker_devices_custom: []
 plextraktsync_docker_devices: "{{ plextraktsync_docker_devices_default
-                              + plextraktsync_docker_devices_custom }}"
+                                  + plextraktsync_docker_devices_custom }}"
 
 # Hosts
 plextraktsync_docker_hosts_default: []
 plextraktsync_docker_hosts_custom: []
 plextraktsync_docker_hosts: "{{ docker_hosts_common
-                            | combine(plextraktsync_docker_hosts_default)
-                            | combine(plextraktsync_docker_hosts_custom) }}"
+                                | combine(plextraktsync_docker_hosts_default)
+                                | combine(plextraktsync_docker_hosts_custom) }}"
 
 # Labels
 plextraktsync_docker_labels_default: {}
 plextraktsync_docker_labels_custom: {}
 plextraktsync_docker_labels: "{{ docker_labels_common
-                             | combine(plextraktsync_docker_labels_default)
-                             | combine(plextraktsync_docker_labels_custom) }}"
+                                 | combine(plextraktsync_docker_labels_default)
+                                 | combine(plextraktsync_docker_labels_custom) }}"
 
 # Hostname
 plextraktsync_docker_hostname: "{{ plextraktsync_name }}"
@@ -89,20 +89,20 @@ plextraktsync_docker_networks_alias: "{{ plextraktsync_name }}"
 plextraktsync_docker_networks_default: []
 plextraktsync_docker_networks_custom: []
 plextraktsync_docker_networks: "{{ docker_networks_common
-                               + plextraktsync_docker_networks_default
-                               + plextraktsync_docker_networks_custom }}"
+                                   + plextraktsync_docker_networks_default
+                                   + plextraktsync_docker_networks_custom }}"
 
 # Capabilities
 plextraktsync_docker_capabilities_default: []
 plextraktsync_docker_capabilities_custom: []
 plextraktsync_docker_capabilities: "{{ plextraktsync_docker_capabilities_default
-                                  + plextraktsync_docker_capabilities_custom }}"
+                                       + plextraktsync_docker_capabilities_custom }}"
 
 # Security Opts
 plextraktsync_docker_security_opts_default: []
 plextraktsync_docker_security_opts_custom: []
 plextraktsync_docker_security_opts: "{{ plextraktsync_docker_security_opts_default
-                                    + plextraktsync_docker_security_opts_custom }}"
+                                        + plextraktsync_docker_security_opts_custom }}"
 
 # Restart Policy
 plextraktsync_docker_restart_policy: unless-stopped

--- a/roles/plextraktsync/tasks/main.yml
+++ b/roles/plextraktsync/tasks/main.yml
@@ -10,29 +10,25 @@
 - name: Import Default Plex variables
   include_vars: /srv/git/saltbox/roles/plex/defaults/main.yml
 
-- name: Run Role
-  block:
+- name: Remove existing Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 
-    - name: Remove existing Docker container
-      include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
 
-    - name: Create directories
-      file:
-        path: "{{ item }}"
-        state: directory
-        owner: "{{ user.name }}"
-        group: "{{ user.name }}"
-        mode: "0775"
-      with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
-
-    - name: Import Plex Auth Token role
-      import_role:
-        name: plex_auth_token
-
-    - name: Create Docker container
-      include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
-
+- name: Import Plex Auth Token role
+  import_role:
+    name: plex_auth_token
   when: plex_account_is_enabled
+   
+- name: Create Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
 
 - name: Display post-install message
   pause:

--- a/roles/plextraktsync/tasks/main.yml
+++ b/roles/plextraktsync/tasks/main.yml
@@ -1,0 +1,52 @@
+##########################################################################
+# Title:            Sandbox: PlexTraktSync Role                          #
+# Author(s):        keldian                                              #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Import Default Plex variables
+  include_vars: /srv/git/saltbox/roles/plex/defaults/main.yml
+
+- name: Run Role
+  block:
+
+    - name: Remove existing Docker container
+      include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+    - name: Create directories
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ user.name }}"
+        group: "{{ user.name }}"
+        mode: "0775"
+      with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+    - name: Import Plex Auth Token role
+      import_role:
+        name: plex_auth_token
+
+    - name: Create Docker container
+      include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+
+  when: plex_account_is_enabled
+
+- name: Display post-install message
+  pause:
+    seconds: 1
+    prompt: |
+    
+      ##### First install? #############################################
+      #                                                                #
+      #                        TO FINISH SETUP:                        #
+      #                                                                #
+      #  1. Set your preferences in {{ plextraktsync_config_location }}     #
+      #                                                                #
+      #  2. Run the following command (and follow the instructions):   #
+      #                                                                #
+      #  docker exec -it {{ plextraktsync_name }} python3 -m plextraktsync login  #
+      #                                                                #
+      ##################################################################

--- a/roles/plextraktsync/tasks/main.yml
+++ b/roles/plextraktsync/tasks/main.yml
@@ -26,7 +26,7 @@
   import_role:
     name: plex_auth_token
   when: plex_account_is_enabled
-   
+
 - name: Create Docker container
   include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
 
@@ -34,7 +34,7 @@
   pause:
     seconds: 1
     prompt: |
-    
+
       ##### First install? #############################################
       #                                                                #
       #                        TO FINISH SETUP:                        #

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -71,8 +71,11 @@
     - { role: ombi, tags: ['ombi'] }
     - { role: ombix, tags: ['ombix'] }
     - { role: ouroboros, tags: ['ouroboros'] }
+    - { role: plex_dupefinder, tags: ['plex_dupefinder'] }
     - { role: plex_meta_manager, tags: ['plex-meta-manager'] }
+    - { role: plex_patrol, tags: ['plex_patrol'] }
     - { role: plextraktsync, tags: ['plextraktsync'] }
+    - { role: python_plexlibrary, tags: ['python-plexlibrary'] }
     - { role: qbit_manage, tags: ['qbit_manage'] }
     - { role: requestrr, tags: ['requestrr'] }
     - { role: requestrrx, tags: ['requestrrx'] }

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -72,6 +72,7 @@
     - { role: ombix, tags: ['ombix'] }
     - { role: ouroboros, tags: ['ouroboros'] }
     - { role: plex_meta_manager, tags: ['plex-meta-manager'] }
+    - { role: plextraktsync, tags: ['plextraktsync'] }
     - { role: qbit_manage, tags: ['qbit_manage'] }
     - { role: requestrr, tags: ['requestrr'] }
     - { role: requestrrx, tags: ['requestrrx'] }


### PR DESCRIPTION
Official docker image **ghcr.io/taxel/plextraktsync** with **watch** command appended so that it runs as a server and scrobbles plays. 

Library sync automation not included (maybe we can work that in later), but can be done by adding `docker exec -it plextraktsync python3 -m plextraktsync sync` to crontab, for example.

The container would not stay up without a valid Plex server to connect to, so I set the envs to login to the local Plex server by default, with override settings in _settings.yml_.

I tried my hand at customizing the tag feed with some eye-catching setup instructions, hoping they will be noticed. ¯\_(シ)_/¯