### PR TITLE
Loki and Promtail

### DIFF
--- a/roles/loki/defaults/main.yml
+++ b/roles/loki/defaults/main.yml
@@ -1,0 +1,124 @@
+#########################################################################
+# Title:            Sandbox: loki Role | Default Variables           #
+# Author(s):        desimaniac, salty                                   #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+
+loki_name: loki
+
+################################
+# Paths
+################################
+
+loki_paths_folder: "{{ loki_name }}"
+loki_paths_location: "{{ server_appdata_path }}/{{ loki_paths_folder }}"
+loki_paths_folders_list:
+  - "{{ loki_paths_location }}"
+
+################################
+# Web
+################################
+
+loki_web_port: "3100"
+
+################################
+# Docker
+################################
+
+# Container
+loki_docker_container: "{{ loki_name }}"
+
+# Image
+loki_docker_image_pull: true
+loki_docker_image_tag: "latest"
+loki_docker_image: "grafana/loki:{{ loki_docker_image_tag }}"
+
+# Ports
+loki_docker_ports_defaults:
+  - "{{ loki_web_port }}"
+loki_docker_ports_custom: []
+loki_docker_ports: "{{ loki_docker_ports_defaults
+                          + loki_docker_ports_custom
+                        if (not reverse_proxy_is_enabled)
+                        else [] + loki_docker_ports_custom }}"
+
+# Envs
+loki_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+loki_docker_envs_custom: {}
+loki_docker_envs: "{{ loki_docker_envs_default
+                          | combine(loki_docker_envs_custom) }}"
+
+# Commands
+loki_docker_commands_default:
+  - "-config.file=/etc/loki/config.yml"
+loki_docker_commands_custom: []
+loki_docker_commands: "{{ loki_docker_commands_default
+                              + loki_docker_commands_custom }}"
+
+# Volumes
+loki_docker_volumes_default:
+  - "{{ loki_paths_location }}:/etc/loki"
+loki_docker_volumes_custom: []
+loki_docker_volumes: "{{ loki_docker_volumes_default
+                            + loki_docker_volumes_custom }}"
+
+# Devices
+loki_docker_devices_default: []
+loki_docker_devices_custom: []
+loki_docker_devices: "{{ loki_docker_devices_default
+                            + loki_docker_devices_custom }}"
+
+# Hosts
+loki_docker_hosts_default: []
+loki_docker_hosts_custom: []
+loki_docker_hosts: "{{ docker_hosts_common
+                          | combine(loki_docker_hosts_default)
+                          | combine(loki_docker_hosts_custom) }}"
+
+# Labels
+loki_docker_labels_default: {}
+loki_docker_labels_custom: {}
+loki_docker_labels: "{{ docker_labels_common
+                            | combine(loki_docker_labels_default)
+                            | combine(loki_docker_labels_custom) }}"
+
+# Hostname
+loki_docker_hostname: "{{ loki_name }}"
+
+# Networks
+loki_docker_networks_alias: "{{ loki_name }}"
+loki_docker_networks_default: []
+loki_docker_networks_custom: []
+loki_docker_networks: "{{ docker_networks_common
+                              + loki_docker_networks_default
+                              + loki_docker_networks_custom }}"
+
+# Capabilities
+loki_docker_capabilities_default: []
+loki_docker_capabilities_custom: []
+loki_docker_capabilities: "{{ loki_docker_capabilities_default
+                                  + loki_docker_capabilities_custom }}"
+
+# Security Opts
+loki_docker_security_opts_default: []
+loki_docker_security_opts_custom: []
+loki_docker_security_opts: "{{ loki_docker_security_opts_default
+                                  + loki_docker_security_opts_custom }}"
+
+# Restart Policy
+loki_docker_restart_policy: unless-stopped
+
+# State
+loki_docker_state: started
+
+# User
+loki_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/loki/defaults/main.yml
+++ b/roles/loki/defaults/main.yml
@@ -59,14 +59,14 @@ loki_docker_envs: "{{ loki_docker_envs_default
 
 # Commands
 loki_docker_commands_default:
-  - "-config.file=/etc/loki/config.yml"
+  - "-config.file=/loki/config.yml"
 loki_docker_commands_custom: []
 loki_docker_commands: "{{ loki_docker_commands_default
                               + loki_docker_commands_custom }}"
 
 # Volumes
 loki_docker_volumes_default:
-  - "{{ loki_paths_location }}:/etc/loki"
+  - "{{ loki_paths_location }}:/loki"
 loki_docker_volumes_custom: []
 loki_docker_volumes: "{{ loki_docker_volumes_default
                             + loki_docker_volumes_custom }}"

