### PR TITLE
Add transmissionvpn role

### DIFF
--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -70,3 +70,7 @@ rfloodx:
   roles: [""]
 transmissionx:
   roles: [""]
+transmissionvpn:
+  vpn_user:
+  vpn_pass:
+  vpn_prov:

--- a/roles/transmissionvpn/defaults/main.yml
+++ b/roles/transmissionvpn/defaults/main.yml
@@ -1,6 +1,6 @@
 ##########################################################################
 # Title:         Sandbox: Transmission VPN | Default Variables           #
-# Author(s):     ayykamp                                                 #
+# Author(s):     Tarek, ayykamp                                          #
 # URL:           https://github.com/saltyorg/Sandbox                     #
 # --                                                                     #
 ##########################################################################
@@ -19,13 +19,15 @@ transmissionvpn_name: transmissionvpn
 
 transmissionvpn_paths_folder: "{{ transmissionvpn_name }}"
 transmissionvpn_paths_location: "{{ server_appdata_path }}/{{ transmissionvpn_paths_folder }}"
+transmissionvpn_paths_downloads_location: "{{ downloads.torrents }}/{{ transmissionvpn_paths_folder }}"
+
 transmissionvpn_paths_folders_list:
-  - "{{ downloads.torrents }}"
-  - "{{ downloads.torrents }}/transmissionvpn"
-  - "{{ downloads.torrents }}/transmissionvpn/completed"
-  - "{{ downloads.torrents }}/transmissionvpn/incoming"
-  - "{{ downloads.torrents }}/transmissionvpn/watched"
-  - "{{ downloads.torrents }}/transmissionvpn/torrents"
+  - "{{ transmissionvpn_paths_location }}"
+  - "{{ transmissionvpn_paths_downloads_location }}"
+  - "{{ transmissionvpn_paths_downloads_location }}/completed"
+  - "{{ transmissionvpn_paths_downloads_location }}/incoming"
+  - "{{ transmissionvpn_paths_downloads_location }}/watched"
+  - "{{ transmissionvpn_paths_downloads_location }}/torrents"
 
 ################################
 # Web
@@ -35,8 +37,8 @@ transmissionvpn_web_subdomain: "{{ transmissionvpn_name }}"
 transmissionvpn_web_domain: "{{ user.domain }}"
 transmissionvpn_web_port: "9091"
 transmissionvpn_web_url: "{{ 'https://' + transmissionvpn_web_subdomain + '.' + transmissionvpn_web_domain
-                    if (reverse_proxy_is_enabled)
-                    else 'http://localhost:' + transmissionvpn_web_port }}"
+                          if (reverse_proxy_is_enabled)
+                          else 'http://localhost:' + transmissionvpn_web_port }}"
 
 ################################
 # DNS
@@ -81,11 +83,11 @@ transmissionvpn_docker_ports_torrents:
   - "51413:51413"
 transmissionvpn_docker_ports_custom: []
 transmissionvpn_docker_ports: "{{ transmissionvpn_docker_ports_defaults
-                            + transmissionvpn_docker_ports_torrents
-                            + transmissionvpn_docker_ports_custom
-                         if (not reverse_proxy_is_enabled)
-                         else [] + transmissionvpn_docker_ports_torrents
-                            + transmissionvpn_docker_ports_custom }}"
+                                  + transmissionvpn_docker_ports_torrents
+                                  + transmissionvpn_docker_ports_custom
+                               if (not reverse_proxy_is_enabled)
+                               else [] + transmissionvpn_docker_ports_torrents
+                                  + transmissionvpn_docker_ports_custom }}"
 
 # Envs
 transmissionvpn_docker_envs_default:
@@ -101,46 +103,46 @@ transmissionvpn_docker_envs_default:
 
 transmissionvpn_docker_envs_custom: {}
 transmissionvpn_docker_envs: "{{ transmissionvpn_docker_envs_default
-                           | combine(transmissionvpn_docker_envs_custom) }}"
+                                 | combine(transmissionvpn_docker_envs_custom) }}"
 
 # Commands
 transmissionvpn_docker_commands_default: []
 transmissionvpn_docker_commands_custom: []
 transmissionvpn_docker_commands: "{{ transmissionvpn_docker_commands_default
