### PR TITLE
saltbox_mod : installation role for saltbox_mod

### DIFF
--- a/roles/saltbox_mod/defaults/main.yml
+++ b/roles/saltbox_mod/defaults/main.yml
@@ -1,0 +1,27 @@
+#########################################################################
+# Title:         Saltbox: saltbox_mod Role                              #
+# Author(s):     Grostim                                                #
+# URL:           https://github.com/saltyorg/Saltbox                    #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+
+saltbox_mod_name: saltbox_mod
+
+################################
+# Paths
+################################
+
+saltbox_mod_paths_folder: "{{ saltbox_mod_name }}" /
+saltbox_mod_paths_location: "{{ server_appdata_path }}/{{ saltbox_mod_paths_folder }}"
+
+################################
+# Git Repository 
+################################
+
+saltbox_mod_repo: "https://github.com/saltyorg/saltbox_mod.git"

--- a/roles/saltbox_mod/tasks/main.yml
+++ b/roles/saltbox_mod/tasks/main.yml
@@ -1,0 +1,42 @@
+#########################################################################
+# Title:         Saltbox: saltbox_mod Role                              #
+# Author(s):     Grostim                                                #
+# URL:           https://github.com/saltyorg/Saltbox                    #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Create saltbox_mod directory
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0775
+    recurse: yes
+  with_items:
+    - "{{ saltbox_mod_paths_location }}"
+
+- name: Clone saltbox_mod repo 'HEAD'
+  git:
+    repo: "{{ saltbox_mod_repo }}"
+    dest: "{{ saltbox_mod_paths_location }}"
+    clone: true
+    version: HEAD
+    force: true
+  become: true
+  become_user: "{{ user.name }}"
+  ignore_errors: true
+  register: saltbox_mod_clone_status
+
+- name: Clone saltbox_mod repo 'master'
+  git:
+    repo: "{{ saltbox_mod_repo }}"
+    dest: "{{ saltbox_mod_paths_location }}"
+    clone: true
+    version: master
+    force: true
+  become: true
+  become_user: "{{ user.name }}"
+  when: saltbox_mod_clone_status is failed

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -85,6 +85,7 @@
     - { role: rflood, tags: ['rflood'] }
     - { role: rfloodx, tags: ['rfloodx'] }
     - { role: rocketchat, tags: ['rocketchat'] }
+    - { role: saltbox_mod, tags: ['saltbox_mod'] }
     - { role: speedtest, tags: ['speedtest'] }
     - { role: sshwifty, tags: ['sshwifty'] }
     - { role: stash, tags: ['stash'] }


### PR DESCRIPTION
# Description

As discussed on discord. A simple role to help installing/reinstalling saltbox_mod.
salbox_mod repo should be forked by each user and the the repo address customized in the inventory : `saltbox_mod_repo`


# How Has This Been Tested?

Tested on my server.