--- a/roles/loki/tasks/main.yml
+++ b/roles/loki/tasks/main.yml
@@ -1,0 +1,35 @@
+#########################################################################
+# Title:            Sandbox: Grafana Role                               #
+# Author(s):        desimaniac, salty                                   #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+
+- name: Remove existing Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+
+- name: Download config.yml.template
+  get_url:
+    url: https://github.com/jolbol1/loki-promtail-configs/blob/main/loki-config.yml
+    dest: "{{ loki_paths_location }}/config.yml.template"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0775
+    force: yes
+    validate_certs: no
+  ignore_errors: true
+
+- name: Create Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/loki/tasks/main.yml
+++ b/roles/loki/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Download config.yml.template
   get_url:
-    url: https://github.com/jolbol1/loki-promtail-configs/blob/main/loki-config.yml
+    url: https://raw.githubusercontent.com/jolbol1/loki-promtail-configs/main/loki-config.yml
     dest: "{{ loki_paths_location }}/config.yml.template"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"

--- a/roles/promtail/defaults/main.yml
+++ b/roles/promtail/defaults/main.yml
@@ -1,0 +1,121 @@
+#########################################################################
+# Title:            Sandbox: promtail Role | Default Variables           #
+# Author(s):        desimaniac, salty                                   #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+
+promtail_name: promtail
+
+################################
+# Paths
+################################
+
+promtail_paths_folder: "{{ promtail_name }}"
+promtail_paths_location: "{{ server_appdata_path }}/{{ promtail_paths_folder }}"
+promtail_paths_folders_list:
+  - "{{ promtail_paths_location }}"
+
+################################
+# Docker
+################################
+
+# Container
+promtail_docker_container: "{{ promtail_name }}"
+
+# Image
+promtail_docker_image_pull: true
+promtail_docker_image_tag: "latest"
+promtail_docker_image: "grafana/promtail:{{ promtail_docker_image_tag }}"
+
+
+# Ports
+promtail_docker_ports_defaults:
+  - "{{ promtail_web_port }}"
+promtail_docker_ports_custom: []
+promtail_docker_ports: "{{ promtail_docker_ports_defaults
+                          + promtail_docker_ports_custom
+                        if (not reverse_proxy_is_enabled)
+                        else [] + promtail_docker_ports_custom }}"
+
+# Envs
+promtail_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+promtail_docker_envs_custom: {}
+promtail_docker_envs: "{{ promtail_docker_envs_default
+                          | combine(promtail_docker_envs_custom) }}"
+
+# Commands
+promtail_docker_commands_default:
+  - "-config.file=/etc/promtail/config.yml"
+promtail_docker_commands_custom: []
+promtail_docker_commands: "{{ promtail_docker_commands_default
+                              + promtail_docker_commands_custom }}"
+
+# Volumes
+promtail_docker_volumes_default:
+  - "{{ promtail_paths_location }}:/etc/promtail"
+  - "/var/lib/docker/containers:/var/lib/docker/containers"
+  - "/var/log:/var/log"
+promtail_docker_volumes_custom: []
+promtail_docker_volumes: "{{ promtail_docker_volumes_default
+                            + promtail_docker_volumes_custom }}"
+
+# Devices
+promtail_docker_devices_default: []
+promtail_docker_devices_custom: []
+promtail_docker_devices: "{{ promtail_docker_devices_default
+                            + promtail_docker_devices_custom }}"
+
+# Hosts
+promtail_docker_hosts_default: []
+promtail_docker_hosts_custom: []
+promtail_docker_hosts: "{{ docker_hosts_common
+                          | combine(promtail_docker_hosts_default)
+                          | combine(promtail_docker_hosts_custom) }}"
+
+# Labels
+promtail_docker_labels_default: {}
+promtail_docker_labels_custom: {}
+promtail_docker_labels: "{{ docker_labels_common
+                            | combine(promtail_docker_labels_default)
+                            | combine(promtail_docker_labels_custom) }}"
+
+# Hostname
+promtail_docker_hostname: "{{ promtail_name }}"
+
+# Networks
+promtail_docker_networks_alias: "{{ promtail_name }}"
+promtail_docker_networks_default: []
+promtail_docker_networks_custom: []
+promtail_docker_networks: "{{ docker_networks_common
+                              + promtail_docker_networks_default
+                              + promtail_docker_networks_custom }}"
+
+# Capabilities
+promtail_docker_capabilities_default: []
+promtail_docker_capabilities_custom: []
+promtail_docker_capabilities: "{{ promtail_docker_capabilities_default
+                                  + promtail_docker_capabilities_custom }}"
+
+# Security Opts
+promtail_docker_security_opts_default: []
+promtail_docker_security_opts_custom: []
+promtail_docker_security_opts: "{{ promtail_docker_security_opts_default
+                                  + promtail_docker_security_opts_custom }}"
+
+# Restart Policy
+promtail_docker_restart_policy: unless-stopped
+
+# State
+promtail_docker_state: started
+
+# User
+#promtail_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/promtail/defaults/main.yml
+++ b/roles/promtail/defaults/main.yml
@@ -64,6 +64,7 @@ promtail_docker_volumes_default:
   - "{{ promtail_paths_location }}:/etc/promtail"
   - "/var/log:/var/log"
   - "/var/run/docker.sock:/var/run/docker.sock"