-                               + transmissionvpn_docker_commands_custom }}"
+                                     + transmissionvpn_docker_commands_custom }}"
 
 # Volumes
 transmissionvpn_docker_volumes_default:
   - "{{ transmissionvpn_paths_location }}:/config"
   - "{{ transmissionvpn_paths_location }}/data:/opt/transmissionvpn"
-  - "/opt/scripts:/scripts"
-  - "/opt/transmissionvpn/vpn:/etc/openvpn/custom"
-  - "/mnt/local/downloads/torrents/transmissionvpn:/data"
+  - "{{ server_appdata_path }}/scripts:/scripts"
+  - "{{ transmissionvpn_paths_location }}/vpn:/etc/openvpn/custom"
+  - "{{ transmissionvpn_paths_downloads_location }}:/data"
   - "/mnt:/mnt"
 transmissionvpn_docker_volumes_custom: []
 transmissionvpn_docker_volumes: "{{ transmissionvpn_docker_volumes_default
-                              + transmissionvpn_docker_volumes_custom
-                              + docker_volumes_downloads_common }}"
+                                    + transmissionvpn_docker_volumes_custom
+                                    + docker_volumes_downloads_common }}"
 
 # Devices
 transmissionvpn_docker_devices_default: []
 transmissionvpn_docker_devices_custom: []
 transmissionvpn_docker_devices: "{{ transmissionvpn_docker_devices_default
-                              + transmissionvpn_docker_devices_custom }}"
+                                    + transmissionvpn_docker_devices_custom }}"
 
 # Hosts
 transmissionvpn_docker_hosts_default: []
 transmissionvpn_docker_hosts_custom: []
 transmissionvpn_docker_hosts: "{{ docker_hosts_common
-                            | combine(transmissionvpn_docker_hosts_default)
-                            | combine(transmissionvpn_docker_hosts_custom) }}"
+                                  | combine(transmissionvpn_docker_hosts_default)
+                                  | combine(transmissionvpn_docker_hosts_custom) }}"
 
 # Labels
 transmissionvpn_docker_labels_default: {}
 transmissionvpn_docker_labels_custom: {}
 transmissionvpn_docker_labels: "{{ docker_labels_common
-                             | combine(transmissionvpn_docker_labels_default)
-                             | combine(transmissionvpn_docker_labels_custom) }}"
+                                   | combine(transmissionvpn_docker_labels_default)
+                                   | combine(transmissionvpn_docker_labels_custom) }}"
 
 # Hostname
 transmissionvpn_docker_hostname: "{{ transmissionvpn_name }}"
@@ -150,21 +152,21 @@ transmissionvpn_docker_networks_alias: "{{ transmissionvpn_name }}"
 transmissionvpn_docker_networks_default: []
 transmissionvpn_docker_networks_custom: []
 transmissionvpn_docker_networks: "{{ docker_networks_common
-                               + transmissionvpn_docker_networks_default
-                               + transmissionvpn_docker_networks_custom }}"
+                                     + transmissionvpn_docker_networks_default
+                                     + transmissionvpn_docker_networks_custom }}"
 
 # Capabilities
 transmissionvpn_docker_capabilities_default:
   - NET_ADMIN
 transmissionvpn_docker_capabilities_custom: []
 transmissionvpn_docker_capabilities: "{{ transmissionvpn_docker_capabilities_default
-                                   + transmissionvpn_docker_capabilities_custom }}"
+                                         + transmissionvpn_docker_capabilities_custom }}"
 
 # Security Opts
 transmissionvpn_docker_security_opts_default: []
 transmissionvpn_docker_security_opts_custom: []
 transmissionvpn_docker_security_opts: "{{ transmissionvpn_docker_security_opts_default
-                                    + transmissionvpn_docker_security_opts_custom }}"
+                                          + transmissionvpn_docker_security_opts_custom }}"
 
 # Restart Policy
 transmissionvpn_docker_restart_policy: unless-stopped

