### PR TITLE
Add persistent thumbnail cache directory

### DIFF
--- a/roles/calibre_web/defaults/main.yml
+++ b/roles/calibre_web/defaults/main.yml
@@ -21,6 +21,7 @@ calibre_web_paths_folder: "{{ calibre_web_name }}"
 calibre_web_paths_location: "{{ server_appdata_path }}/{{ calibre_web_paths_folder }}"
 calibre_web_paths_folders_list:
   - "{{ calibre_web_paths_location }}"
+  - "{{ calibre_web_paths_location }}/cache"
 
 ################################
 # Web
@@ -84,6 +85,7 @@ calibre_web_docker_envs_default:
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
   TZ: "{{ tz }}"
+  CACHE_DIR: "/cache/"
   USE_CONFIG_DIR: "true"
   DOCKER_MODS: linuxserver/calibre-web:calibre
 calibre_web_docker_envs_custom: {}
@@ -108,6 +110,7 @@ calibre_web_docker_commands: "{{ calibre_web_docker_commands_default
 calibre_web_docker_volumes_default:
   - "{{ calibre_web_paths_location }}:/calibre-web"
   - "{{ calibre_web_paths_location }}/config:/config"
+  - "{{ calibre_web_paths_location }}/cache:/cache"
   - "/mnt/unionfs/Media/Books:/books"
 calibre_web_docker_volumes_custom: []
 calibre_web_docker_volumes: "{{ calibre_web_docker_volumes_default


### PR DESCRIPTION
# Description

Calibre-web will create thumbnails inside the container unless the `CACHE_DIR` environment variable is set a bind volume. This adds the docker env and specifies a cache directory in the calibre-web path.

# How Has This Been Tested?

Tested on my production instance of calibre-web.