### PR TITLE
Set DEBUG env to 0

### DIFF
--- a/roles/tandoor/defaults/main.yml
+++ b/roles/tandoor/defaults/main.yml
@@ -82,6 +82,7 @@ tandoor_docker_envs_default:
   POSTGRES_USER: "{{ postgres_docker_env_user }}"
   POSTGRES_PASSWORD: "{{ postgres_docker_env_password }}"
   POSTGRES_DB: "{{ postgres_docker_env_db }}"
+  DEBUG: "0"
 tandoor_docker_envs_custom: {}
 tandoor_docker_envs: "{{ tandoor_docker_envs_default
                            | combine(tandoor_docker_envs_custom) }}"


### PR DESCRIPTION
# Description

Debug mode is enabled by default. This sets a docker env of DEBUG=0 to disable it. 

# How Has This Been Tested?

Tested on my production installation. Confirmed that it disabled debug mode.