### PR TITLE
feat: add qbittorrentvpn role

### DIFF
--- a/roles/qbittorrentvpn/defaults/main.yml
+++ b/roles/qbittorrentvpn/defaults/main.yml
@@ -19,7 +19,7 @@ qbittorrentvpn_instances: ["qbittorrentvpnvpn"]
 qbittorrentvpn_paths_folder: "{{ qbittorrentvpn_name }}"
 qbittorrentvpn_paths_location: "{{ server_appdata_path }}/{{ qbittorrentvpn_paths_folder }}"
 qbittorrentvpn_paths_downloads_location: "{{ downloads_torrents_path }}/{{ qbittorrentvpn_paths_folder }}"
-qbittorrentvpn_paths_conf: "{{ qbittorrentvpn_paths_location }}/qbittorrentvpn/qbittorrentvpn.conf"
+qbittorrentvpn_paths_conf: "{{ qbittorrentvpn_paths_location }}/qbittorrent/qbittorrent.conf"
 qbittorrentvpn_paths_folders_list:
   - "{{ qbittorrentvpn_paths_location }}"
   - "{{ qbittorrentvpn_paths_location }}/wireguard"

--- a/roles/qbittorrentvpn/defaults/main.yml
+++ b/roles/qbittorrentvpn/defaults/main.yml
@@ -10,7 +10,7 @@
 # Basics
 ################################
 
-qbittorrentvpnvpn_instances: ["qbittorrentvpnvpn"]
+qbittorrentvpn_instances: ["qbittorrentvpnvpn"]
 
 ################################
 # Paths

--- a/roles/qbittorrentvpn/defaults/main.yml
+++ b/roles/qbittorrentvpn/defaults/main.yml
@@ -10,7 +10,7 @@
 # Basics
 ################################
 
-qbittorrentvpn_instances: ["qbittorrentvpnvpn"]
+qbittorrentvpn_instances: ["qbittorrentvpn"]
 
 ################################
 # Paths
@@ -19,7 +19,7 @@ qbittorrentvpn_instances: ["qbittorrentvpnvpn"]
 qbittorrentvpn_paths_folder: "{{ qbittorrentvpn_name }}"
 qbittorrentvpn_paths_location: "{{ server_appdata_path }}/{{ qbittorrentvpn_paths_folder }}"
 qbittorrentvpn_paths_downloads_location: "{{ downloads_torrents_path }}/{{ qbittorrentvpn_paths_folder }}"
-qbittorrentvpn_paths_conf: "{{ qbittorrentvpn_paths_location }}/qbittorrent/qbittorrent.conf"
+qbittorrentvpn_paths_conf: "{{ qbittorrentvpn_paths_location }}/qBittorrent/config/qBittorrent.conf"
 qbittorrentvpn_paths_folders_list:
   - "{{ qbittorrentvpn_paths_location }}"
   - "{{ qbittorrentvpn_paths_location }}/wireguard"

--- a/roles/qbittorrentvpn/defaults/main.yml
+++ b/roles/qbittorrentvpn/defaults/main.yml
@@ -1,5 +1,5 @@
 #########################################################################
-# Title:            Saltbox: qbittorrentvpn                                #
+# Title:            Saltbox: qbittorrentvpn                             #
 # Author(s):        salty                                               #
 # URL:              https://github.com/saltyorg/Saltbox                 #
 #########################################################################
@@ -37,9 +37,9 @@ qbittorrentvpn_web_subdomain: "{{ qbittorrentvpn_name }}"
 qbittorrentvpn_web_domain: "{{ user.domain }}"
 qbittorrentvpn_web_port: "8080"
 qbittorrentvpn_web_url: "{{ 'https://' + lookup('vars', qbittorrentvpn_name + '_web_subdomain', default=qbittorrentvpn_web_subdomain)
-                         + '.' + lookup('vars', qbittorrentvpn_name + '_web_domain', default=qbittorrentvpn_web_domain)
-                      if (reverse_proxy_is_enabled)
-                      else 'http://localhost:' + lookup('vars', qbittorrentvpn_name + '_web_port', default=qbittorrentvpn_web_port) }}"
+                            + '.' + lookup('vars', qbittorrentvpn_name + '_web_domain', default=qbittorrentvpn_web_domain)
+                         if (reverse_proxy_is_enabled)
+                         else 'http://localhost:' + lookup('vars', qbittorrentvpn_name + '_web_port', default=qbittorrentvpn_web_port) }}"
 
 ################################
 # DNS
@@ -55,14 +55,14 @@ qbittorrentvpn_dns_proxy: "{{ dns.proxied }}"
 
 qbittorrentvpn_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
 qbittorrentvpn_traefik_middleware_default: "{{ traefik_default_middleware + ',' + qbittorrentvpn_traefik_sso_middleware
