### PR TITLE
Speedtest: Add theme.park support

### DIFF
--- a/roles/speedtest/defaults/main.yml
+++ b/roles/speedtest/defaults/main.yml
@@ -50,6 +50,15 @@ speedtest_traefik_certresolver: "{{ traefik_default_certresolver }}"
 speedtest_traefik_enabled: true
 
 ################################
+# THEME
+################################
+
+# Options can be found at https://github.com/gilbN/theme.park
+speedtest_themepark_enabled: false
+speedtest_themepark_theme: "{{ global_themepark_theme }}"
+speedtest_themepark_domain: "{{ global_themepark_domain }}"
+
+################################
 # Docker
 ################################
 
@@ -77,6 +86,9 @@ speedtest_docker_envs_default:
   TZ: "{{ tz }}"
   PASSWORD: "{{ user.pass }}"
   DB_TYPE: "sqlite"
+  DOCKER_MODS: "{{ 'ghcr.io/gilbn/theme.park:librespeed' if speedtest_themepark_enabled else omit }}"
+  TP_DOMAIN: "{{ lookup('vars', speedtest_name + '_themepark_domain', default=speedtest_themepark_domain) }}"
+  TP_THEME: "{{ lookup('vars', speedtest_name + '_themepark_theme', default=speedtest_themepark_theme) }}"
 speedtest_docker_envs_custom: {}
 speedtest_docker_envs: "{{ speedtest_docker_envs_default
                            | combine(speedtest_docker_envs_custom) }}"


### PR DESCRIPTION
Add theme.park to Speedtest role using Docker Mod method.