--- a/roles/transmissionvpn/defaults/main.yml
+++ b/roles/transmissionvpn/defaults/main.yml
@@ -19,7 +19,7 @@ transmissionvpn_name: transmissionvpn
 
 transmissionvpn_paths_folder: "{{ transmissionvpn_name }}"
 transmissionvpn_paths_location: "{{ server_appdata_path }}/{{ transmissionvpn_paths_folder }}"
-transmissionvpn_paths_downloads_location: "{{ downloads.torrents }}/{{ transmissionvpn_paths_folder }}"
+transmissionvpn_paths_downloads_location: "{{ downloads_torrents_path }}/{{ transmissionvpn_paths_folder }}"
 
 transmissionvpn_paths_folders_list:
   - "{{ transmissionvpn_paths_location }}"
@@ -114,11 +114,9 @@ transmissionvpn_docker_volumes_default:
   - "{{ server_appdata_path }}/scripts:/scripts"
   - "{{ transmissionvpn_paths_location }}/vpn:/etc/openvpn/custom"
   - "{{ transmissionvpn_paths_downloads_location }}:/data"
-  - "/mnt:/mnt"
 transmissionvpn_docker_volumes_custom: []
 transmissionvpn_docker_volumes: "{{ transmissionvpn_docker_volumes_default
-                                    + transmissionvpn_docker_volumes_custom
-                                    + docker_volumes_downloads_common }}"
+                                    + transmissionvpn_docker_volumes_custom }}"
 
 # Devices
 transmissionvpn_docker_devices_default: []