-                                         if (qbittorrentvpn_traefik_sso_middleware | length > 0)
-                                         else traefik_default_middleware }}"
+                                            if (qbittorrentvpn_traefik_sso_middleware | length > 0)
+                                            else traefik_default_middleware }}"
 qbittorrentvpn_traefik_middleware_custom: ""
 qbittorrentvpn_traefik_middleware: "{{ qbittorrentvpn_traefik_middleware_default + ','
-                                    + qbittorrentvpn_traefik_middleware_custom
-                                 if (not qbittorrentvpn_traefik_middleware_custom.startswith(',') and qbittorrentvpn_traefik_middleware_custom | length > 0)
-                                 else qbittorrentvpn_traefik_middleware_default
-                                    + qbittorrentvpn_traefik_middleware_custom }}"
+                                       + qbittorrentvpn_traefik_middleware_custom
+                                    if (not qbittorrentvpn_traefik_middleware_custom.startswith(',') and qbittorrentvpn_traefik_middleware_custom | length > 0)
+                                    else qbittorrentvpn_traefik_middleware_default
+                                       + qbittorrentvpn_traefik_middleware_custom }}"
 qbittorrentvpn_traefik_certresolver: "{{ traefik_default_certresolver }}"
 qbittorrentvpn_traefik_enabled: true
 qbittorrentvpn_traefik_api_enabled: true
@@ -80,13 +80,13 @@ qbittorrentvpn_docker_image_pull: true
 qbittorrentvpn_docker_image_repo: "binhex/arch-qbittorrentvpn"
 qbittorrentvpn_docker_image_tag: "latest"
 qbittorrentvpn_docker_image: "{{ lookup('vars', qbittorrentvpn_name + '_docker_image_repo', default=qbittorrentvpn_docker_image_repo)
-                              + ':' + lookup('vars', qbittorrentvpn_name + '_docker_image_tag', default=qbittorrentvpn_docker_image_tag) }}"
+                                 + ':' + lookup('vars', qbittorrentvpn_name + '_docker_image_tag', default=qbittorrentvpn_docker_image_tag) }}"
 
 # Ports
 qbittorrentvpn_docker_ports_56881: "{{ port_lookup_56881.port
-                                 if (port_lookup_56881.port is defined)
-                                    and (port_lookup_56881.port | trim | length > 0)
-                                 else '56881' }}"
+                                    if (port_lookup_56881.port is defined)
+                                       and (port_lookup_56881.port | trim | length > 0)
+                                    else '56881' }}"
 qbittorrentvpn_web_port_lookup: "{{ lookup('vars', qbittorrentvpn_name + '_web_port', default=qbittorrentvpn_web_port) }}"
 
 qbittorrentvpn_docker_ports_defaults:
@@ -96,11 +96,11 @@ qbittorrentvpn_docker_ports_ui:
   - "{{ qbittorrentvpn_web_port_lookup }}:{{ qbittorrentvpn_web_port_lookup }}"
 qbittorrentvpn_docker_ports_custom: []
 qbittorrentvpn_docker_ports: "{{ lookup('vars', qbittorrentvpn_name + '_docker_ports_defaults', default=qbittorrentvpn_docker_ports_defaults)
-                              + lookup('vars', qbittorrentvpn_name + '_docker_ports_ui', default=qbittorrentvpn_docker_ports_ui)
-                              + lookup('vars', qbittorrentvpn_name + '_docker_ports_custom', default=qbittorrentvpn_docker_ports_custom)
-                           if (not reverse_proxy_is_enabled)
-                           else lookup('vars', qbittorrentvpn_name + '_docker_ports_defaults', default=qbittorrentvpn_docker_ports_defaults)
-                              + lookup('vars', qbittorrentvpn_name + '_docker_ports_custom', default=qbittorrentvpn_docker_ports_custom) }}"
+                                 + lookup('vars', qbittorrentvpn_name + '_docker_ports_ui', default=qbittorrentvpn_docker_ports_ui)
+                                 + lookup('vars', qbittorrentvpn_name + '_docker_ports_custom', default=qbittorrentvpn_docker_ports_custom)
+                              if (not reverse_proxy_is_enabled)
+                              else lookup('vars', qbittorrentvpn_name + '_docker_ports_defaults', default=qbittorrentvpn_docker_ports_defaults)
+                                 + lookup('vars', qbittorrentvpn_name + '_docker_ports_custom', default=qbittorrentvpn_docker_ports_custom) }}"
 ################################
 # Settings
 ################################
@@ -128,13 +128,13 @@ qbittorrentvpn_docker_envs_default:
 
 qbittorrentvpn_docker_envs_custom: {}
 qbittorrentvpn_docker_envs: "{{ lookup('vars', qbittorrentvpn_name + '_docker_envs_default', default=qbittorrentvpn_docker_envs_default)
