### PR TITLE
Recyclarr: New Role

### DIFF
--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -66,6 +66,8 @@ qbit_manage:
   qbt_width: "100" # Default is "100"
   qbt_debug: "false"
   qbt_trace: "false"
+recyclarr:
+  cron_schedule: "@daily" # Standard cron syntax for how often you want Recyclarr to run
 requestrrx:
   roles: ["1080p", "4k"]
 rfloodx:

--- a/roles/recyclarr/defaults/main.yml
+++ b/roles/recyclarr/defaults/main.yml
@@ -1,5 +1,5 @@
 ##########################################################################
-# Title:            Sandbox: Recyclarr                                   #
+# Title:            Sandbox: Recyclarr   | Default Variables             #
 # Author(s):        BeansIsFat                                           #
 # URL:              https://github.com/saltyorg/Sandbox                  #
 # --                                                                     #
@@ -38,9 +38,9 @@ recyclarr_docker_image: "ghcr.io/recyclarr/recyclarr:{{ recyclarr_docker_image_t
 recyclarr_docker_ports_defaults: []
 recyclarr_docker_ports_custom: []
 recyclarr_docker_ports: "{{ recyclarr_docker_ports_defaults
-                           + recyclarr_docker_ports_custom
-                        if (not reverse_proxy_is_enabled)
-                        else [] + recyclarr_docker_ports_custom }}"
+                            + recyclarr_docker_ports_custom
+                         if (not reverse_proxy_is_enabled)
+                         else [] + recyclarr_docker_ports_custom }}"
 
 # Envs
 recyclarr_docker_envs_default:
@@ -50,40 +50,40 @@ recyclarr_docker_envs_default:
   CRON_SCHEDULE: "{{ recyclarr.cron_schedule }}"
 recyclarr_docker_envs_custom: {}
 recyclarr_docker_envs: "{{ recyclarr_docker_envs_default
-                          | combine(recyclarr_docker_envs_custom) }}"
+                           | combine(recyclarr_docker_envs_custom) }}"
 
 # Commands
 recyclarr_docker_commands_default: []
 recyclarr_docker_commands_custom: []
 recyclarr_docker_commands: "{{ recyclarr_docker_commands_default
-                              + recyclarr_docker_commands_custom }}"
+                               + recyclarr_docker_commands_custom }}"
 
 # Volumes
 recyclarr_docker_volumes_default:
   - "{{ recyclarr_paths_location }}:/config"
 recyclarr_docker_volumes_custom: []
 recyclarr_docker_volumes: "{{ recyclarr_docker_volumes_default
-                             + recyclarr_docker_volumes_custom }}"
+                              + recyclarr_docker_volumes_custom }}"
 
 # Devices
 recyclarr_docker_devices_default: []
 recyclarr_docker_devices_custom: []
 recyclarr_docker_devices: "{{ recyclarr_docker_devices_default
-                             + recyclarr_docker_devices_custom }}"
+                              + recyclarr_docker_devices_custom }}"
 
 # Hosts
 recyclarr_docker_hosts_default: []
 recyclarr_docker_hosts_custom: []
 recyclarr_docker_hosts: "{{ docker_hosts_common
-                           | combine(recyclarr_docker_hosts_default)
-                           | combine(recyclarr_docker_hosts_custom) }}"
+                            | combine(recyclarr_docker_hosts_default)
+                            | combine(recyclarr_docker_hosts_custom) }}"
 
 # Labels
 recyclarr_docker_labels_default: {}
 recyclarr_docker_labels_custom: {}
 recyclarr_docker_labels: "{{ docker_labels_common
-                            | combine(recyclarr_docker_labels_default)
-                            | combine(recyclarr_docker_labels_custom) }}"
+                             | combine(recyclarr_docker_labels_default)
+                             | combine(recyclarr_docker_labels_custom) }}"
 
 # Hostname
 recyclarr_docker_hostname: "{{ recyclarr_name }}"