--- a/roles/transmissionvpn/defaults/main.yml
+++ b/roles/transmissionvpn/defaults/main.yml
@@ -1,0 +1,180 @@
+##########################################################################
+# Title:         Sandbox: Transmission VPN | Default Variables           #
+# Author(s):     ayykamp                                                 #
+# URL:           https://github.com/saltyorg/Sandbox                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+transmissionvpn_name: transmissionvpn
+
+################################
+# Paths
+################################
+
+transmissionvpn_paths_folder: "{{ transmissionvpn_name }}"
+transmissionvpn_paths_location: "{{ server_appdata_path }}/{{ transmissionvpn_paths_folder }}"
+transmissionvpn_paths_folders_list:
+  - "{{ downloads.torrents }}"
+  - "{{ downloads.torrents }}/transmissionvpn"
+  - "{{ downloads.torrents }}/transmissionvpn/completed"
+  - "{{ downloads.torrents }}/transmissionvpn/incoming"
+  - "{{ downloads.torrents }}/transmissionvpn/watched"
+  - "{{ downloads.torrents }}/transmissionvpn/torrents"
+
+################################
+# Web
+################################
+
+transmissionvpn_web_subdomain: "{{ transmissionvpn_name }}"
+transmissionvpn_web_domain: "{{ user.domain }}"
+transmissionvpn_web_port: "9091"
+transmissionvpn_web_url: "{{ 'https://' + transmissionvpn_web_subdomain + '.' + transmissionvpn_web_domain
+                    if (reverse_proxy_is_enabled)
+                    else 'http://localhost:' + transmissionvpn_web_port }}"
+
+################################
+# DNS
+################################
+
+transmissionvpn_dns_record: "{{ transmissionvpn_web_subdomain }}"
+transmissionvpn_dns_zone: "{{ transmissionvpn_web_domain }}"
+transmissionvpn_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+transmissionvpn_traefik_middleware: "{{ traefik_default_middleware }}"
+transmissionvpn_traefik_certresolver: "{{ traefik_default_certresolver }}"
+transmissionvpn_traefik_enabled: true
+
+################################
+# Settings
+################################
+
+transmissionvpn_create_tun_device: "false"
+transmissionvpn_transmission_home: "/opt/transmissionvpn"
+transmissionvpn_umask_set: "022"
+
+################################
+# Docker
+################################
+
+# Container
+transmissionvpn_docker_container: "{{ transmissionvpn_name }}"
+
+# Image
+transmissionvpn_docker_image_pull: true
+transmissionvpn_docker_image_tag: "latest"
+transmissionvpn_docker_image: "haugene/transmission-openvpn:{{ transmissionvpn_docker_image_tag }}"
+
+# Ports
+transmissionvpn_docker_ports_defaults:
+  - "{{ transmissionvpn_web_port }}"
+transmissionvpn_docker_ports_torrents:
+  - "51413:51413"
+transmissionvpn_docker_ports_custom: []
+transmissionvpn_docker_ports: "{{ transmissionvpn_docker_ports_defaults
+                            + transmissionvpn_docker_ports_torrents
+                            + transmissionvpn_docker_ports_custom
+                         if (not reverse_proxy_is_enabled)
+                         else [] + transmissionvpn_docker_ports_torrents
+                            + transmissionvpn_docker_ports_custom }}"
+
+# Envs
+transmissionvpn_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+  OPENVPN_PROVIDER: "{{ transmissionvpn.vpn_prov|default('pia',true) }}"
+  OPENVPN_USERNAME: "{{ transmissionvpn.vpn_user|default('username',true) }}"
+  OPENVPN_PASSWORD: "{{ transmissionvpn.vpn_pass|default('password',true) }}"
+  UMASK_SET: "{{ transmissionvpn_umask_set }}"
+  CREATE_TUN_DEVICE: " {{ transmissionvpn_create_tun_device }}"
+  TRANSMISSION_HOME: " {{ transmissionvpn_transmission_home }}"
+
+transmissionvpn_docker_envs_custom: {}
+transmissionvpn_docker_envs: "{{ transmissionvpn_docker_envs_default
+                           | combine(transmissionvpn_docker_envs_custom) }}"
+
+# Commands
+transmissionvpn_docker_commands_default: []
+transmissionvpn_docker_commands_custom: []
+transmissionvpn_docker_commands: "{{ transmissionvpn_docker_commands_default
+                               + transmissionvpn_docker_commands_custom }}"
+
+# Volumes
+transmissionvpn_docker_volumes_default:
+  - "{{ transmissionvpn_paths_location }}:/config"
+  - "{{ transmissionvpn_paths_location }}/data:/opt/transmissionvpn"
+  - "/opt/scripts:/scripts"
+  - "/opt/transmissionvpn/vpn:/etc/openvpn/custom"
+  - "/mnt/local/downloads/torrents/transmissionvpn:/data"
+  - "/mnt:/mnt"
+transmissionvpn_docker_volumes_custom: []
+transmissionvpn_docker_volumes: "{{ transmissionvpn_docker_volumes_default
+                              + transmissionvpn_docker_volumes_custom
+                              + docker_volumes_downloads_common }}"
+
+# Devices
+transmissionvpn_docker_devices_default: []
+transmissionvpn_docker_devices_custom: []
+transmissionvpn_docker_devices: "{{ transmissionvpn_docker_devices_default
+                              + transmissionvpn_docker_devices_custom }}"
+
+# Hosts
+transmissionvpn_docker_hosts_default: []
+transmissionvpn_docker_hosts_custom: []
+transmissionvpn_docker_hosts: "{{ docker_hosts_common
+                            | combine(transmissionvpn_docker_hosts_default)
+                            | combine(transmissionvpn_docker_hosts_custom) }}"
+
+# Labels
+transmissionvpn_docker_labels_default: {}
+transmissionvpn_docker_labels_custom: {}
+transmissionvpn_docker_labels: "{{ docker_labels_common
+                             | combine(transmissionvpn_docker_labels_default)
+                             | combine(transmissionvpn_docker_labels_custom) }}"
+
+# Hostname
+transmissionvpn_docker_hostname: "{{ transmissionvpn_name }}"
+
+# Networks
+transmissionvpn_docker_networks_alias: "{{ transmissionvpn_name }}"
+transmissionvpn_docker_networks_default: []
+transmissionvpn_docker_networks_custom: []
+transmissionvpn_docker_networks: "{{ docker_networks_common
+                               + transmissionvpn_docker_networks_default
+                               + transmissionvpn_docker_networks_custom }}"
+
+# Capabilities
+transmissionvpn_docker_capabilities_default:
+  - NET_ADMIN
+transmissionvpn_docker_capabilities_custom: []
+transmissionvpn_docker_capabilities: "{{ transmissionvpn_docker_capabilities_default
+                                   + transmissionvpn_docker_capabilities_custom }}"
+
+# Security Opts
+transmissionvpn_docker_security_opts_default: []
+transmissionvpn_docker_security_opts_custom: []
+transmissionvpn_docker_security_opts: "{{ transmissionvpn_docker_security_opts_default
+                                    + transmissionvpn_docker_security_opts_custom }}"
+
+# Restart Policy
+transmissionvpn_docker_restart_policy: unless-stopped
+
+# State
+transmissionvpn_docker_state: started
+
+# Sysctls
+transmissionvpn_docker_sysctls:
+  net.ipv4.conf.all.src_valid_mark: "1"
+
+# Privledged
+transmissionvpn_docker_privileged: "yes"