-                             | combine(lookup('vars', qbittorrentvpn_name + '_docker_envs_custom', default=qbittorrentvpn_docker_envs_custom)) }}"
+                                | combine(lookup('vars', qbittorrentvpn_name + '_docker_envs_custom', default=qbittorrentvpn_docker_envs_custom)) }}"
 
 # Commands
 qbittorrentvpn_docker_commands_default: []
 qbittorrentvpn_docker_commands_custom: []
 qbittorrentvpn_docker_commands: "{{ lookup('vars', qbittorrentvpn_name + '_docker_commands_default', default=qbittorrentvpn_docker_commands_default)
-                                 + lookup('vars', qbittorrentvpn_name + '_docker_docker_commands_custom', default=qbittorrentvpn_docker_commands_custom) }}"
+                                    + lookup('vars', qbittorrentvpn_name + '_docker_docker_commands_custom', default=qbittorrentvpn_docker_commands_custom) }}"
 
 # Volumes
 qbittorrentvpn_docker_volumes_default:
@@ -142,27 +142,27 @@ qbittorrentvpn_docker_volumes_default:
   - "{{ server_appdata_path }}/scripts:/scripts"
 qbittorrentvpn_docker_volumes_custom: []
 qbittorrentvpn_docker_volumes: "{{ lookup('vars', qbittorrentvpn_name + '_docker_volumes_default', default=qbittorrentvpn_docker_volumes_default)
-                                + lookup('vars', qbittorrentvpn_name + '_docker_volumes_custom', default=qbittorrentvpn_docker_volumes_custom) }}"
+                                   + lookup('vars', qbittorrentvpn_name + '_docker_volumes_custom', default=qbittorrentvpn_docker_volumes_custom) }}"
 
 # Devices
 qbittorrentvpn_docker_devices_default: []
 qbittorrentvpn_docker_devices_custom: []
 qbittorrentvpn_docker_devices: "{{ lookup('vars', qbittorrentvpn_name + '_docker_devices_default', default=qbittorrentvpn_docker_devices_default)
-                                + lookup('vars', qbittorrentvpn_name + '_docker_devices_custom', default=qbittorrentvpn_docker_devices_custom) }}"
+                                   + lookup('vars', qbittorrentvpn_name + '_docker_devices_custom', default=qbittorrentvpn_docker_devices_custom) }}"
 
 # Hosts
 qbittorrentvpn_docker_hosts_default: []
 qbittorrentvpn_docker_hosts_custom: []
 qbittorrentvpn_docker_hosts: "{{ docker_hosts_common
-                              | combine(lookup('vars', qbittorrentvpn_name + '_docker_hosts_default', default=qbittorrentvpn_docker_hosts_default))
-                              | combine(lookup('vars', qbittorrentvpn_name + '_docker_hosts_custom', default=qbittorrentvpn_docker_hosts_custom)) }}"
+                                 | combine(lookup('vars', qbittorrentvpn_name + '_docker_hosts_default', default=qbittorrentvpn_docker_hosts_default))
+                                 | combine(lookup('vars', qbittorrentvpn_name + '_docker_hosts_custom', default=qbittorrentvpn_docker_hosts_custom)) }}"
 
 # Labels
 qbittorrentvpn_docker_labels_default: {}
 qbittorrentvpn_docker_labels_custom: {}
 qbittorrentvpn_docker_labels: "{{ docker_labels_common
-                               | combine(lookup('vars', qbittorrentvpn_name + '_docker_labels_default', default=qbittorrentvpn_docker_labels_default))
-                               | combine(lookup('vars', qbittorrentvpn_name + '_docker_labels_custom', default=qbittorrentvpn_docker_labels_custom)) }}"
+                                  | combine(lookup('vars', qbittorrentvpn_name + '_docker_labels_default', default=qbittorrentvpn_docker_labels_default))
+                                  | combine(lookup('vars', qbittorrentvpn_name + '_docker_labels_custom', default=qbittorrentvpn_docker_labels_custom)) }}"
 
 # Hostname
 qbittorrentvpn_docker_hostname: "{{ qbittorrentvpn_name }}"
@@ -172,8 +172,8 @@ qbittorrentvpn_docker_networks_alias: "{{ qbittorrentvpn_name }}"
 qbittorrentvpn_docker_networks_default: []
 qbittorrentvpn_docker_networks_custom: []
 qbittorrentvpn_docker_networks: "{{ docker_networks_common