@@ -93,20 +93,20 @@ recyclarr_docker_networks_alias: "{{ recyclarr_name }}"
 recyclarr_docker_networks_default: []
 recyclarr_docker_networks_custom: []
 recyclarr_docker_networks: "{{ docker_networks_common
-                              + recyclarr_docker_networks_default
-                              + recyclarr_docker_networks_custom }}"
+                               + recyclarr_docker_networks_default
+                               + recyclarr_docker_networks_custom }}"
 
 # Capabilities
 recyclarr_docker_capabilities_default: []
 recyclarr_docker_capabilities_custom: []
 recyclarr_docker_capabilities: "{{ recyclarr_docker_capabilities_default
-                                  + recyclarr_docker_capabilities_custom }}"
+                                   + recyclarr_docker_capabilities_custom }}"
 
 # Security Opts
 recyclarr_docker_security_opts_default: []
 recyclarr_docker_security_opts_custom: []
 recyclarr_docker_security_opts: "{{ recyclarr_docker_security_opts_default
-                                   + recyclarr_docker_security_opts_custom }}"
+                                    + recyclarr_docker_security_opts_custom }}"
 
 # Restart Policy
 recyclarr_docker_restart_policy: unless-stopped

--- a/roles/recyclarr/defaults/main.yml
+++ b/roles/recyclarr/defaults/main.yml
@@ -47,6 +47,7 @@ recyclarr_docker_envs_default:
   TZ: "{{ tz }}"
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
+  CRON_SCHEDULE: "{{ recyclarr.cron_schedule }}"
 recyclarr_docker_envs_custom: {}
 recyclarr_docker_envs: "{{ recyclarr_docker_envs_default
                           | combine(recyclarr_docker_envs_custom) }}"

--- a/roles/recyclarr/defaults/main.yml
+++ b/roles/recyclarr/defaults/main.yml
@@ -1,0 +1,114 @@
+##########################################################################
+# Title:            Sandbox: Recyclarr                                   #
+# Author(s):        BeansIsFat                                           #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+recyclarr_name: recyclarr
+
+################################
+# Paths
+################################
+
+recyclarr_paths_folder: "{{ recyclarr_name }}"
+recyclarr_paths_location: "{{ server_appdata_path }}/{{ recyclarr_paths_folder }}"
+recyclarr_paths_folders_list:
+  - "{{ recyclarr_paths_location }}"
+
+################################
+# Docker
+################################
+
+# Container
+recyclarr_docker_container: "{{ recyclarr_name }}"
+
+# Image
+recyclarr_docker_image_pull: true
+recyclarr_docker_image_tag: "latest"
+recyclarr_docker_image: "ghcr.io/recyclarr/recyclarr:{{ recyclarr_docker_image_tag }}"
+
+# Ports
+recyclarr_docker_ports_defaults: []
+recyclarr_docker_ports_custom: []
+recyclarr_docker_ports: "{{ recyclarr_docker_ports_defaults
+                           + recyclarr_docker_ports_custom
+                        if (not reverse_proxy_is_enabled)
+                        else [] + recyclarr_docker_ports_custom }}"
+
+# Envs
+recyclarr_docker_envs_default:
+  TZ: "{{ tz }}"
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+recyclarr_docker_envs_custom: {}
+recyclarr_docker_envs: "{{ recyclarr_docker_envs_default
+                          | combine(recyclarr_docker_envs_custom) }}"
+
+# Commands
+recyclarr_docker_commands_default: []
+recyclarr_docker_commands_custom: []
+recyclarr_docker_commands: "{{ recyclarr_docker_commands_default
+                              + recyclarr_docker_commands_custom }}"
+
+# Volumes
+recyclarr_docker_volumes_default:
+  - "{{ recyclarr_paths_location }}:/config"
+recyclarr_docker_volumes_custom: []
+recyclarr_docker_volumes: "{{ recyclarr_docker_volumes_default
+                             + recyclarr_docker_volumes_custom }}"
+
+# Devices
+recyclarr_docker_devices_default: []
+recyclarr_docker_devices_custom: []
+recyclarr_docker_devices: "{{ recyclarr_docker_devices_default
+                             + recyclarr_docker_devices_custom }}"
+
+# Hosts
+recyclarr_docker_hosts_default: []
+recyclarr_docker_hosts_custom: []
+recyclarr_docker_hosts: "{{ docker_hosts_common
+                           | combine(recyclarr_docker_hosts_default)
+                           | combine(recyclarr_docker_hosts_custom) }}"
+
+# Labels
+recyclarr_docker_labels_default: {}
+recyclarr_docker_labels_custom: {}
+recyclarr_docker_labels: "{{ docker_labels_common
+                            | combine(recyclarr_docker_labels_default)
+                            | combine(recyclarr_docker_labels_custom) }}"
+
+# Hostname
+recyclarr_docker_hostname: "{{ recyclarr_name }}"
+
+# Networks
+recyclarr_docker_networks_alias: "{{ recyclarr_name }}"
+recyclarr_docker_networks_default: []
+recyclarr_docker_networks_custom: []
+recyclarr_docker_networks: "{{ docker_networks_common
+                              + recyclarr_docker_networks_default
+                              + recyclarr_docker_networks_custom }}"
+
+# Capabilities
+recyclarr_docker_capabilities_default: []
+recyclarr_docker_capabilities_custom: []
+recyclarr_docker_capabilities: "{{ recyclarr_docker_capabilities_default
+                                  + recyclarr_docker_capabilities_custom }}"
+
+# Security Opts
+recyclarr_docker_security_opts_default: []
+recyclarr_docker_security_opts_custom: []
+recyclarr_docker_security_opts: "{{ recyclarr_docker_security_opts_default
+                                   + recyclarr_docker_security_opts_custom }}"
+
+# Restart Policy
+recyclarr_docker_restart_policy: unless-stopped
+
+# State
+recyclarr_docker_state: started

