### PR TITLE
Minecraft

### DIFF
--- a/roles/mcrouter/defaults/main.yml
+++ b/roles/mcrouter/defaults/main.yml
@@ -1,0 +1,117 @@
+#########################################################################
+# Title:            Sandbox: mcrouter                                   #
+# Author(s):        astroMD, kowalski                                   #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+minecraft_instances: ["minecraft"]
+
+mcrouter_name: mcrouter
+mcrouter_minecraft_port: "25565"
+
+################################
+# Paths
+################################
+
+mcrouter_paths_folder: "{{ mcrouter_name }}"
+mcrouter_paths_location: "{{ server_appdata_path }}/{{ mcrouter_paths_folder }}"
+mcrouter_paths_folders_list:
+  - "{{ mcrouter_paths_location }}"
+
+
+################################
+# Docker
+################################
+
+# Container
+mcrouter_docker_container: "{{ mcrouter_name }}"
+
+# Image
+mcrouter_docker_image_pull: true
+mcrouter_docker_image_tag: "latest"
+mcrouter_docker_image: "itzg/mc-router:{{ mcrouter_docker_image_tag }}"
+
+# Ports
+mcrouter_docker_ports_defaults:
+  - "{{ mcrouter_minecraft_port }}:{{ mcrouter_minecraft_port }}"
+  - "{{ mcrouter_minecraft_port }}:{{ mcrouter_minecraft_port }}/udp"
+mcrouter_docker_ports_custom: []
+mcrouter_docker_ports: "{{ mcrouter_docker_ports_defaults
+                        + mcrouter_docker_ports_custom }}"
+
+# Envs
+mcrouter_docker_envs_default: {}
+mcrouter_docker_envs_custom: {}
+mcrouter_docker_envs: "{{ mcrouter_docker_envs_default
+                       | combine(mcrouter_docker_envs_custom) }}"
+
+# Commands
+mcrouter_docker_commands_default:
+  - "--mapping={% for item in minecraft_instances %}{{ lookup('vars', item + '_web_subdomain', default=item) }}.{{ user.domain }}={{ lookup('vars', item + '_web_subdomain', default=item) }}:25565{{ '' if loop.last else ',' }}{% endfor %}"
+mcrouter_docker_commands_custom: []
+mcrouter_docker_commands: "{{ mcrouter_docker_commands_default
+                           + mcrouter_docker_commands_custom }}"
+
+# Volumes
+mcrouter_docker_volumes_default: []
+mcrouter_docker_volumes_custom: []
+mcrouter_docker_volumes: "{{ mcrouter_docker_volumes_default
+                          + mcrouter_docker_volumes_custom }}"
+
+# Devices
+mcrouter_docker_devices_default: []
+mcrouter_docker_devices_custom: []
+mcrouter_docker_devices: "{{ mcrouter_docker_devices_default
+                          + mcrouter_docker_devices_custom }}"
+
+# Hosts
+mcrouter_docker_hosts_default: []
+mcrouter_docker_hosts_custom: []
+mcrouter_docker_hosts: "{{ docker_hosts_common
+                        | combine(mcrouter_docker_hosts_default)
+                        | combine(mcrouter_docker_hosts_custom) }}"
+
+# Labels
+mcrouter_docker_labels_default: {}
+mcrouter_docker_labels_custom: {}
+mcrouter_docker_labels: "{{ docker_labels_common
+                         | combine(mcrouter_docker_labels_default)
+                         | combine(mcrouter_docker_labels_custom) }}"
+
+# Hostname
+mcrouter_docker_hostname: "{{ mcrouter_name }}"
+
+# Networks
+mcrouter_docker_networks_alias: "{{ mcrouter_name }}"
+mcrouter_docker_networks_default: []
+mcrouter_docker_networks_custom: []
+mcrouter_docker_networks: "{{ docker_networks_common
+                           + mcrouter_docker_networks_default
+                           + mcrouter_docker_networks_custom }}"
+
+# Capabilities
+mcrouter_docker_capabilities_default: []
+mcrouter_docker_capabilities_custom: []
+mcrouter_docker_capabilities: "{{ mcrouter_docker_capabilities_default
+                               + mcrouter_docker_capabilities_custom }}"
+
+# Security Opts
+mcrouter_docker_security_opts_default: []
+mcrouter_docker_security_opts_custom: []
+mcrouter_docker_security_opts: "{{ mcrouter_docker_security_opts_default
+                                + mcrouter_docker_security_opts_custom }}"
+
+# Restart Policy
+mcrouter_docker_restart_policy: unless-stopped
+
+# State
+mcrouter_docker_state: started
+
+# User
+mcrouter_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/mcrouter/defaults/main.yml
+++ b/roles/mcrouter/defaults/main.yml
@@ -1,6 +1,6 @@
 #########################################################################
 # Title:            Sandbox: mcrouter                                   #