-                                 + lookup('vars', qbittorrentvpn_name + '_docker_networks_default', default=qbittorrentvpn_docker_networks_default)
-                                 + lookup('vars', qbittorrentvpn_name + '_docker_networks_custom', default=qbittorrentvpn_docker_networks_custom) }}"
+                                    + lookup('vars', qbittorrentvpn_name + '_docker_networks_default', default=qbittorrentvpn_docker_networks_default)
+                                    + lookup('vars', qbittorrentvpn_name + '_docker_networks_custom', default=qbittorrentvpn_docker_networks_custom) }}"
 qbittorrentvpn_docker_purge_networks: true
 
 # Capabilities
@@ -181,13 +181,13 @@ qbittorrentvpn_docker_capabilities_default:
   - NET_ADMIN
 qbittorrentvpn_docker_capabilities_custom: []
 qbittorrentvpn_docker_capabilities: "{{ qbittorrentvpn_docker_capabilities_default
-                                   + qbittorrentvpn_docker_capabilities_custom }}"
+                                        + qbittorrentvpn_docker_capabilities_custom }}"
 
 # Security Opts
 qbittorrentvpn_docker_security_opts_default: []
 qbittorrentvpn_docker_security_opts_custom: []
 qbittorrentvpn_docker_security_opts: "{{ lookup('vars', qbittorrentvpn_name + '_docker_security_opts_default', default=qbittorrentvpn_docker_security_opts_default)
-                                      + lookup('vars', qbittorrentvpn_name + '_docker_security_opts_custom', default=qbittorrentvpn_docker_security_opts_custom) }}"
+                                         + lookup('vars', qbittorrentvpn_name + '_docker_security_opts_custom', default=qbittorrentvpn_docker_security_opts_custom) }}"
 # Sysctls
 qbittorrentvpn_docker_sysctls:
   net.ipv4.conf.all.src_valid_mark: "1"

