### PR TITLE
Added env to explicitly enable Gunicorn for media files

### DIFF
--- a/roles/tandoor/defaults/main.yml
+++ b/roles/tandoor/defaults/main.yml
@@ -83,6 +83,7 @@ tandoor_docker_envs_default:
   POSTGRES_PASSWORD: "{{ postgres_docker_env_password }}"
   POSTGRES_DB: "{{ postgres_docker_env_db }}"
   DEBUG: "0"
+  GUNICORN_MEDIA: "1"
 tandoor_docker_envs_custom: {}
 tandoor_docker_envs: "{{ tandoor_docker_envs_default
                            | combine(tandoor_docker_envs_custom) }}"


### PR DESCRIPTION
# Description

Added docker env `GUNICORN_MEDIA: 1` to explicitly enable Gunicorn to serve media files. This is currently the default but the dev has stated that it will change at some point.

Note: The dev recommends running a separate webserver for media files because of performance issues with Gunicorn. For small installs with few users it should be fine. But it might be worth looking at integrating an nginx container, similar to the invoiceninja role.

# How Has This Been Tested?

Tested on my production install of Tandoor.