+  - "/var/lib/docker:/var/lib/docker"
 promtail_docker_volumes_custom: []
 promtail_docker_volumes: "{{ promtail_docker_volumes_default
                             + promtail_docker_volumes_custom }}"

--- a/roles/promtail/defaults/main.yml
+++ b/roles/promtail/defaults/main.yml
@@ -62,8 +62,8 @@ promtail_docker_commands: "{{ promtail_docker_commands_default
 # Volumes
 promtail_docker_volumes_default:
   - "{{ promtail_paths_location }}:/etc/promtail"
-  - "/var/lib/docker/containers:/var/lib/docker/containers"
   - "/var/log:/var/log"
+  - "/var/run/docker.sock:/var/run/docker.sock"
 promtail_docker_volumes_custom: []
 promtail_docker_volumes: "{{ promtail_docker_volumes_default
                             + promtail_docker_volumes_custom }}"

--- a/roles/promtail/tasks/main.yml
+++ b/roles/promtail/tasks/main.yml
@@ -1,0 +1,34 @@
+#########################################################################
+# Title:            Sandbox: Grafana Role                               #
+# Author(s):        desimaniac, salty                                   #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Remove existing Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+
+- name: Download config.yml.template
+  get_url:
+    url: https://raw.githubusercontent.com/jolbol1/loki-promtail-configs/main/promtail-config.yml
+    dest: "{{ promtail_paths_location }}/config.yml.template"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0775
+    force: yes
+    validate_certs: no
+  ignore_errors: true
+
+- name: Create Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -61,6 +61,7 @@
     - { role: komga, tags: ['komga'] }
     - { role: lazylibrarian, tags: ['lazylibrarian'] }
     - { role: logarr, tags: ['logarr'] }
+    - { role: loki, tags: ['loki'] }
     - { role: medusa, tags: ['medusa'] }
     - { role: monitorr, tags: ['monitorr'] }
     - { role: moviematch, tags: ['moviematch'] }
@@ -78,6 +79,7 @@
     - { role: plex_patrol, tags: ['plex_patrol'] }
     - { role: plex_utills, tags: ['plex_utills'] }
     - { role: plextraktsync, tags: ['plextraktsync'] }
+    - { role: promtail, tags: ['promtail'] }
     - { role: privatebin, tags: ['privatebin'] }
     - { role: pyload, tags: ['pyload'] }
     - { role: python_plexlibrary, tags: ['python-plexlibrary'] }


### PR DESCRIPTION
# Description

Adds Loki https://grafana.com/oss/loki/
Adds promtial https://grafana.com/docs/loki/latest/clients/promtail/

This allows for log visualisation and aggregation on grafana.

I used these configs, and have provided them as templates: 
https://github.com/jolbol1/loki-promtail-configs/blob/main/loki-config.yml
https://github.com/jolbol1/loki-promtail-configs/blob/main/promtail-config.yml

In order for docker logs to be tagged, you need the following:
`--log-driver json-file --log-opt tag="{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}"` on every container.

I have [submitted a PR](https://github.com/saltyorg/Saltbox/pull/68) to Saltbox that would allow you to set this a a global, or per role variable like so:
Globally in localhost.yml
```
docker_log_driver: "json-file"
docker_log_options: "{% raw %}tag='{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'{% endraw %}"
```
or per role:
```
plex_log_driver: "json-file"
plex_log_options: "{% raw %}tag='{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'{% endraw %}"
```

I got these options from the recommended set up here: https://gist.github.com/ruanbekker/c6fa9bc6882e6f324b4319c5e3622460

Lastly, Salty as you mentioned you will be taking a look at this yourself. I decided to post this here anyways as I already gave it a go and maybe we would go about it in the same ways. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.  You can use the checkboxes below or delete them as you wish.

- [x] modified saltbox server with sandbox [(see saltbox PR)](https://github.com/saltyorg/Saltbox/pull/68)
- [x] Default SB install and sandbox
- [x] Fresh server install