--- a/roles/qbittorrentvpn/defaults/main.yml
+++ b/roles/qbittorrentvpn/defaults/main.yml
@@ -1,0 +1,205 @@
+#########################################################################
+# Title:            Saltbox: qbittorrentvpn                                #
+# Author(s):        salty                                               #
+# URL:              https://github.com/saltyorg/Saltbox                 #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+
+qbittorrentvpnvpn_instances: ["qbittorrentvpnvpn"]
+
+################################
+# Paths
+################################
+
+qbittorrentvpn_paths_folder: "{{ qbittorrentvpn_name }}"
+qbittorrentvpn_paths_location: "{{ server_appdata_path }}/{{ qbittorrentvpn_paths_folder }}"
+qbittorrentvpn_paths_downloads_location: "{{ downloads_torrents_path }}/{{ qbittorrentvpn_paths_folder }}"
+qbittorrentvpn_paths_conf: "{{ qbittorrentvpn_paths_location }}/qbittorrentvpn/qbittorrentvpn.conf"
+qbittorrentvpn_paths_folders_list:
+  - "{{ qbittorrentvpn_paths_location }}"
+  - "{{ qbittorrentvpn_paths_location }}/wireguard"
+  - "{{ qbittorrentvpn_paths_downloads_location }}"
+  - "{{ qbittorrentvpn_paths_downloads_location }}/completed"
+  - "{{ qbittorrentvpn_paths_downloads_location }}/incoming"
+  - "{{ qbittorrentvpn_paths_downloads_location }}/watched"
+  - "{{ qbittorrentvpn_paths_downloads_location }}/torrents"
+
+################################
+# Web
+################################
+
+qbittorrentvpn_web_subdomain: "{{ qbittorrentvpn_name }}"
+qbittorrentvpn_web_domain: "{{ user.domain }}"
+qbittorrentvpn_web_port: "8080"
+qbittorrentvpn_web_url: "{{ 'https://' + lookup('vars', qbittorrentvpn_name + '_web_subdomain', default=qbittorrentvpn_web_subdomain)
+                         + '.' + lookup('vars', qbittorrentvpn_name + '_web_domain', default=qbittorrentvpn_web_domain)
+                      if (reverse_proxy_is_enabled)
+                      else 'http://localhost:' + lookup('vars', qbittorrentvpn_name + '_web_port', default=qbittorrentvpn_web_port) }}"
+
+################################
+# DNS
+################################
+
+qbittorrentvpn_dns_record: "{{ lookup('vars', qbittorrentvpn_name + '_web_subdomain', default=qbittorrentvpn_web_subdomain) }}"
+qbittorrentvpn_dns_zone: "{{ lookup('vars', qbittorrentvpn_name + '_web_domain', default=qbittorrentvpn_web_domain) }}"
+qbittorrentvpn_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+qbittorrentvpn_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+qbittorrentvpn_traefik_middleware_default: "{{ traefik_default_middleware + ',' + qbittorrentvpn_traefik_sso_middleware
+                                         if (qbittorrentvpn_traefik_sso_middleware | length > 0)
+                                         else traefik_default_middleware }}"
+qbittorrentvpn_traefik_middleware_custom: ""
+qbittorrentvpn_traefik_middleware: "{{ qbittorrentvpn_traefik_middleware_default + ','
+                                    + qbittorrentvpn_traefik_middleware_custom
+                                 if (not qbittorrentvpn_traefik_middleware_custom.startswith(',') and qbittorrentvpn_traefik_middleware_custom | length > 0)
+                                 else qbittorrentvpn_traefik_middleware_default
+                                    + qbittorrentvpn_traefik_middleware_custom }}"
+qbittorrentvpn_traefik_certresolver: "{{ traefik_default_certresolver }}"
+qbittorrentvpn_traefik_enabled: true
+qbittorrentvpn_traefik_api_enabled: true
+qbittorrentvpn_traefik_api_endpoint: "`/api`,`/command`,`/query`,`/login`,`/sync`"
+
+################################
+# Docker
+################################
+
+# Container
+qbittorrentvpn_docker_container: "{{ qbittorrentvpn_name }}"
+
+# Image
+qbittorrentvpn_docker_image_pull: true
+qbittorrentvpn_docker_image_repo: "binhex/arch-qbittorrentvpn"
+qbittorrentvpn_docker_image_tag: "latest"
+qbittorrentvpn_docker_image: "{{ lookup('vars', qbittorrentvpn_name + '_docker_image_repo', default=qbittorrentvpn_docker_image_repo)
+                              + ':' + lookup('vars', qbittorrentvpn_name + '_docker_image_tag', default=qbittorrentvpn_docker_image_tag) }}"
+
+# Ports
+qbittorrentvpn_docker_ports_56881: "{{ port_lookup_56881.port
+                                 if (port_lookup_56881.port is defined)
+                                    and (port_lookup_56881.port | trim | length > 0)
+                                 else '56881' }}"
+qbittorrentvpn_web_port_lookup: "{{ lookup('vars', qbittorrentvpn_name + '_web_port', default=qbittorrentvpn_web_port) }}"
+
+qbittorrentvpn_docker_ports_defaults:
+  - "{{ qbittorrentvpn_docker_ports_56881 }}:{{ qbittorrentvpn_docker_ports_56881 }}"
+  - "{{ qbittorrentvpn_docker_ports_56881 }}:{{ qbittorrentvpn_docker_ports_56881 }}/udp"
+qbittorrentvpn_docker_ports_ui:
+  - "{{ qbittorrentvpn_web_port_lookup }}:{{ qbittorrentvpn_web_port_lookup }}"
+qbittorrentvpn_docker_ports_custom: []
+qbittorrentvpn_docker_ports: "{{ lookup('vars', qbittorrentvpn_name + '_docker_ports_defaults', default=qbittorrentvpn_docker_ports_defaults)
+                              + lookup('vars', qbittorrentvpn_name + '_docker_ports_ui', default=qbittorrentvpn_docker_ports_ui)
+                              + lookup('vars', qbittorrentvpn_name + '_docker_ports_custom', default=qbittorrentvpn_docker_ports_custom)
+                           if (not reverse_proxy_is_enabled)
+                           else lookup('vars', qbittorrentvpn_name + '_docker_ports_defaults', default=qbittorrentvpn_docker_ports_defaults)
+                              + lookup('vars', qbittorrentvpn_name + '_docker_ports_custom', default=qbittorrentvpn_docker_ports_custom) }}"
+################################
+# Settings
+################################
+
+qbittorrentvpn_log_level_daemon: info
+qbittorrentvpn_log_level_web: info
+qbittorrentvpn_name_servers: "209.222.18.222,84.200.69.80,37.235.1.174,1.1.1.1,209.222.18.218,37.235.1.177,84.200.70.40,1.0.0.1"
+qbittorrentvpn_lan_network: "172.19.0.0/16"
+
+# Envs
+qbittorrentvpn_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+  UMASK_SET: "002"
+  VPN_ENABLED: "yes"
+  VPN_USER: "{{ qbittorrentvpn.vpn_user|default('username',true) }}"
+  VPN_PASS: "{{ qbittorrentvpn.vpn_pass|default('password',true) }}"
+  VPN_PROV: "{{ qbittorrentvpn.vpn_prov|default('pia',true) }}"
+  VPN_CLIENT: "{{ qbittorrentvpn.vpn_client|default('wireguard',true) }}"
+  STRICT_PORT_FORWARD: "yes"
+  ENABLE_PRIVOXY: "no"
+  LAN_NETWORK: "{{ qbittorrentvpn_lan_network }}"
+  NAME_SERVERS: "{{ qbittorrentvpn_name_servers }}"
+
+qbittorrentvpn_docker_envs_custom: {}
+qbittorrentvpn_docker_envs: "{{ lookup('vars', qbittorrentvpn_name + '_docker_envs_default', default=qbittorrentvpn_docker_envs_default)
+                             | combine(lookup('vars', qbittorrentvpn_name + '_docker_envs_custom', default=qbittorrentvpn_docker_envs_custom)) }}"
+
+# Commands
+qbittorrentvpn_docker_commands_default: []
+qbittorrentvpn_docker_commands_custom: []
+qbittorrentvpn_docker_commands: "{{ lookup('vars', qbittorrentvpn_name + '_docker_commands_default', default=qbittorrentvpn_docker_commands_default)
+                                 + lookup('vars', qbittorrentvpn_name + '_docker_docker_commands_custom', default=qbittorrentvpn_docker_commands_custom) }}"
+
+# Volumes
+qbittorrentvpn_docker_volumes_default:
+  - "{{ qbittorrentvpn_paths_location }}:/config"
+  - "{{ server_appdata_path }}/scripts:/scripts"
+qbittorrentvpn_docker_volumes_custom: []
+qbittorrentvpn_docker_volumes: "{{ lookup('vars', qbittorrentvpn_name + '_docker_volumes_default', default=qbittorrentvpn_docker_volumes_default)
+                                + lookup('vars', qbittorrentvpn_name + '_docker_volumes_custom', default=qbittorrentvpn_docker_volumes_custom) }}"
+
+# Devices
+qbittorrentvpn_docker_devices_default: []
+qbittorrentvpn_docker_devices_custom: []
+qbittorrentvpn_docker_devices: "{{ lookup('vars', qbittorrentvpn_name + '_docker_devices_default', default=qbittorrentvpn_docker_devices_default)
+                                + lookup('vars', qbittorrentvpn_name + '_docker_devices_custom', default=qbittorrentvpn_docker_devices_custom) }}"
+
+# Hosts
+qbittorrentvpn_docker_hosts_default: []
+qbittorrentvpn_docker_hosts_custom: []
+qbittorrentvpn_docker_hosts: "{{ docker_hosts_common
+                              | combine(lookup('vars', qbittorrentvpn_name + '_docker_hosts_default', default=qbittorrentvpn_docker_hosts_default))
+                              | combine(lookup('vars', qbittorrentvpn_name + '_docker_hosts_custom', default=qbittorrentvpn_docker_hosts_custom)) }}"
+
+# Labels
+qbittorrentvpn_docker_labels_default: {}
+qbittorrentvpn_docker_labels_custom: {}
+qbittorrentvpn_docker_labels: "{{ docker_labels_common
+                               | combine(lookup('vars', qbittorrentvpn_name + '_docker_labels_default', default=qbittorrentvpn_docker_labels_default))
+                               | combine(lookup('vars', qbittorrentvpn_name + '_docker_labels_custom', default=qbittorrentvpn_docker_labels_custom)) }}"
+
+# Hostname
+qbittorrentvpn_docker_hostname: "{{ qbittorrentvpn_name }}"
+
+# Networks
+qbittorrentvpn_docker_networks_alias: "{{ qbittorrentvpn_name }}"
+qbittorrentvpn_docker_networks_default: []
+qbittorrentvpn_docker_networks_custom: []
+qbittorrentvpn_docker_networks: "{{ docker_networks_common
+                                 + lookup('vars', qbittorrentvpn_name + '_docker_networks_default', default=qbittorrentvpn_docker_networks_default)
+                                 + lookup('vars', qbittorrentvpn_name + '_docker_networks_custom', default=qbittorrentvpn_docker_networks_custom) }}"
+qbittorrentvpn_docker_purge_networks: true
+
+# Capabilities
+qbittorrentvpn_docker_capabilities_default:
+  - NET_ADMIN
+qbittorrentvpn_docker_capabilities_custom: []
+qbittorrentvpn_docker_capabilities: "{{ qbittorrentvpn_docker_capabilities_default
+                                   + qbittorrentvpn_docker_capabilities_custom }}"
+
+# Security Opts
+qbittorrentvpn_docker_security_opts_default: []
+qbittorrentvpn_docker_security_opts_custom: []
+qbittorrentvpn_docker_security_opts: "{{ lookup('vars', qbittorrentvpn_name + '_docker_security_opts_default', default=qbittorrentvpn_docker_security_opts_default)
+                                      + lookup('vars', qbittorrentvpn_name + '_docker_security_opts_custom', default=qbittorrentvpn_docker_security_opts_custom) }}"
+# Sysctls
+qbittorrentvpn_docker_sysctls:
+  net.ipv4.conf.all.src_valid_mark: "1"
+
+# Restart Policy
+qbittorrentvpn_docker_restart_policy: unless-stopped
+
+# Stop Timeout
+qbittorrentvpn_docker_stop_timeout: 900
+
+# State
+qbittorrentvpn_docker_state: started
+
+# Privledged
+qbittorrentvpn_docker_privileged: "yes"

