### PR TITLE
Removed tandoor_docker_user, container expects root user

### DIFF
--- a/roles/tandoor/defaults/main.yml
+++ b/roles/tandoor/defaults/main.yml
@@ -150,6 +150,3 @@ tandoor_docker_restart_policy: unless-stopped
 
 # State
 tandoor_docker_state: started
-
-# User
-tandoor_docker_user: "{{ uid }}:{{ gid }}"


### PR DESCRIPTION
# Description

The Tandoor docker image expects a root user. When using the SB `uid` and `pid` for `tandoor_docker_user` some functionality breaks. In particular, the Space Settings are completely inaccessible. Without this, it's impossible to invite users.

Removing `tandoor_docker_user` restores the functionality. The two directories that are created (`mediafiles` and `staticfiles`) will be still be owned by the SB user but any content added to those directories by the container will be owned by root. Since these files aren't typically edited directly by the user, this shouldn't be a significant problem.

The dev has expressed some interest in fixing this but it's not a priority. If a fix is ever implemented, we can revert to a non-root user.

# How Has This Been Tested?

Tested on my production installation. Created new recipes, shopping lists, and cookbooks. Used Space Settings to invite new users.