### PR TITLE
Update deemix to add authelia auth

### DIFF
--- a/roles/deemix/defaults/main.yml
+++ b/roles/deemix/defaults/main.yml
@@ -45,7 +45,19 @@ deemix_dns_proxy: "{{ dns.proxied }}"
 # Traefik
 ################################
 
-deemix_traefik_middleware: "{{ traefik_default_middleware }}"
+deemix_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+
+deemix_traefik_middleware_default: "{{ traefik_default_middleware + ','
+                                       + lookup('vars', deemix_name + '_traefik_sso_middleware', default=deemix_traefik_sso_middleware)
+                                    if (lookup('vars', deemix_name + '_traefik_sso_middleware', default=deemix_traefik_sso_middleware) | length > 0)
+                                    else traefik_default_middleware }}"
+deemix_traefik_middleware_custom: ""
+deemix_traefik_middleware: "{{ deemix_traefik_middleware_default + ','
+                               + deemix_traefik_middleware_custom
+                            if (not deemix_traefik_middleware_custom.startswith(',') and deemix_traefik_middleware_custom | length > 0)
+                            else deemix_traefik_middleware_default
+                               + deemix_traefik_middleware_custom }}"
+
 deemix_traefik_certresolver: "{{ traefik_default_certresolver }}"
 deemix_traefik_enabled: true
 


### PR DESCRIPTION
- This adds the default sso middleware for deemix.

# Description

For new roles please include a brief description of what this app does, or what the purpose of this role is. Include a link to the docker container used, the projects home page and a link to the documentation if it exists.

It would be greatly appreciated if you create a sandbox documentation page yourself and do a PR into the [docs repo](https://github.com/saltyorg/docs).  You, as the person creating the role, have presumably used the thing and are presumably familiar with any setup steps required.  Anyone else here would need to research that.

For existing roles, please include a summary of the change and which issue is fixed if any. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.  You can use the checkboxes below or delete them as you wish.

Ran `sb install sandbox-deemix` with updates. It now adds an auth page when not logged in. Once logged in, I can get to deemix. I did not notice any issues with this piece of middleware in place.