--- a/roles/qbittorrentvpn/tasks/main.yml
+++ b/roles/qbittorrentvpn/tasks/main.yml
@@ -1,0 +1,16 @@
+#########################################################################
+# Title:         Saltbox: Deluge Role                                   #
+# Author(s):     salty                                                  #
+# URL:           https://github.com/saltyorg/Saltbox                    #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Execute qBittorrent VPN roles"
+  ansible.builtin.include_tasks: main2.yml
+  vars:
+    qbittorrentvpn_name: "{{ role }}"
+  with_items: "{{ qbittorrentvpn_instances }}"
+  loop_control:
+    loop_var: role

--- a/roles/qbittorrentvpn/tasks/main.yml
+++ b/roles/qbittorrentvpn/tasks/main.yml
@@ -1,5 +1,5 @@
 #########################################################################
-# Title:         Saltbox: Deluge Role                                   #
+# Title:         Saltbox: qbittorrentvpn Role                           #
 # Author(s):     salty                                                  #
 # URL:           https://github.com/saltyorg/Saltbox                    #
 # --                                                                    #

--- a/roles/qbittorrentvpn/tasks/main2.yml
+++ b/roles/qbittorrentvpn/tasks/main2.yml
@@ -1,0 +1,41 @@
+#########################################################################
+# Title:            Saltbox: qbittorrentvpn                                #
+# Author(s):        Kalroth, salty                                      #
+# URL:              https://github.com/saltyorg/Saltbox                 #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+- name: Check if existing config file exists
+  ansible.builtin.stat:
+    path: "{{ qbittorrentvpn_paths_conf }}"
+  register: qbittorrentvpn_paths_conf_stat
+
+- name: Pre-Install Tasks
+  ansible.builtin.import_tasks: "subtasks/pre-install/main.yml"
+  when: not continuous_integration
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+
+- name: Post-Install Tasks
+  ansible.builtin.import_tasks: "subtasks/post-install/main.yml"
+  when: (not continuous_integration) and (not qbittorrentvpn_paths_conf_stat.stat.exists)

