### PR TITLE
PlexTraktSync: Rework

### DIFF
--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -25,10 +25,6 @@ ombix:
   roles: ["4k"]
 plex_meta_manager:
   time: "03:00"
-plextraktsync: # overrides only
-  plex_url:
-  plex_token:
-  plex_user:
 qbit_manage:
   qbt_run: "false" # Default is "false"
   qbt_schedule: "30" # Default is "30"

--- a/roles/plextraktsync/defaults/main.yml
+++ b/roles/plextraktsync/defaults/main.yml
@@ -19,7 +19,7 @@ plextraktsync_name: plextraktsync
 
 plextraktsync_paths_folder: "{{ plextraktsync_name }}"
 plextraktsync_paths_location: "{{ server_appdata_path }}/{{ plextraktsync_paths_folder }}"
-plextraktsync_config_location: "{{ plextraktsync_paths_location }}/config.json"
+plextraktsync_paths_config_location: "{{ plextraktsync_paths_location }}/.env"
 plextraktsync_paths_folders_list:
   - "{{ plextraktsync_paths_location }}"
 
@@ -38,9 +38,6 @@ plextraktsync_docker_image: "ghcr.io/taxel/plextraktsync:{{ plextraktsync_docker
 # Envs
 plextraktsync_docker_envs_default:
   TZ: "{{ tz }}"
-  PLEX_BASEURL: "{{ plextraktsync.plex_url|d('http://' + plex_docker_networks_alias + ':' + plex_web_port,true) }}"
-  PLEX_TOKEN: "{{ plextraktsync.plex_token|d(plex_auth_token,true) }}"
-  PLEX_USERNAME: "{{ plextraktsync.plex_user|d(omit,true) if plex.user is search('@') else plextraktsync.plex_user|d(plex.user,true) }}"
 plextraktsync_docker_envs_custom: {}
 plextraktsync_docker_envs: "{{ plextraktsync_docker_envs_default
                                | combine(plextraktsync_docker_envs_custom) }}"
@@ -107,6 +104,9 @@ plextraktsync_docker_restart_policy: unless-stopped
 
 # State
 plextraktsync_docker_state: started
+
+# Stop Timeout
+plextraktsync_docker_stop_timeout: 10
 
 # User
 plextraktsync_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/plextraktsync/tasks/main.yml
+++ b/roles/plextraktsync/tasks/main.yml
@@ -7,9 +7,6 @@
 #                   GNU General Public License v3.0                      #
 ##########################################################################
 ---
-- name: Import Default Plex variables
-  include_vars: /srv/git/saltbox/roles/plex/defaults/main.yml
-
 - name: Remove existing Docker container
   include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 
@@ -22,27 +19,17 @@
     mode: "0775"
   with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
 
-- name: Import Plex Auth Token role
-  import_role:
-    name: plex_auth_token
-  when: plex_account_is_enabled
+- name: Check if `{{ plextraktsync_paths_config_location | basename }}` exists
+  stat:
+    path: "{{ plextraktsync_paths_config_location }}"
+  register: plextraktsync_env
+
+- name: Pre-Install Tasks
+  include_tasks: "subtasks/pre-install/main.yml"
+  when: not plextraktsync_env.stat.exists
 
 - name: Create Docker container
   include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
 
-- name: Display post-install message
-  pause:
-    seconds: 1
-    prompt: |
-
-      ##### First install? #############################################
-      #                                                                #
-      #                        TO FINISH SETUP:                        #
-      #                                                                #
-      #  1. Set your preferences in {{ plextraktsync_config_location }}     #
-      #                                                                #
-      #  2. Run the following command (and follow the instructions):   #
-      #                                                                #
-      #  docker exec -it {{ plextraktsync_name }} python3 -m plextraktsync login  #
-      #                                                                #
-      ##################################################################
+- name: Post-Install Tasks
+  import_tasks: "subtasks/post-install/main.yml"

--- a/roles/plextraktsync/tasks/subtasks/post-install/main.yml
+++ b/roles/plextraktsync/tasks/subtasks/post-install/main.yml
@@ -55,4 +55,4 @@
       ╚════════════════════════════════════════════════════════════════╝
 
   when: not plextraktsync_env_trakt_username.found or
-    not plextraktsync_pytrakt.stat.exists
+        not plextraktsync_pytrakt.stat.exists