--- a/roles/recyclarr/tasks/main.yml
+++ b/roles/recyclarr/tasks/main.yml
@@ -1,0 +1,23 @@
+##########################################################################
+# Title:            Sandbox: Recyclarr                                   #
+# Author(s):        BeansIsFat                                           #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Remove existing Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+- name: Create Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -90,6 +90,7 @@
     - { role: python_plexlibrary, tags: ['python-plexlibrary'] }
     - { role: qbit_manage, tags: ['qbit_manage'] }
     - { role: rdtclient, tags: ['rdtclient'] }
+    - { role: recyclarr, tags: ['recyclarr'] }
     - { role: requestrr, tags: ['requestrr'] }
     - { role: requestrrx, tags: ['requestrrx'] }
     - { role: resiliosync, tags: ['resiliosync'] }


### PR DESCRIPTION
# Description

Recyclarr automatically synchronizes recommended settings from TRaSH guides to your Sonarr/Radarr instances.

* Docker container: [ghcr.io/recyclarr/recyclarr](https://ghcr.io/recyclarr/recyclarr)
* Project homepage: [github.com/recyclarr/recyclarr](https://github.com/recyclarr/recyclarr)
* Configuration reference: [github.com/recyclarr/recyclarr/wiki/Configuration-Reference](https://github.com/recyclarr/recyclarr/wiki/Configuration-Reference)
* Configuration examples: [github.com/recyclarr/recyclarr/wiki/Configuration-Examples](https://github.com/recyclarr/recyclarr/wiki/Configuration-Examples)
* Documentation wiki for docker image: [github.com/recyclarr/recyclarr/wiki/Docker](https://github.com/recyclarr/recyclarr/wiki/Docker)

# How Has This Been Tested?

I ran the role on my saltbox server and tested the following:

* Changing cron_schedule in settings.yml using standard cron syntax
* Changing settings in recyclarr.yml
* Reinstalling with and without deleting existing container and /opt/recyclarr

I confirmed that Recyclarr ran as expected and updated properly when changing cron_schedule and recyclarr.yml settings.

Discord user killo also tested the role on their saltbox server.