--- a/roles/qbittorrentvpn/tasks/main2.yml
+++ b/roles/qbittorrentvpn/tasks/main2.yml
@@ -1,5 +1,5 @@
 #########################################################################
-# Title:            Saltbox: qbittorrentvpn                                #
+# Title:            Saltbox: qbittorrentvpn                             #
 # Author(s):        Kalroth, salty                                      #
 # URL:              https://github.com/saltyorg/Saltbox                 #
 #########################################################################

--- a/roles/qbittorrentvpn/tasks/subtasks/post-install/main.yml
+++ b/roles/qbittorrentvpn/tasks/subtasks/post-install/main.yml
@@ -1,5 +1,5 @@
 #########################################################################
-# Title:         Saltbox: qbittorrentvpn | Post-Install Tasks              #
+# Title:         Saltbox: qbittorrentvpn | Post-Install Tasks           #
 # Author(s):     salty                                                  #
 # URL:           https://github.com/saltyorg/Saltbox                    #
 # --                                                                    #

--- a/roles/qbittorrentvpn/tasks/subtasks/post-install/main.yml
+++ b/roles/qbittorrentvpn/tasks/subtasks/post-install/main.yml
@@ -1,0 +1,34 @@
+#########################################################################
+# Title:         Saltbox: qbittorrentvpn | Post-Install Tasks              #
+# Author(s):     salty                                                  #
+# URL:           https://github.com/saltyorg/Saltbox                    #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Post-Install | Wait for config to be created
+  ansible.builtin.wait_for:
+    path: "{{ qbittorrentvpn_paths_conf }}"
+    state: present
+
+- name: Post-Install | Wait for 10 seconds
+  ansible.builtin.wait_for:
+    timeout: 10
+
+- name: Post-Install | Stop container
+  docker_container:
+    name: "{{ qbittorrentvpn_docker_container }}"
+    container_default_behavior: compatibility
+    tls_hostname: localhost
+    state: stopped
+
+- name: Post-Install | Settings Task
+  ansible.builtin.import_tasks: "settings/main.yml"
+
+- name: Post-Install | Start container
+  docker_container:
+    name: "{{ qbittorrentvpn_docker_container }}"
+    container_default_behavior: compatibility
+    tls_hostname: localhost
+    state: "{{ qbittorrentvpn_docker_state }}"