-# Author(s):        astroMD, kowalski                                   #
+# Author(s):        jolbol1                                             #
 # URL:              https://github.com/saltyorg/Sandbox                 #
 # --                                                                    #
 #########################################################################

--- a/roles/mcrouter/defaults/main.yml
+++ b/roles/mcrouter/defaults/main.yml
@@ -43,46 +43,46 @@ mcrouter_docker_ports_defaults:
   - "{{ mcrouter_minecraft_port }}:{{ mcrouter_minecraft_port }}/udp"
 mcrouter_docker_ports_custom: []
 mcrouter_docker_ports: "{{ mcrouter_docker_ports_defaults
-                        + mcrouter_docker_ports_custom }}"
+                           + mcrouter_docker_ports_custom }}"
 
 # Envs
 mcrouter_docker_envs_default: {}
 mcrouter_docker_envs_custom: {}
 mcrouter_docker_envs: "{{ mcrouter_docker_envs_default
-                       | combine(mcrouter_docker_envs_custom) }}"
+                          | combine(mcrouter_docker_envs_custom) }}"
 
 # Commands
 mcrouter_docker_commands_default:
   - "--mapping={% for item in minecraft_instances %}{{ lookup('vars', item + '_web_subdomain', default=item) }}.{{ user.domain }}={{ lookup('vars', item + '_web_subdomain', default=item) }}:25565{{ '' if loop.last else ',' }}{% endfor %}"
 mcrouter_docker_commands_custom: []
 mcrouter_docker_commands: "{{ mcrouter_docker_commands_default
-                           + mcrouter_docker_commands_custom }}"
+                              + mcrouter_docker_commands_custom }}"
 
 # Volumes
 mcrouter_docker_volumes_default: []
 mcrouter_docker_volumes_custom: []
 mcrouter_docker_volumes: "{{ mcrouter_docker_volumes_default
-                          + mcrouter_docker_volumes_custom }}"
+                             + mcrouter_docker_volumes_custom }}"
 
 # Devices
 mcrouter_docker_devices_default: []
 mcrouter_docker_devices_custom: []
 mcrouter_docker_devices: "{{ mcrouter_docker_devices_default
-                          + mcrouter_docker_devices_custom }}"
+                             + mcrouter_docker_devices_custom }}"
 
 # Hosts
 mcrouter_docker_hosts_default: []
 mcrouter_docker_hosts_custom: []
 mcrouter_docker_hosts: "{{ docker_hosts_common
-                        | combine(mcrouter_docker_hosts_default)
-                        | combine(mcrouter_docker_hosts_custom) }}"
+                           | combine(mcrouter_docker_hosts_default)
+                           | combine(mcrouter_docker_hosts_custom) }}"
 
 # Labels
 mcrouter_docker_labels_default: {}
 mcrouter_docker_labels_custom: {}
 mcrouter_docker_labels: "{{ docker_labels_common
-                         | combine(mcrouter_docker_labels_default)
-                         | combine(mcrouter_docker_labels_custom) }}"
+                            | combine(mcrouter_docker_labels_default)
+                            | combine(mcrouter_docker_labels_custom) }}"
 
 # Hostname
 mcrouter_docker_hostname: "{{ mcrouter_name }}"
@@ -92,20 +92,20 @@ mcrouter_docker_networks_alias: "{{ mcrouter_name }}"
 mcrouter_docker_networks_default: []
 mcrouter_docker_networks_custom: []
 mcrouter_docker_networks: "{{ docker_networks_common
-                           + mcrouter_docker_networks_default
-                           + mcrouter_docker_networks_custom }}"
+                              + mcrouter_docker_networks_default
+                              + mcrouter_docker_networks_custom }}"
 
 # Capabilities
 mcrouter_docker_capabilities_default: []
 mcrouter_docker_capabilities_custom: []
 mcrouter_docker_capabilities: "{{ mcrouter_docker_capabilities_default
