### PR TITLE
Add Authelia SSO support for AllTube

### DIFF
--- a/roles/alltube/defaults/main.yml
+++ b/roles/alltube/defaults/main.yml
@@ -45,7 +45,17 @@ alltube_dns_proxy: "{{ dns.proxied }}"
 # Traefik
 ################################
 
-alltube_traefik_middleware: "{{ traefik_default_middleware }}"
+alltube_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+alltube_traefik_middleware_default: "{{ traefik_default_middleware + ','
+                                         + lookup('vars', alltube_name + '_traefik_sso_middleware', default=alltube_traefik_sso_middleware)
+                                      if (lookup('vars', alltube_name + '_traefik_sso_middleware', default=alltube_traefik_sso_middleware) | length > 0)
+                                      else traefik_default_middleware }}"
+alltube_traefik_middleware_custom: ""
+alltube_traefik_middleware: "{{ alltube_traefik_middleware_default + ','
+                                 + alltube_traefik_middleware_custom
+                              if (not alltube_traefik_middleware_custom.startswith(',') and alltube_traefik_middleware_custom | length > 0)
+                              else alltube_traefik_middleware_default
+                                 + alltube_traefik_middleware_custom }}"
 alltube_traefik_certresolver: "{{ traefik_default_certresolver }}"
 alltube_traefik_enabled: true
 


### PR DESCRIPTION
# Description
Updates All Tube's default main.yml to configure Traefik with Authelia's middleware. This prevents users from accessing the alltube URL without first authenticated with Authelia if it's configured.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.  You can use the checkboxes below or delete them as you wish.

- [X] This is a test I performed
- [X] Tested with Authelia configured and active

```
Sunday 24 July 2022  22:19:37 +0200 (0:00:05.292)       0:00:30.869 *********** 
=============================================================================== 
alltube : Download alltube config example ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 12.69s
alltube : Resources | Tasks | Docker | Create Docker Container | Create Docker Container -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.29s
Gathering Facts --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 4.06s
sanity_check : Get all available tags ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.89s
alltube : Resources | Tasks | Docker | Remove Docker Container | Remove Docker Container -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 1.79s
pre_tasks : APT | Remove APT locks -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.54s
sanity_check : Check if 'saltbox' folder is present --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.31s
pre_tasks : Git | Lookup git safe directories --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.28s
alltube : Create directories -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.26s
sanity_check : Check if 'backup.lock' is present in the 'saltbox' folder ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 0.22s
sanity_check : Delete stale 'backup.lock' ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.21s
sanity_check : Repository | Check Current Hash -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.20s
sanity_check : Find Ansible version ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.19s
sanity_check : Repository | Print Current Hash -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.18s
alltube : Add DNS record ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 0.07s
alltube : Create Docker container --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.07s
alltube : Remove existing Docker container ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 0.07s
alltube : Get subdomain var --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.06s
sanity_check : Fail when 'backup.lock' exists. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.06s
sanity_check : Import Default Sanity Check variables -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.06s
```