--- a/roles/qbittorrentvpn/tasks/subtasks/post-install/settings/main.yml
+++ b/roles/qbittorrentvpn/tasks/subtasks/post-install/settings/main.yml
@@ -1,0 +1,44 @@
+####################################################################################
+# Title:         Saltbox: qbittorrentvpn | Post-Install | Settings                    #
+# Author(s):     salty                                                             #
+# URL:           https://github.com/saltyorg/Saltbox                               #
+# --                                                                               #
+####################################################################################
+#                   GNU General Public License v3.0                                #
+####################################################################################
+---
+- name: Post-Install | Settings | Update Port in 'qbittorrentvpn.conf' config settings
+  community.general.ini_file:
+    path: "{{ qbittorrentvpn_paths_conf }}"
+    section: BitTorrent
+    option: Session\Port
+    value: "{{ qbittorrentvpn_docker_ports_56881 }}"
+    no_extra_spaces: true
+    state: present
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+
+- name: Post-Install | Settings | Update HostHeaderValidation 'qbittorrentvpn.conf' config settings
+  community.general.ini_file:
+    path: "{{ qbittorrentvpn_paths_conf }}"
+    section: Preferences
+    option: WebUI\HostHeaderValidation
+    value: "false"
+    no_extra_spaces: true
+    state: present
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+
+- name: Post-Install | Settings | Update CSRFProtection 'qbittorrentvpn.conf' config settings
+  community.general.ini_file:
+    path: "{{ qbittorrentvpn_paths_conf }}"
+    section: Preferences
+    option: WebUI\CSRFProtection
+    value: "false"
+    no_extra_spaces: true
+    state: present
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"

--- a/roles/qbittorrentvpn/tasks/subtasks/post-install/settings/main.yml
+++ b/roles/qbittorrentvpn/tasks/subtasks/post-install/settings/main.yml
@@ -1,5 +1,5 @@
 ####################################################################################
-# Title:         Saltbox: qbittorrentvpn | Post-Install | Settings                    #
+# Title:         Saltbox: qbittorrentvpn | Post-Install | Settings                 #
 # Author(s):     salty                                                             #
 # URL:           https://github.com/saltyorg/Saltbox                               #
 # --                                                                               #

--- a/roles/qbittorrentvpn/tasks/subtasks/pre-install/main.yml
+++ b/roles/qbittorrentvpn/tasks/subtasks/pre-install/main.yml
@@ -1,5 +1,5 @@
 #########################################################################
-# Title:         Saltbox: qbittorrentvpn | Pre-Install Tasks               #
+# Title:         Saltbox: qbittorrentvpn | Pre-Install Tasks            #
 # Author(s):     salty                                                  #
 # URL:           https://github.com/saltyorg/Saltbox                    #
 # --                                                                    #

--- a/roles/qbittorrentvpn/tasks/subtasks/pre-install/main.yml
+++ b/roles/qbittorrentvpn/tasks/subtasks/pre-install/main.yml
@@ -1,0 +1,28 @@
+#########################################################################
+# Title:         Saltbox: qbittorrentvpn | Pre-Install Tasks               #
+# Author(s):     salty                                                  #
+# URL:           https://github.com/saltyorg/Saltbox                    #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Pre-Install | Get next available port within the range of '56881-56901'
+  find_next_open_port:
+    low_bound: 56881
+    high_bound: 56901
+  register: port_lookup_56881
+  ignore_errors: true
+
+- name: Pre-Install | Settings | Update 'qbittorrentvpn.conf' config settings
+  community.general.ini_file:
+    path: "{{ qbittorrentvpn_paths_conf }}"
+    section: BitTorrent
+    option: Session\Port
+    value: "{{ qbittorrentvpn_docker_ports_56881 }}"
+    no_extra_spaces: true
+    state: present
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  when: qbittorrentvpn_paths_conf_stat.stat.exists

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -94,6 +94,7 @@
     - { role: pyload, tags: ['pyload'] }
     - { role: python_plexlibrary, tags: ['python-plexlibrary'] }
     - { role: qbit_manage, tags: ['qbit_manage'] }
+    - { role: qbittorrentvpn, tags: ['qbittorrentvpn'] }
     - { role: rdtclient, tags: ['rdtclient'] }
     - { role: recyclarr, tags: ['recyclarr'] }
     - { role: requestrr, tags: ['requestrr'] }


### PR DESCRIPTION
# Description

Add a role for qbitttorrent with VPN from https://github.com/binhex/arch-qbittorrentvpn image.

# How Has This Been Tested?

Tested by include the role in the actual sandbox and run the tag by sb install sandbox-qbittorrentvpn

- [ ] This is not a test I performed
- [ ] I did not read the paragraph above this before checking this box
- [ ] I have now checked three boxes without reading any of the text