--- a/roles/transmissionvpn/defaults/main.yml
+++ b/roles/transmissionvpn/defaults/main.yml
@@ -79,15 +79,11 @@ transmissionvpn_docker_image: "haugene/transmission-openvpn:{{ transmissionvpn_d
 # Ports
 transmissionvpn_docker_ports_defaults:
   - "{{ transmissionvpn_web_port }}"
-transmissionvpn_docker_ports_torrents:
-  - "51413:51413"
 transmissionvpn_docker_ports_custom: []
 transmissionvpn_docker_ports: "{{ transmissionvpn_docker_ports_defaults
-                                  + transmissionvpn_docker_ports_torrents
                                   + transmissionvpn_docker_ports_custom
                                if (not reverse_proxy_is_enabled)
-                               else [] + transmissionvpn_docker_ports_torrents
-                                  + transmissionvpn_docker_ports_custom }}"
+                               else [] + transmissionvpn_docker_ports_custom }}"
 
 # Envs
 transmissionvpn_docker_envs_default:

--- a/roles/transmissionvpn/tasks/main.yml
+++ b/roles/transmissionvpn/tasks/main.yml
@@ -7,9 +7,6 @@
 #                   GNU General Public License v3.0                     #
 #########################################################################
 ---
-- name: "Ansible | Print a variable"
-  debug:
-    msg: "The operating system is {{ transmissionvpn_docker_envs_default }}"
 
 - name: Add DNS record
   include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"

--- a/roles/transmissionvpn/tasks/main.yml
+++ b/roles/transmissionvpn/tasks/main.yml
@@ -1,0 +1,35 @@
+#########################################################################
+# Title:            Sandbox: Transmission VPN                           #
+# Author(s):        ayykamp                                             #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Ansible | Print a variable"
+  debug:
+    msg: "The operating system is {{ transmissionvpn_docker_envs_default }}"
+
+- name: Add DNS record
+  include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+- name: Create Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -94,8 +94,8 @@
     - { role: telegraf, tags: ['telegraf'] }
     - { role: thelounge, tags: ['thelounge'] }
     - { role: transmission, tags: ['transmission'] }
-    - { role: transmissionx, tags: ['transmissionx'] }
     - { role: transmissionvpn, tags: ['transmissionvpn'] }
+    - { role: transmissionx, tags: ['transmissionx'] }
     - { role: unifi, tags: ['unifi'] }
     - { role: unmanic, tags: ['unmanic'] }
     - { role: unpackerr, tags: ['unpackerr'] }

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -95,6 +95,7 @@
     - { role: thelounge, tags: ['thelounge'] }
     - { role: transmission, tags: ['transmission'] }
     - { role: transmissionx, tags: ['transmissionx'] }
+    - { role: transmissionvpn, tags: ['transmissionvpn'] }
     - { role: unifi, tags: ['unifi'] }
     - { role: unmanic, tags: ['unmanic'] }
     - { role: unpackerr, tags: ['unpackerr'] }


### PR DESCRIPTION
# Description

Adapted from the cloudbox community role. [Container](https://hub.docker.com/r/haugene/transmission-openvpn/) and [docs](https://haugene.github.io/docker-transmission-openvpn/)

# How Has This Been Tested?

Recently migrated from cloudbox and tested on my new saltbox instance.