-                               + mcrouter_docker_capabilities_custom }}"
+                                  + mcrouter_docker_capabilities_custom }}"
 
 # Security Opts
 mcrouter_docker_security_opts_default: []
 mcrouter_docker_security_opts_custom: []
 mcrouter_docker_security_opts: "{{ mcrouter_docker_security_opts_default
-                                + mcrouter_docker_security_opts_custom }}"
+                                   + mcrouter_docker_security_opts_custom }}"
 
 # Restart Policy
 mcrouter_docker_restart_policy: unless-stopped

--- a/roles/mcrouter/tasks/main.yml
+++ b/roles/mcrouter/tasks/main.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:            Sandbox: Coder                                      #
+# Author(s):        astroMD, kowalski                                   #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+
+- name: Remove existing Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+- name: Create Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/mcrouter/tasks/main.yml
+++ b/roles/mcrouter/tasks/main.yml
@@ -1,6 +1,6 @@
 #########################################################################
-# Title:            Sandbox: Coder                                      #
-# Author(s):        astroMD, kowalski                                   #
+# Title:            Sandbox: McRouter                                   #
+# Author(s):        jolbol1                                             #
 # URL:              https://github.com/saltyorg/Sandbox                 #
 # --                                                                    #
 #########################################################################

--- a/roles/minecraft/defaults/main.yml
+++ b/roles/minecraft/defaults/main.yml
@@ -16,11 +16,12 @@ minecraft_instances: ["minecraft"]
 # Paths
 ################################
 
-minecraft_paths_folder: "{{ minecraft_name }}"
+minecraft_paths_folder: "minecraft"
 minecraft_paths_location: "{{ server_appdata_path }}/{{ minecraft_paths_folder }}"
 minecraft_paths_folders_list:
-  - "{{ minecraft_paths_location }}"
-  - "{{ minecraft_paths_location }}/data"
+  - "{{ minecraft_paths_location }}/"
+  - "{{ minecraft_paths_location }}/{{ minecraft_name }}"
+  - "{{ minecraft_paths_location }}/{{ minecraft_name }}/data"
 
 ################################
 # Web
@@ -68,7 +69,7 @@ minecraft_docker_commands: "{{ lookup('vars', minecraft_name + '_docker_commands
 
 # Volumes
 minecraft_docker_volumes_default:
-  - "{{ minecraft_paths_location }}/data:/data"
+  - "{{ minecraft_paths_location }}/{{ minecraft_name }}/data:/data"
 minecraft_docker_volumes_custom: []
 minecraft_docker_volumes: "{{ lookup('vars', minecraft_name + '_docker_volumes_default', default=minecraft_docker_volumes_default)
                               + lookup('vars', minecraft_name + '_docker_volumes_custom', default=minecraft_docker_volumes_custom) }}"

--- a/roles/minecraft/defaults/main.yml
+++ b/roles/minecraft/defaults/main.yml
@@ -48,7 +48,7 @@ minecraft_docker_image_pull: true
 minecraft_docker_image_repo: "itzg/minecraft-server"
 minecraft_docker_image_tag: "latest"
 minecraft_docker_image: "{{ lookup('vars', minecraft_name + '_docker_image_repo', default=minecraft_docker_image_repo)
-                              + ':' + lookup('vars', minecraft_name + '_docker_image_tag', default=minecraft_docker_image_tag) }}"
+                            + ':' + lookup('vars', minecraft_name + '_docker_image_tag', default=minecraft_docker_image_tag) }}"
 
 # Envs
 minecraft_docker_envs_default:
@@ -58,40 +58,40 @@ minecraft_docker_envs_default:
   OPS: "{{ uid }}"
 minecraft_docker_envs_custom: {}
 minecraft_docker_envs: "{{ lookup('vars', minecraft_name + '_docker_envs_default', default=minecraft_docker_envs_default)
-                             | combine(lookup('vars', minecraft_name + '_docker_envs_custom', default=minecraft_docker_envs_custom)) }}"
+                           | combine(lookup('vars', minecraft_name + '_docker_envs_custom', default=minecraft_docker_envs_custom)) }}"
 
 # Commands
 minecraft_docker_commands_default: []
 minecraft_docker_commands_custom: []
 minecraft_docker_commands: "{{ lookup('vars', minecraft_name + '_docker_commands_default', default=minecraft_docker_commands_default)
