### PR TITLE
Update for Recyclarr rootless container

### DIFF
--- a/roles/recyclarr/defaults/main.yml
+++ b/roles/recyclarr/defaults/main.yml
@@ -111,3 +111,6 @@ recyclarr_docker_restart_policy: unless-stopped
 
 # State
 recyclarr_docker_state: started
+
+# User
+recyclarr_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/recyclarr/defaults/main.yml
+++ b/roles/recyclarr/defaults/main.yml
@@ -45,8 +45,6 @@ recyclarr_docker_ports: "{{ recyclarr_docker_ports_defaults
 # Envs
 recyclarr_docker_envs_default:
   TZ: "{{ tz }}"
-  PUID: "{{ uid }}"
-  PGID: "{{ gid }}"
   CRON_SCHEDULE: "{{ recyclarr.cron_schedule }}"
 recyclarr_docker_envs_custom: {}
 recyclarr_docker_envs: "{{ recyclarr_docker_envs_default


### PR DESCRIPTION
# Description

Remove PUID/PGID from role as Recyclarr has switched to a rootless container and these envs will break new installs.

# How Has This Been Tested?

Tested on my production server using the `edge` tag for Recyclarr. Confirmed it's working with `latest` tag now that it's been released.