--- a/roles/plextraktsync/tasks/subtasks/post-install/main.yml
+++ b/roles/plextraktsync/tasks/subtasks/post-install/main.yml
@@ -1,0 +1,58 @@
+##########################################################################
+# Title:            Sandbox: PlexTraktSync Role                          #
+# Author(s):        keldian                                              #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Post-Install | Check if `.pytrakt.json` exists
+  stat:
+    path: "{{ plextraktsync_paths_location }}/.pytrakt.json"
+  register: plextraktsync_pytrakt
+
+- name: Post-Install | Check if a Trakt.tv username is provided
+  lineinfile:
+    path: "{{ plextraktsync_paths_config_location }}"
+    regexp: '^TRAKT_USERNAME=(?!\s*$).+'
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: plextraktsync_env_trakt_username
+
+- name: Post-Install | Check if a Plex.tv username is provided
+  lineinfile:
+    path: "{{ plextraktsync_paths_config_location }}"
+    regexp: '^PLEX_USERNAME=(?!\s*$).+'
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: plextraktsync_env_plex_username
+
+- name: Post-Install | Warn if no Plex.tv username is provided
+  debug:
+    msg:
+      Username not found for Plex. If a user is not specified, watch activity from ALL
+      users of the target Plex server will be scrobbled to the target Trakt.tv account.
+  when: not plextraktsync_env_plex_username.found
+
+- name: Post-Install | Guide if Trakt.tv login data is missing
+  pause:
+    seconds: 1
+    prompt: |
+
+      ╔════ Fresh install detected ════════════════════════════════════╗
+      ║                                                                ║
+      ║                        TO FINISH SETUP                         ║
+      ║                                                                ║
+      ║  1. Set your preferences in {{ plextraktsync_paths_location + '/config.json     ║' }}
+      ║                                                                ║
+      ║  2. Run the below command and follow the interactive script    ║
+      ║                                                                ║
+      ║  docker exec -it {{ plextraktsync_name + ' python3 -m plextraktsync login  ║' }}
+      ║                                                                ║
+      ╚════════════════════════════════════════════════════════════════╝
+
+  when: not plextraktsync_env_trakt_username.found or
+    not plextraktsync_pytrakt.stat.exists

--- a/roles/plextraktsync/tasks/subtasks/pre-install/main.yml
+++ b/roles/plextraktsync/tasks/subtasks/pre-install/main.yml
@@ -1,0 +1,51 @@
+##########################################################################
+# Title:            Sandbox: PlexTraktSync Role                          #
+# Author(s):        keldian                                              #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Pre-Install | Import Default Plex variables
+  include_vars: /srv/git/saltbox/roles/plex/defaults/main.yml
+
+- name: Pre-Install | Check if {{ plex_paths_config_location | basename }} exists
+  stat:
+    path: "{{ plex_paths_config_location }}"
+  register: preferences_xml
+
+- name: Pre-Install | {{ plex_paths_config_location | basename }} Tasks
+  block:
+    - name: Pre-Install | Get {{ plex_paths_config_location | basename }} XML data
+      xml:
+        path: "{{ plex_paths_config_location }}"
+        xpath: /Preferences
+        content: attribute
+      register: preferences_xml_resp
+
+    - name: Pre-Install | Set plex_admin_username variable
+      set_fact:
+        plex_admin_username: "{{ preferences_xml_resp.matches[0].Preferences.PlexOnlineUsername }}"
+
+  ignore_errors: true
+  when: preferences_xml.stat.exists
+
+- name: Pre-Install | Plex Auth Token tasks
+  import_role:
+    name: plex_auth_token
+
+- name: Pre-Install | Create {{ plextraktsync_paths_config_location | basename }}
+  copy:
+    content: |
+      # This is .env file for PlexTraktSync
+      PLEX_BASEURL=
+      PLEX_FALLBACKURL={{ 'http://localhost:' + plex_web_port }}
+      PLEX_LOCALURL={{ 'http://' + plex_docker_networks_alias + ':' + plex_web_port }}
+      PLEX_TOKEN={{ plex_auth_token | d('') }}
+      PLEX_USERNAME={{ plex_admin_username | d('') | escape }}
+      TRAKT_USERNAME=
+    dest: "{{ plextraktsync_paths_config_location }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664

--- a/roles/plextraktsync/tasks/subtasks/pre-install/main.yml
+++ b/roles/plextraktsync/tasks/subtasks/pre-install/main.yml
@@ -34,6 +34,7 @@
 - name: Pre-Install | Plex Auth Token tasks
   import_role:
     name: plex_auth_token
+  when: plex_account_is_enabled
 
 - name: Pre-Install | Create {{ plextraktsync_paths_config_location | basename }}
   copy:

--- a/roles/plextraktsync/tasks/subtasks/pre-install/main.yml
+++ b/roles/plextraktsync/tasks/subtasks/pre-install/main.yml
@@ -24,9 +24,9 @@
         content: attribute
       register: preferences_xml_resp
 
-    - name: Pre-Install | Set plex_admin_username variable
+    - name: Pre-Install | Set plex_host_username variable
       set_fact:
-        plex_admin_username: "{{ preferences_xml_resp.matches[0].Preferences.PlexOnlineUsername }}"
+        plex_host_username: "{{ preferences_xml_resp.matches[0].Preferences.PlexOnlineUsername }}"
 
   ignore_errors: true
   when: preferences_xml.stat.exists
@@ -41,10 +41,9 @@
     content: |
       # This is .env file for PlexTraktSync
       PLEX_BASEURL=
-      PLEX_FALLBACKURL={{ 'http://localhost:' + plex_web_port }}
       PLEX_LOCALURL={{ 'http://' + plex_docker_networks_alias + ':' + plex_web_port }}
       PLEX_TOKEN={{ plex_auth_token | d('') }}
-      PLEX_USERNAME={{ plex_admin_username | d('') | escape }}
+      PLEX_USERNAME={{ plex_host_username | d('') | escape }}
       TRAKT_USERNAME=
     dest: "{{ plextraktsync_paths_config_location }}"
     owner: "{{ user.name }}"


### PR DESCRIPTION
Take two...

- Plex envs are now fully applied with the .env file instead of Docker parameters
- More reliable way to retrieve a valid Plex username to use by default
- Added another post-install message
- Reinstall will no longer get stuck on "Remove existing Docker container" past 10 seconds
- Settings.yml block removed, since any change in setup should be done via the built-in interactive script