-                                 + lookup('vars', minecraft_name + '_docker_docker_commands_custom', default=minecraft_docker_commands_custom) }}"
+                               + lookup('vars', minecraft_name + '_docker_docker_commands_custom', default=minecraft_docker_commands_custom) }}"
 
 # Volumes
 minecraft_docker_volumes_default:
   - "{{ minecraft_paths_location }}/data:/data"
 minecraft_docker_volumes_custom: []
 minecraft_docker_volumes: "{{ lookup('vars', minecraft_name + '_docker_volumes_default', default=minecraft_docker_volumes_default)
-                                + lookup('vars', minecraft_name + '_docker_volumes_custom', default=minecraft_docker_volumes_custom) }}"
+                              + lookup('vars', minecraft_name + '_docker_volumes_custom', default=minecraft_docker_volumes_custom) }}"
 
 # Devices
 minecraft_docker_devices_default: []
 minecraft_docker_devices_custom: []
 minecraft_docker_devices: "{{ lookup('vars', minecraft_name + '_docker_devices_default', default=minecraft_docker_devices_default)
-                                + lookup('vars', minecraft_name + '_docker_devices_custom', default=minecraft_docker_devices_custom) }}"
+                              + lookup('vars', minecraft_name + '_docker_devices_custom', default=minecraft_docker_devices_custom) }}"
 
 # Hosts
 minecraft_docker_hosts_default: []
 minecraft_docker_hosts_custom: []
 minecraft_docker_hosts: "{{ docker_hosts_common
-                              | combine(lookup('vars', minecraft_name + '_docker_hosts_default', default=minecraft_docker_hosts_default))
-                              | combine(lookup('vars', minecraft_name + '_docker_hosts_custom', default=minecraft_docker_hosts_custom)) }}"
+                            | combine(lookup('vars', minecraft_name + '_docker_hosts_default', default=minecraft_docker_hosts_default))
+                            | combine(lookup('vars', minecraft_name + '_docker_hosts_custom', default=minecraft_docker_hosts_custom)) }}"
 
 # Labels
 minecraft_docker_labels_default: {}
 minecraft_docker_labels_custom: {}
 minecraft_docker_labels: "{{ docker_labels_common
-                               | combine(lookup('vars', minecraft_name + '_docker_labels_default', default=minecraft_docker_labels_default))
-                               | combine(lookup('vars', minecraft_name + '_docker_labels_custom', default=minecraft_docker_labels_custom)) }}"
+                             | combine(lookup('vars', minecraft_name + '_docker_labels_default', default=minecraft_docker_labels_default))
+                             | combine(lookup('vars', minecraft_name + '_docker_labels_custom', default=minecraft_docker_labels_custom)) }}"
 
 # Hostname
 minecraft_docker_hostname: "{{ minecraft_name }}"
@@ -101,20 +101,20 @@ minecraft_docker_networks_alias: "{{ minecraft_name }}"
 minecraft_docker_networks_default: []
 minecraft_docker_networks_custom: []
 minecraft_docker_networks: "{{ docker_networks_common
-                                 + lookup('vars', minecraft_name + '_docker_networks_default', default=minecraft_docker_networks_default)
-                                 + lookup('vars', minecraft_name + '_docker_networks_custom', default=minecraft_docker_networks_custom) }}"
+                               + lookup('vars', minecraft_name + '_docker_networks_default', default=minecraft_docker_networks_default)
+                               + lookup('vars', minecraft_name + '_docker_networks_custom', default=minecraft_docker_networks_custom) }}"
 
 # Capabilities
 minecraft_docker_capabilities_default: []
 minecraft_docker_capabilities_custom: []
 minecraft_docker_capabilities: "{{ lookup('vars', minecraft_name + '_docker_capabilities_default', default=minecraft_docker_capabilities_default)
-                                     + lookup('vars', minecraft_name + '_docker_capabilities_custom', default=minecraft_docker_capabilities_custom) }}"
+                                   + lookup('vars', minecraft_name + '_docker_capabilities_custom', default=minecraft_docker_capabilities_custom) }}"
 
 # Security Opts
 minecraft_docker_security_opts_default: []
 minecraft_docker_security_opts_custom: []
 minecraft_docker_security_opts: "{{ lookup('vars', minecraft_name + '_docker_security_opts_default', default=minecraft_docker_security_opts_default)
-                                      + lookup('vars', minecraft_name + '_docker_security_opts_custom', default=minecraft_docker_security_opts_custom) }}"
+                                    + lookup('vars', minecraft_name + '_docker_security_opts_custom', default=minecraft_docker_security_opts_custom) }}"
 
 # Restart Policy
 minecraft_docker_restart_policy: unless-stopped

--- a/roles/minecraft/defaults/main.yml
+++ b/roles/minecraft/defaults/main.yml
@@ -1,0 +1,126 @@
+#########################################################################
+# Title:            Saltbox: minecraft                                  #
+# Author(s):        jolbol1                                             #
+# URL:              https://github.com/saltyorg/Saltbox                 #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+
+minecraft_instances: ["minecraft"]
+
+################################
+# Paths
+################################
+
+minecraft_paths_folder: "{{ minecraft_name }}"
+minecraft_paths_location: "{{ server_appdata_path }}/{{ minecraft_paths_folder }}"
+minecraft_paths_folders_list:
+  - "{{ minecraft_paths_location }}"
+  - "{{ minecraft_paths_location }}/data"
+
+################################
+# Web
+################################
+
+minecraft_web_subdomain: "{{ minecraft_name }}"
+minecraft_web_domain: "{{ user.domain }}"
+
+################################
+# DNS
+################################
+
+minecraft_dns_record: "{{ lookup('vars', minecraft_name + '_web_subdomain', default=minecraft_web_subdomain) }}"
+minecraft_dns_zone: "{{ minecraft_web_domain }}"
+
+################################
+# Docker
+################################
+
+# Container
+minecraft_docker_container: "{{ minecraft_name }}"
+
+# Image
+minecraft_docker_image_pull: true
+minecraft_docker_image_repo: "itzg/minecraft-server"
+minecraft_docker_image_tag: "latest"
+minecraft_docker_image: "{{ lookup('vars', minecraft_name + '_docker_image_repo', default=minecraft_docker_image_repo)
+                              + ':' + lookup('vars', minecraft_name + '_docker_image_tag', default=minecraft_docker_image_tag) }}"
+
+# Envs
+minecraft_docker_envs_default:
+  TZ: "{{ tz }}"
+  EULA: "TRUE"
+  WHITELIST: "{{ uid }}"
+  OPS: "{{ uid }}"
+minecraft_docker_envs_custom: {}
+minecraft_docker_envs: "{{ lookup('vars', minecraft_name + '_docker_envs_default', default=minecraft_docker_envs_default)
+                             | combine(lookup('vars', minecraft_name + '_docker_envs_custom', default=minecraft_docker_envs_custom)) }}"
+
+# Commands
+minecraft_docker_commands_default: []
+minecraft_docker_commands_custom: []
+minecraft_docker_commands: "{{ lookup('vars', minecraft_name + '_docker_commands_default', default=minecraft_docker_commands_default)
+                                 + lookup('vars', minecraft_name + '_docker_docker_commands_custom', default=minecraft_docker_commands_custom) }}"
+
+# Volumes
+minecraft_docker_volumes_default:
+  - "{{ minecraft_paths_location }}/data:/data"
+minecraft_docker_volumes_custom: []
+minecraft_docker_volumes: "{{ lookup('vars', minecraft_name + '_docker_volumes_default', default=minecraft_docker_volumes_default)
+                                + lookup('vars', minecraft_name + '_docker_volumes_custom', default=minecraft_docker_volumes_custom) }}"
+
+# Devices
+minecraft_docker_devices_default: []
+minecraft_docker_devices_custom: []
+minecraft_docker_devices: "{{ lookup('vars', minecraft_name + '_docker_devices_default', default=minecraft_docker_devices_default)
+                                + lookup('vars', minecraft_name + '_docker_devices_custom', default=minecraft_docker_devices_custom) }}"
+
+# Hosts
+minecraft_docker_hosts_default: []
+minecraft_docker_hosts_custom: []
+minecraft_docker_hosts: "{{ docker_hosts_common
+                              | combine(lookup('vars', minecraft_name + '_docker_hosts_default', default=minecraft_docker_hosts_default))
+                              | combine(lookup('vars', minecraft_name + '_docker_hosts_custom', default=minecraft_docker_hosts_custom)) }}"
+
+# Labels
+minecraft_docker_labels_default: {}
+minecraft_docker_labels_custom: {}
+minecraft_docker_labels: "{{ docker_labels_common
+                               | combine(lookup('vars', minecraft_name + '_docker_labels_default', default=minecraft_docker_labels_default))
+                               | combine(lookup('vars', minecraft_name + '_docker_labels_custom', default=minecraft_docker_labels_custom)) }}"
+
+# Hostname
+minecraft_docker_hostname: "{{ minecraft_name }}"
+
+# Networks
+minecraft_docker_networks_alias: "{{ minecraft_name }}"
+minecraft_docker_networks_default: []
+minecraft_docker_networks_custom: []
+minecraft_docker_networks: "{{ docker_networks_common
+                                 + lookup('vars', minecraft_name + '_docker_networks_default', default=minecraft_docker_networks_default)
+                                 + lookup('vars', minecraft_name + '_docker_networks_custom', default=minecraft_docker_networks_custom) }}"
+
+# Capabilities
+minecraft_docker_capabilities_default: []
+minecraft_docker_capabilities_custom: []
+minecraft_docker_capabilities: "{{ lookup('vars', minecraft_name + '_docker_capabilities_default', default=minecraft_docker_capabilities_default)
+                                     + lookup('vars', minecraft_name + '_docker_capabilities_custom', default=minecraft_docker_capabilities_custom) }}"
+
+# Security Opts
+minecraft_docker_security_opts_default: []
+minecraft_docker_security_opts_custom: []
+minecraft_docker_security_opts: "{{ lookup('vars', minecraft_name + '_docker_security_opts_default', default=minecraft_docker_security_opts_default)
+                                      + lookup('vars', minecraft_name + '_docker_security_opts_custom', default=minecraft_docker_security_opts_custom) }}"
+
+# Restart Policy
+minecraft_docker_restart_policy: unless-stopped
+
+# Stop Timeout
+minecraft_docker_stop_timeout: 900
+
+# State
+minecraft_docker_state: started

--- a/roles/minecraft/tasks/main.yml
+++ b/roles/minecraft/tasks/main.yml
@@ -1,0 +1,20 @@
+#########################################################################
+# Title:         Saltbox: Minecraft                                     #
+# Author(s):     jolbol1                                                #
+# URL:           https://github.com/saltyorg/Saltbox                    #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Execute minecraft roles"
+  ansible.builtin.include_tasks: main2.yml
+  vars:
+    minecraft_name: "{{ role }}"
+  with_items: "{{ minecraft_instances }}"
+  loop_control:
+    loop_var: role
+
+- name: McRouter Role
+  include_role:
+    name: mcrouter

--- a/roles/minecraft/tasks/main2.yml
+++ b/roles/minecraft/tasks/main2.yml
@@ -13,7 +13,6 @@
     dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
     dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
 
-
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 

--- a/roles/minecraft/tasks/main2.yml
+++ b/roles/minecraft/tasks/main2.yml
@@ -1,0 +1,30 @@
+#########################################################################
+# Title:            Saltbox: minecraft                                  #
+# Author(s):        Kalroth, jolbol1                                    #
+# URL:              https://github.com/saltyorg/Saltbox                 #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+
+- name: Add DNS record
+  include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/minecraft/tasks/main2.yml
+++ b/roles/minecraft/tasks/main2.yml
@@ -1,6 +1,6 @@
 #########################################################################
 # Title:            Saltbox: minecraft                                  #
-# Author(s):        Kalroth, jolbol1                                    #
+# Author(s):        jolbol1                                             #
 # URL:              https://github.com/saltyorg/Saltbox                 #
 #########################################################################
 #                   GNU General Public License v3.0                     #

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -62,7 +62,9 @@
     - { role: komga, tags: ['komga'] }
     - { role: lazylibrarian, tags: ['lazylibrarian'] }
     - { role: logarr, tags: ['logarr'] }
+    - { role: mcrouter, tags: ['mcrouter'] }
     - { role: medusa, tags: ['medusa'] }
+    - { role: minecraft, tags: ['minecraft'] }
     - { role: monitorr, tags: ['monitorr'] }
     - { role: moviematch, tags: ['moviematch'] }
     - { role: mylar3, tags: ['mylar3'] }


### PR DESCRIPTION
# Description

Adds a minecraft role with the ability to have multiple minecraft instances, with their own subdomains. 

This is achieved by using [mc-router](https://github.com/itzg/mc-router) and [minecraft-server](https://github.com/itzg/docker-minecraft-server). 

Docs to come shortly. 

There may be further considerations down the line needed, for things such as ports for online maps but will tackle these when needed/requested.

# How Has This Been Tested?

- [x] Running on my machine, a standard saltbox and sandbox install
- [x] Running on a fresh install 
