### PR TITLE
feat(role): add paperless-ngx (inc. gotenberg and tika) (#114)

### DIFF
--- a/roles/gotenberg/defaults/main.yml
+++ b/roles/gotenberg/defaults/main.yml
@@ -1,0 +1,115 @@
+##########################################################################
+# Title:            Sandbox: Gotenberg | Default Variables               #
+# Author(s):        JigSawFr                                             #
+# URL:              https://github.com/gotenberg/gotenberg               #
+# DOCKER:           https://hub.docker.com/r/gotenberg/gotenberg         #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+gotenberg_name: gotenberg
+
+################################
+# Paths
+################################
+
+gotenberg_paths_folder: "{{ gotenberg_name }}"
+gotenberg_paths_location: "{{ server_appdata_path }}/{{ gotenberg_paths_folder }}"
+gotenberg_paths_folders_list:
+  - "{{ gotenberg_paths_location }}"
+
+################################
+# Docker
+################################
+
+# Container
+gotenberg_docker_container: "{{ gotenberg_name }}"
+
+# Image
+gotenberg_docker_image_pull: true
+gotenberg_docker_image_tag: "latest"
+gotenberg_docker_image: "gotenberg/gotenberg:{{ gotenberg_docker_image_tag }}"
+
+# Ports
+gotenberg_docker_ports_defaults: []
+gotenberg_docker_ports_custom: []
+gotenberg_docker_ports: "{{ gotenberg_docker_ports_defaults
+                        + gotenberg_docker_ports_custom
+                     if (not reverse_proxy_is_enabled)
+                     else gotenberg_docker_ports_custom }}"
+
+# Envs
+gotenberg_docker_envs_default:
+  TZ: "{{ tz }}"
+gotenberg_docker_envs_custom: {}
+gotenberg_docker_envs: "{{ gotenberg_docker_envs_default
+                       | combine(gotenberg_docker_envs_custom) }}"
+
+# Commands
+gotenberg_docker_commands_default: []
+gotenberg_docker_commands_custom: []
+gotenberg_docker_commands: "{{ gotenberg_docker_commands_default
+                           + gotenberg_docker_commands_custom }}"
+
+# Volumes
+gotenberg_docker_volumes_default: []
+gotenberg_docker_volumes_custom: []
+gotenberg_docker_volumes: "{{ gotenberg_docker_volumes_default
+                          + gotenberg_docker_volumes_custom }}"
+
+# Devices
+gotenberg_docker_devices_default: []
+gotenberg_docker_devices_custom: []
+gotenberg_docker_devices: "{{ gotenberg_docker_devices_default
+                          + gotenberg_docker_devices_custom }}"
+
+# Hosts
+gotenberg_docker_hosts_default: []
+gotenberg_docker_hosts_custom: []
+gotenberg_docker_hosts: "{{ docker_hosts_common
+                        | combine(gotenberg_docker_hosts_default)
+                        | combine(gotenberg_docker_hosts_custom) }}"
+
+# Labels
+gotenberg_docker_labels_default: {}
+gotenberg_docker_labels_custom: {}
+gotenberg_docker_labels: "{{ docker_labels_common
+                         | combine(gotenberg_docker_labels_default)
+                         | combine(gotenberg_docker_labels_custom) }}"
+
+# Hostname
+gotenberg_docker_hostname: "{{ gotenberg_name }}"
+
+# Networks
+gotenberg_docker_networks_alias: "{{ gotenberg_name }}"
+gotenberg_docker_networks_default: []
+gotenberg_docker_networks_custom: []
+gotenberg_docker_networks: "{{ docker_networks_common
+                           + gotenberg_docker_networks_default
+                           + gotenberg_docker_networks_custom }}"
+
+# Capabilities
+gotenberg_docker_capabilities_default: []
+gotenberg_docker_capabilities_custom: []
+gotenberg_docker_capabilities: "{{ gotenberg_docker_capabilities_default
+                               + gotenberg_docker_capabilities_custom }}"
+
+# Security Opts
+gotenberg_docker_security_opts_default: []
+gotenberg_docker_security_opts_custom: []
+gotenberg_docker_security_opts: "{{ gotenberg_docker_security_opts_default
+                                + gotenberg_docker_security_opts_custom }}"
+
+# Restart Policy
+gotenberg_docker_restart_policy: always
+
+# State
+gotenberg_docker_state: started
+
+# User
+gotenberg_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/gotenberg/defaults/main.yml
+++ b/roles/gotenberg/defaults/main.yml
@@ -1,8 +1,7 @@
 ##########################################################################
 # Title:            Sandbox: Gotenberg | Default Variables               #
 # Author(s):        JigSawFr                                             #
-# URL:              https://github.com/gotenberg/gotenberg               #
-# DOCKER:           https://hub.docker.com/r/gotenberg/gotenberg         #
+# URL:              https://github.com/saltyorg/Sandbox                  #
 # --                                                                     #
 ##########################################################################
 #                   GNU General Public License v3.0                      #

--- a/roles/gotenberg/defaults/main.yml
+++ b/roles/gotenberg/defaults/main.yml
@@ -39,48 +39,48 @@ gotenberg_docker_image: "gotenberg/gotenberg:{{ gotenberg_docker_image_tag }}"
 gotenberg_docker_ports_defaults: []
 gotenberg_docker_ports_custom: []
 gotenberg_docker_ports: "{{ gotenberg_docker_ports_defaults
-                        + gotenberg_docker_ports_custom
-                     if (not reverse_proxy_is_enabled)
-                     else gotenberg_docker_ports_custom }}"
+                            + gotenberg_docker_ports_custom
+                         if (not reverse_proxy_is_enabled)
+                         else gotenberg_docker_ports_custom }}"
 
 # Envs
 gotenberg_docker_envs_default:
   TZ: "{{ tz }}"
 gotenberg_docker_envs_custom: {}
 gotenberg_docker_envs: "{{ gotenberg_docker_envs_default
-                       | combine(gotenberg_docker_envs_custom) }}"
+                           | combine(gotenberg_docker_envs_custom) }}"
 
 # Commands
 gotenberg_docker_commands_default: []
 gotenberg_docker_commands_custom: []
 gotenberg_docker_commands: "{{ gotenberg_docker_commands_default
-                           + gotenberg_docker_commands_custom }}"
+                               + gotenberg_docker_commands_custom }}"
 
 # Volumes
 gotenberg_docker_volumes_default: []
 gotenberg_docker_volumes_custom: []
 gotenberg_docker_volumes: "{{ gotenberg_docker_volumes_default
-                          + gotenberg_docker_volumes_custom }}"
+                              + gotenberg_docker_volumes_custom }}"
 
 # Devices
 gotenberg_docker_devices_default: []
 gotenberg_docker_devices_custom: []
 gotenberg_docker_devices: "{{ gotenberg_docker_devices_default
-                          + gotenberg_docker_devices_custom }}"
+                              + gotenberg_docker_devices_custom }}"
 
 # Hosts
 gotenberg_docker_hosts_default: []
 gotenberg_docker_hosts_custom: []
 gotenberg_docker_hosts: "{{ docker_hosts_common
-                        | combine(gotenberg_docker_hosts_default)
-                        | combine(gotenberg_docker_hosts_custom) }}"
+                            | combine(gotenberg_docker_hosts_default)
+                            | combine(gotenberg_docker_hosts_custom) }}"
 
 # Labels
 gotenberg_docker_labels_default: {}
 gotenberg_docker_labels_custom: {}
 gotenberg_docker_labels: "{{ docker_labels_common
-                         | combine(gotenberg_docker_labels_default)
-                         | combine(gotenberg_docker_labels_custom) }}"
+                             | combine(gotenberg_docker_labels_default)
+                             | combine(gotenberg_docker_labels_custom) }}"
 
 # Hostname
 gotenberg_docker_hostname: "{{ gotenberg_name }}"
@@ -90,20 +90,20 @@ gotenberg_docker_networks_alias: "{{ gotenberg_name }}"
 gotenberg_docker_networks_default: []
 gotenberg_docker_networks_custom: []
 gotenberg_docker_networks: "{{ docker_networks_common
-                           + gotenberg_docker_networks_default
-                           + gotenberg_docker_networks_custom }}"
+                               + gotenberg_docker_networks_default
+                               + gotenberg_docker_networks_custom }}"
 
 # Capabilities
 gotenberg_docker_capabilities_default: []
 gotenberg_docker_capabilities_custom: []
 gotenberg_docker_capabilities: "{{ gotenberg_docker_capabilities_default
-                               + gotenberg_docker_capabilities_custom }}"
+                                   + gotenberg_docker_capabilities_custom }}"
 
 # Security Opts
 gotenberg_docker_security_opts_default: []
 gotenberg_docker_security_opts_custom: []
 gotenberg_docker_security_opts: "{{ gotenberg_docker_security_opts_default
-                                + gotenberg_docker_security_opts_custom }}"
+                                    + gotenberg_docker_security_opts_custom }}"
 
 # Restart Policy
 gotenberg_docker_restart_policy: always

--- a/roles/gotenberg/tasks/main.yml
+++ b/roles/gotenberg/tasks/main.yml
@@ -13,4 +13,3 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
-  

--- a/roles/gotenberg/tasks/main.yml
+++ b/roles/gotenberg/tasks/main.yml
@@ -1,0 +1,15 @@
+##########################################################################
+# Title:            Sandbox: Gotenberg                                   #
+# Author(s):        JigSawFr                                             #
+# URL:              https://github.com/gotenberg/gotenberg               #
+# DOCKER:           https://hub.docker.com/r/gotenberg/gotenberg         #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/gotenberg/tasks/main.yml
+++ b/roles/gotenberg/tasks/main.yml
@@ -13,3 +13,4 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+  

--- a/roles/gotenberg/tasks/main.yml
+++ b/roles/gotenberg/tasks/main.yml
@@ -1,8 +1,7 @@
 ##########################################################################
 # Title:            Sandbox: Gotenberg                                   #
 # Author(s):        JigSawFr                                             #
-# URL:              https://github.com/gotenberg/gotenberg               #
-# DOCKER:           https://hub.docker.com/r/gotenberg/gotenberg         #
+# URL:              https://github.com/saltyorg/Sandbox                  #
 # --                                                                     #
 ##########################################################################
 #                   GNU General Public License v3.0                      #

--- a/roles/paperless_ngx/defaults/main.yml
+++ b/roles/paperless_ngx/defaults/main.yml
@@ -12,134 +12,169 @@
 # Basics
 ################################
 
-paperless_name: paperless
+paperless_ngx_name: paperless
 
 ################################
 # Paths
 ################################
 
-paperless_paths_folder: "{{ paperless_name }}"
-paperless_paths_location: "{{ server_appdata_path }}/{{ paperless_paths_folder }}"
-paperless_paths_folders_list:
-  - "{{ paperless_paths_location }}"
-  - "{{ paperless_paths_location }}/data"
-  - "{{ paperless_paths_location }}/config"
+paperless_ngx_paths_folder: "{{ paperless_ngx_name }}"
+paperless_ngx_paths_location: "{{ server_appdata_path }}/{{ paperless_ngx_paths_folder }}/app"
+paperless_ngx_paths_folders_list:
+  - "{{ paperless_ngx_paths_location }}"
+  - "{{ paperless_ngx_paths_location }}/data"
+  - "{{ paperless_ngx_paths_location }}/config"
+  - "{{ paperless_ngx_paths_location }}/consume"
+  - "{{ paperless_ngx_paths_location }}/media"
+  - "{{ paperless_ngx_paths_location }}/trash"
 
 ################################
 # Web
 ################################
 
-paperless_web_subdomain: "{{ paperless_name }}"
-paperless_web_domain: "{{ user.domain }}"
-paperless_web_port: "8000"
-paperless_web_url: "{{ 'https://' + paperless_web_subdomain + '.' + paperless_web_domain
-                  if (reverse_proxy_is_enabled)
-                  else 'http://localhost:' + paperless_web_port }}"
+paperless_ngx_web_subdomain: "{{ paperless_ngx_name }}"
+paperless_ngx_web_domain: "{{ user.domain }}"
+paperless_ngx_web_port: "8000"
+paperless_ngx_web_url: "{{ 'https://' + paperless_ngx_web_subdomain + '.' + paperless_ngx_web_domain
+                    if (reverse_proxy_is_enabled)
+                    else 'http://localhost:' + paperless_ngx_web_port }}"
 
 ################################
 # DNS
 ################################
 
-paperless_dns_record: "{{ paperless_web_subdomain }}"
-paperless_dns_zone: "{{ paperless_web_domain }}"
-paperless_dns_proxy: "{{ dns.proxied }}"
+paperless_ngx_dns_record: "{{ paperless_ngx_web_subdomain }}"
+paperless_ngx_dns_zone: "{{ paperless_ngx_web_domain }}"
+paperless_ngx_dns_proxy: "{{ dns.proxied }}"
 
 ################################
 # Traefik
 ################################
 
-paperless_traefik_middleware: "{{ traefik_default_middleware }}"
-paperless_traefik_certresolver: "{{ traefik_default_certresolver }}"
-paperless_traefik_enabled: true
+paperless_ngx_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+paperless_ngx_traefik_middleware_default: "{{ traefik_default_middleware + ','
+                                       + lookup('vars', paperless_ngx_name + '_traefik_sso_middleware', default=paperless_ngx_traefik_sso_middleware)
+                                    if (lookup('vars', paperless_ngx_name + '_traefik_sso_middleware', default=paperless_ngx_traefik_sso_middleware) | length > 0)
+                                    else traefik_default_middleware }}"
+paperless_ngx_traefik_middleware_custom: ""
+paperless_ngx_traefik_middleware: "{{ paperless_ngx_traefik_middleware_default + ','
+                               + paperless_ngx_traefik_middleware_custom
+                            if (not paperless_ngx_traefik_middleware_custom.startswith(',') and paperless_ngx_traefik_middleware_custom | length > 0)
+                            else paperless_ngx_traefik_middleware_default
+                               + paperless_ngx_traefik_middleware_custom }}"
+paperless_ngx_traefik_certresolver: "{{ traefik_default_certresolver }}"
+paperless_ngx_traefik_enabled: true
+paperless_ngx_traefik_api_enabled: true
+paperless_ngx_traefik_api_endpoint: "`/api`"
 
 ################################
 # Docker
 ################################
 
 # Container
-paperless_docker_container: "{{ paperless_name }}"
+paperless_ngx_docker_container: "{{ paperless_ngx_name }}"
 
 # Image
-paperless_docker_image_pull: true
-paperless_docker_image_tag: "latest"
-paperless_docker_image: "lscr.io/linuxserver/paperless-ngx:{{ paperless_docker_image_tag }}"
+paperless_ngx_docker_image_pull: true
+paperless_ngx_docker_image_tag: "latest"
+paperless_ngx_docker_image: "ghcr.io/paperless-ngx/paperless-ngx:{{ paperless_ngx_docker_image_tag }}"
 
 # Ports
-paperless_docker_ports_defaults:
-  - "{{ paperless_web_port }}"
-paperless_docker_ports_custom: []
-paperless_docker_ports: "{{ paperless_docker_ports_defaults
-                          + paperless_docker_ports_custom
+paperless_ngx_docker_ports_defaults:
+  - "{{ paperless_ngx_web_port }}"
+paperless_ngx_docker_ports_custom: []
+paperless_ngx_docker_ports: "{{ paperless_ngx_docker_ports_defaults
+                          + paperless_ngx_docker_ports_custom
                        if (not reverse_proxy_is_enabled)
-                       else paperless_docker_ports_custom }}"
+                       else paperless_ngx_docker_ports_custom }}"
 
 # Envs
-paperless_docker_envs_default:
-  TZ: "{{ tz }}"
-  REDIS_URL: "redis:6379"
-paperless_docker_envs_custom: {}
-paperless_docker_envs: "{{ paperless_docker_envs_default
-                         | combine(paperless_docker_envs_custom) }}"
+paperless_ngx_docker_envs_default:
+  PAPERLESS_TIME_ZONE: "{{ tz }}"
+  USERMAP_UID: "{{ uid }}"
+  USERMAP_GID: "{{ gid }}"
+  PAPERLESS_REDIS: "redis://{{ paperless_ngx_name }}_redis:6379"
+  PAPERLESS_DBHOST: "{{ paperless_ngx_name }}_postgres"
+  PAPERLESS_DBPORT: "5432"
+  PAPERLESS_DBNAME: "{{ paperless_ngx_name }}"
+  PAPERLESS_DBPASS: "{{ postgres_docker_env_password }}"
+  PAPERLESS_DBUSER: "{{ postgres_docker_env_user }}"
+  PAPERLESS_URL: "{{ paperless_ngx_web_url }}"
+  PAPERLESS_ENABLE_UPDATE_CHECK: "true"
+  PAPERLESS_TRASH_DIR: "../trash/"
+  PAPERLESS_TIKA_ENABLED: "1"
+  PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://{{ paperless_ngx_name }}_gotenberg:3000
+  PAPERLESS_TIKA_ENDPOINT: "http://{{ paperless_ngx_name }}_tika:9998"
+  PAPERLESS_AUTO_LOGIN_USERNAME: "{{ user.name }}"
+  PAPERLESS_ADMIN_USER: "{{ user.name }}"
+  PAPERLESS_ADMIN_PASSWORD: "{{ user.pass }}"
+  PAPERLESS_SECRET_KEY: "{{ paperless_ngx_secret_key.stdout }}"
+paperless_ngx_docker_envs_custom: {}
+paperless_ngx_docker_envs: "{{ paperless_ngx_docker_envs_default
+                           | combine(paperless_ngx_docker_envs_custom) }}"
 
 # Commands
-paperless_docker_commands_default: []
-paperless_docker_commands_custom: []
-paperless_docker_commands: "{{ paperless_docker_commands_default
-                             + paperless_docker_commands_custom }}"
+paperless_ngx_docker_commands_default: []
+paperless_ngx_docker_commands_custom: []
+paperless_ngx_docker_commands: "{{ paperless_ngx_docker_commands_default
+                             + paperless_ngx_docker_commands_custom }}"
 
 # Volumes
-paperless_docker_volumes_default:
-  - "{{ paperless_paths_location }}/data:/opt/paperless/data"
-  - "{{ paperless_paths_location }}/config:/opt/paperless/config"
-paperless_docker_volumes_custom: []
-paperless_docker_volumes: "{{ paperless_docker_volumes_default
-                            + paperless_docker_volumes_custom }}"
+paperless_ngx_docker_volumes_default:
+  - "{{ paperless_ngx_paths_location }}/data:/usr/src/paperless/data"
+  - "{{ paperless_ngx_paths_location }}/config:/usr/src/paperless/config"
+  - "{{ paperless_ngx_paths_location }}/consume:/usr/src/paperless/consume"
+  - "{{ paperless_ngx_paths_location }}/media:/usr/src/paperless/media"
+  - "{{ paperless_ngx_paths_location }}/trash:/usr/src/paperless/trash"
+paperless_ngx_docker_volumes_custom: []
+paperless_ngx_docker_volumes: "{{ paperless_ngx_docker_volumes_default
+                            + paperless_ngx_docker_volumes_custom }}"
 
 # Devices
-paperless_docker_devices_default: []
-paperless_docker_devices_custom: []
-paperless_docker_devices: "{{ paperless_docker_devices_default
-                            + paperless_docker_devices_custom }}"
+paperless_ngx_docker_devices_default: []
+paperless_ngx_docker_devices_custom: []
+paperless_ngx_docker_devices: "{{ paperless_ngx_docker_devices_default
+                            + paperless_ngx_docker_devices_custom }}"
 
 # Hosts
-paperless_docker_hosts_default: []
-paperless_docker_hosts_custom: []
-paperless_docker_hosts: "{{ docker_hosts_common
-                          | combine(paperless_docker_hosts_default)
-                          | combine(paperless_docker_hosts_custom) }}"
+paperless_ngx_docker_hosts_default: []
+paperless_ngx_docker_hosts_custom: []
+paperless_ngx_docker_hosts: "{{ docker_hosts_common
+                          | combine(paperless_ngx_docker_hosts_default)
+                          | combine(paperless_ngx_docker_hosts_custom) }}"
 
 # Labels
-paperless_docker_labels_default: {}
-paperless_docker_labels_custom: {}
-paperless_docker_labels: "{{ docker_labels_common
-                           | combine(paperless_docker_labels_default)
-                           | combine(paperless_docker_labels_custom) }}"
+paperless_ngx_docker_labels_default: {}
+paperless_ngx_docker_labels_custom: {}
+paperless_ngx_docker_labels: "{{ docker_labels_common
+                           | combine(paperless_ngx_docker_labels_default)
+                           | combine(paperless_ngx_docker_labels_custom) }}"
 
 # Hostname
-paperless_docker_hostname: "{{ paperless_name }}"
+paperless_ngx_docker_hostname: "{{ paperless_ngx_name }}"
 
 # Networks
-paperless_docker_networks_alias: "{{ paperless_name }}"
-paperless_docker_networks_default: []
-paperless_docker_networks_custom: []
-paperless_docker_networks: "{{ docker_networks_common
-                             + paperless_docker_networks_default
-                             + paperless_docker_networks_custom }}"
+paperless_ngx_docker_networks_alias: "{{ paperless_ngx_name }}"
+paperless_ngx_docker_networks_default: []
+paperless_ngx_docker_networks_custom: []
+paperless_ngx_docker_networks: "{{ docker_networks_common
+                             + paperless_ngx_docker_networks_default
+                             + paperless_ngx_docker_networks_custom }}"
 
 # Capabilities
-paperless_docker_capabilities_default: []
-paperless_docker_capabilities_custom: []
-paperless_docker_capabilities: "{{ paperless_docker_capabilities_default
-                                 + paperless_docker_capabilities_custom }}"
+paperless_ngx_docker_capabilities_default: []
+paperless_ngx_docker_capabilities_custom: []
+paperless_ngx_docker_capabilities: "{{ paperless_ngx_docker_capabilities_default
+                                 + paperless_ngx_docker_capabilities_custom }}"
 
 # Security Opts
-paperless_docker_security_opts_default: []
-paperless_docker_security_opts_custom: []
-paperless_docker_security_opts: "{{ paperless_docker_security_opts_default
-                                  + paperless_docker_security_opts_custom }}"
+paperless_ngx_docker_security_opts_default: []
+paperless_ngx_docker_security_opts_custom: []
+paperless_ngx_docker_security_opts: "{{ paperless_ngx_docker_security_opts_default
+                                  + paperless_ngx_docker_security_opts_custom }}"
 
 # Restart Policy
-paperless_docker_restart_policy: unless-stopped
+paperless_ngx_docker_restart_policy: unless-stopped
 
 # State
-paperless_docker_state: started
+paperless_ngx_docker_state: started

--- a/roles/paperless_ngx/defaults/main.yml
+++ b/roles/paperless_ngx/defaults/main.yml
@@ -1,0 +1,145 @@
+##########################################################################
+# Title:            Sandbox: Paperless Ngx | Default Variables           #
+# Author(s):        JigSawFr                                             #
+# URL:              https://github.com/paperless-ngx/paperless-ngx       #
+# DOCKER:           https://github.com/linuxserver/docker-paperless-ngx  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+paperless_name: paperless
+
+################################
+# Paths
+################################
+
+paperless_paths_folder: "{{ paperless_name }}"
+paperless_paths_location: "{{ server_appdata_path }}/{{ paperless_paths_folder }}"
+paperless_paths_folders_list:
+  - "{{ paperless_paths_location }}"
+  - "{{ paperless_paths_location }}/data"
+  - "{{ paperless_paths_location }}/config"
+
+################################
+# Web
+################################
+
+paperless_web_subdomain: "{{ paperless_name }}"
+paperless_web_domain: "{{ user.domain }}"
+paperless_web_port: "8000"
+paperless_web_url: "{{ 'https://' + paperless_web_subdomain + '.' + paperless_web_domain
+                  if (reverse_proxy_is_enabled)
+                  else 'http://localhost:' + paperless_web_port }}"
+
+################################
+# DNS
+################################
+
+paperless_dns_record: "{{ paperless_web_subdomain }}"
+paperless_dns_zone: "{{ paperless_web_domain }}"
+paperless_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+paperless_traefik_middleware: "{{ traefik_default_middleware }}"
+paperless_traefik_certresolver: "{{ traefik_default_certresolver }}"
+paperless_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+paperless_docker_container: "{{ paperless_name }}"
+
+# Image
+paperless_docker_image_pull: true
+paperless_docker_image_tag: "latest"
+paperless_docker_image: "lscr.io/linuxserver/paperless-ngx:{{ paperless_docker_image_tag }}"
+
+# Ports
+paperless_docker_ports_defaults:
+  - "{{ paperless_web_port }}"
+paperless_docker_ports_custom: []
+paperless_docker_ports: "{{ paperless_docker_ports_defaults
+                          + paperless_docker_ports_custom
+                       if (not reverse_proxy_is_enabled)
+                       else paperless_docker_ports_custom }}"
+
+# Envs
+paperless_docker_envs_default:
+  TZ: "{{ tz }}"
+  REDIS_URL: "redis:6379"
+paperless_docker_envs_custom: {}
+paperless_docker_envs: "{{ paperless_docker_envs_default
+                         | combine(paperless_docker_envs_custom) }}"
+
+# Commands
+paperless_docker_commands_default: []
+paperless_docker_commands_custom: []
+paperless_docker_commands: "{{ paperless_docker_commands_default
+                             + paperless_docker_commands_custom }}"
+
+# Volumes
+paperless_docker_volumes_default:
+  - "{{ paperless_paths_location }}/data:/opt/paperless/data"
+  - "{{ paperless_paths_location }}/config:/opt/paperless/config"
+paperless_docker_volumes_custom: []
+paperless_docker_volumes: "{{ paperless_docker_volumes_default
+                            + paperless_docker_volumes_custom }}"
+
+# Devices
+paperless_docker_devices_default: []
+paperless_docker_devices_custom: []
+paperless_docker_devices: "{{ paperless_docker_devices_default
+                            + paperless_docker_devices_custom }}"
+
+# Hosts
+paperless_docker_hosts_default: []
+paperless_docker_hosts_custom: []
+paperless_docker_hosts: "{{ docker_hosts_common
+                          | combine(paperless_docker_hosts_default)
+                          | combine(paperless_docker_hosts_custom) }}"
+
+# Labels
+paperless_docker_labels_default: {}
+paperless_docker_labels_custom: {}
+paperless_docker_labels: "{{ docker_labels_common
+                           | combine(paperless_docker_labels_default)
+                           | combine(paperless_docker_labels_custom) }}"
+
+# Hostname
+paperless_docker_hostname: "{{ paperless_name }}"
+
+# Networks
+paperless_docker_networks_alias: "{{ paperless_name }}"
+paperless_docker_networks_default: []
+paperless_docker_networks_custom: []
+paperless_docker_networks: "{{ docker_networks_common
+                             + paperless_docker_networks_default
+                             + paperless_docker_networks_custom }}"
+
+# Capabilities
+paperless_docker_capabilities_default: []
+paperless_docker_capabilities_custom: []
+paperless_docker_capabilities: "{{ paperless_docker_capabilities_default
+                                 + paperless_docker_capabilities_custom }}"
+
+# Security Opts
+paperless_docker_security_opts_default: []
+paperless_docker_security_opts_custom: []
+paperless_docker_security_opts: "{{ paperless_docker_security_opts_default
+                                  + paperless_docker_security_opts_custom }}"
+
+# Restart Policy
+paperless_docker_restart_policy: unless-stopped
+
+# State
+paperless_docker_state: started

--- a/roles/paperless_ngx/defaults/main.yml
+++ b/roles/paperless_ngx/defaults/main.yml
@@ -36,8 +36,8 @@ paperless_ngx_web_subdomain: "{{ paperless_ngx_name }}"
 paperless_ngx_web_domain: "{{ user.domain }}"
 paperless_ngx_web_port: "8000"
 paperless_ngx_web_url: "{{ 'https://' + paperless_ngx_web_subdomain + '.' + paperless_ngx_web_domain
-                    if (reverse_proxy_is_enabled)
-                    else 'http://localhost:' + paperless_ngx_web_port }}"
+                        if (reverse_proxy_is_enabled)
+                        else 'http://localhost:' + paperless_ngx_web_port }}"
 
 ################################
 # DNS
@@ -53,15 +53,15 @@ paperless_ngx_dns_proxy: "{{ dns.proxied }}"
 
 paperless_ngx_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
 paperless_ngx_traefik_middleware_default: "{{ traefik_default_middleware + ','
-                                       + lookup('vars', paperless_ngx_name + '_traefik_sso_middleware', default=paperless_ngx_traefik_sso_middleware)
-                                    if (lookup('vars', paperless_ngx_name + '_traefik_sso_middleware', default=paperless_ngx_traefik_sso_middleware) | length > 0)
-                                    else traefik_default_middleware }}"
+                                              + lookup('vars', paperless_ngx_name + '_traefik_sso_middleware', default=paperless_ngx_traefik_sso_middleware)
+                                           if (lookup('vars', paperless_ngx_name + '_traefik_sso_middleware', default=paperless_ngx_traefik_sso_middleware) | length > 0)
+                                           else traefik_default_middleware }}"
 paperless_ngx_traefik_middleware_custom: ""
 paperless_ngx_traefik_middleware: "{{ paperless_ngx_traefik_middleware_default + ','
-                               + paperless_ngx_traefik_middleware_custom
-                            if (not paperless_ngx_traefik_middleware_custom.startswith(',') and paperless_ngx_traefik_middleware_custom | length > 0)
-                            else paperless_ngx_traefik_middleware_default
-                               + paperless_ngx_traefik_middleware_custom }}"
+                                      + paperless_ngx_traefik_middleware_custom
+                                   if (not paperless_ngx_traefik_middleware_custom.startswith(',') and paperless_ngx_traefik_middleware_custom | length > 0)
+                                   else paperless_ngx_traefik_middleware_default
+                                      + paperless_ngx_traefik_middleware_custom }}"
 paperless_ngx_traefik_certresolver: "{{ traefik_default_certresolver }}"
 paperless_ngx_traefik_enabled: true
 paperless_ngx_traefik_api_enabled: true
@@ -84,9 +84,9 @@ paperless_ngx_docker_ports_defaults:
   - "{{ paperless_ngx_web_port }}"
 paperless_ngx_docker_ports_custom: []
 paperless_ngx_docker_ports: "{{ paperless_ngx_docker_ports_defaults
-                          + paperless_ngx_docker_ports_custom
-                       if (not reverse_proxy_is_enabled)
-                       else paperless_ngx_docker_ports_custom }}"
+                                + paperless_ngx_docker_ports_custom
+                             if (not reverse_proxy_is_enabled)
+                             else paperless_ngx_docker_ports_custom }}"
 
 # Envs
 paperless_ngx_docker_envs_default:
@@ -111,13 +111,13 @@ paperless_ngx_docker_envs_default:
   PAPERLESS_SECRET_KEY: "{{ paperless_ngx_secret_key.stdout }}"
 paperless_ngx_docker_envs_custom: {}
 paperless_ngx_docker_envs: "{{ paperless_ngx_docker_envs_default
-                           | combine(paperless_ngx_docker_envs_custom) }}"
+                               | combine(paperless_ngx_docker_envs_custom) }}"
 
 # Commands
 paperless_ngx_docker_commands_default: []
 paperless_ngx_docker_commands_custom: []
 paperless_ngx_docker_commands: "{{ paperless_ngx_docker_commands_default
-                             + paperless_ngx_docker_commands_custom }}"
+                                   + paperless_ngx_docker_commands_custom }}"
 
 # Volumes
 paperless_ngx_docker_volumes_default:
@@ -128,27 +128,27 @@ paperless_ngx_docker_volumes_default:
   - "{{ paperless_ngx_paths_location }}/trash:/usr/src/paperless/trash"
 paperless_ngx_docker_volumes_custom: []
 paperless_ngx_docker_volumes: "{{ paperless_ngx_docker_volumes_default
-                            + paperless_ngx_docker_volumes_custom }}"
+                                  + paperless_ngx_docker_volumes_custom }}"
 
 # Devices
 paperless_ngx_docker_devices_default: []
 paperless_ngx_docker_devices_custom: []
 paperless_ngx_docker_devices: "{{ paperless_ngx_docker_devices_default
-                            + paperless_ngx_docker_devices_custom }}"
+                                  + paperless_ngx_docker_devices_custom }}"
 
 # Hosts
 paperless_ngx_docker_hosts_default: []
 paperless_ngx_docker_hosts_custom: []
 paperless_ngx_docker_hosts: "{{ docker_hosts_common
-                          | combine(paperless_ngx_docker_hosts_default)
-                          | combine(paperless_ngx_docker_hosts_custom) }}"
+                                | combine(paperless_ngx_docker_hosts_default)
+                                | combine(paperless_ngx_docker_hosts_custom) }}"
 
 # Labels
 paperless_ngx_docker_labels_default: {}
 paperless_ngx_docker_labels_custom: {}
 paperless_ngx_docker_labels: "{{ docker_labels_common
-                           | combine(paperless_ngx_docker_labels_default)
-                           | combine(paperless_ngx_docker_labels_custom) }}"
+                                 | combine(paperless_ngx_docker_labels_default)
+                                 | combine(paperless_ngx_docker_labels_custom) }}"
 
 # Hostname
 paperless_ngx_docker_hostname: "{{ paperless_ngx_name }}"
@@ -158,20 +158,20 @@ paperless_ngx_docker_networks_alias: "{{ paperless_ngx_name }}"
 paperless_ngx_docker_networks_default: []
 paperless_ngx_docker_networks_custom: []
 paperless_ngx_docker_networks: "{{ docker_networks_common
-                             + paperless_ngx_docker_networks_default
-                             + paperless_ngx_docker_networks_custom }}"
+                                   + paperless_ngx_docker_networks_default
+                                   + paperless_ngx_docker_networks_custom }}"
 
 # Capabilities
 paperless_ngx_docker_capabilities_default: []
 paperless_ngx_docker_capabilities_custom: []
 paperless_ngx_docker_capabilities: "{{ paperless_ngx_docker_capabilities_default
-                                 + paperless_ngx_docker_capabilities_custom }}"
+                                       + paperless_ngx_docker_capabilities_custom }}"
 
 # Security Opts
 paperless_ngx_docker_security_opts_default: []
 paperless_ngx_docker_security_opts_custom: []
 paperless_ngx_docker_security_opts: "{{ paperless_ngx_docker_security_opts_default
-                                  + paperless_ngx_docker_security_opts_custom }}"
+                                        + paperless_ngx_docker_security_opts_custom }}"
 
 # Restart Policy
 paperless_ngx_docker_restart_policy: unless-stopped

--- a/roles/paperless_ngx/defaults/main.yml
+++ b/roles/paperless_ngx/defaults/main.yml
@@ -1,8 +1,7 @@
 ##########################################################################
 # Title:            Sandbox: Paperless Ngx | Default Variables           #
 # Author(s):        JigSawFr                                             #
-# URL:              https://github.com/paperless-ngx/paperless-ngx       #
-# DOCKER:           https://github.com/linuxserver/docker-paperless-ngx  #
+# URL:              https://github.com/saltyorg/Sandbox                  #
 # --                                                                     #
 ##########################################################################
 #                   GNU General Public License v3.0                      #

--- a/roles/paperless_ngx/tasks/main.yml
+++ b/roles/paperless_ngx/tasks/main.yml
@@ -1,0 +1,31 @@
+#########################################################################
+# Title:            Sandbox: Paperless Ngx                              #
+# Author(s):        JigSawFr                                            #
+# URL:              https://github.com/paperless-ngx/paperless-ngx      #
+# DOCKER:           https://github.com/linuxserver/docker-paperless-ngx #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+- name: Create Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/paperless_ngx/tasks/main.yml
+++ b/roles/paperless_ngx/tasks/main.yml
@@ -90,5 +90,5 @@
   register: paperless_ngx_proc
 
 - name: Print tweaks infos
-  debug:
+  ansible.builtin.debug:
     msg: "Your server has {{ paperless_ngx_proc.stdout }} CPU core, you can tweak your config with: https://paperless-ngx.readthedocs.io/en/latest/configuration.html#software-tweaks"

--- a/roles/paperless_ngx/tasks/main.yml
+++ b/roles/paperless_ngx/tasks/main.yml
@@ -7,7 +7,62 @@
 #########################################################################
 #                   GNU General Public License v3.0                     #
 #########################################################################
+# Versions: https://github.com/paperless-ngx/paperless-ngx/blob/main/docker/compose/docker-compose.postgres-tika.yml
 ---
+- name: Redis Role
+  ansible.builtin.import_role:
+    name: redis
+  vars:
+    redis_name: "{{ paperless_ngx_name }}_redis"
+    redis_docker_image_tag: "7-alpine"
+    redis_paths_folder: "{{ paperless_ngx_name }}"
+    redis_paths_location: "{{ server_appdata_path }}/{{ redis_paths_folder }}/redis"
+
+- name: Import Default Redis variables
+  ansible.builtin.include_vars: /srv/git/saltbox/roles/redis/defaults/main.yml
+
+- name: PostgreSQL Role
+  ansible.builtin.import_role:
+    name: postgres
+  vars:
+    postgres_name: "{{ paperless_ngx_name }}_postgres"
+    postgres_docker_env_db: "{{ paperless_ngx_name }}"
+    postgres_docker_image_tag: "14-alpine"
+    postgres_paths_folder: "{{ paperless_ngx_name }}"
+    postgres_paths_location: "{{ server_appdata_path }}/{{ postgres_paths_folder }}/postgres"
+
+- name: Import Default PostgreSQL variables
+  ansible.builtin.include_vars: /srv/git/saltbox/roles/postgres/defaults/main.yml
+
+- name: Gotenberg Role
+  ansible.builtin.import_role:
+    name: gotenberg
+  vars:
+    gotenberg_name: "{{ paperless_ngx_name }}_gotenberg"
+    gotenberg_docker_image_tag: "7-cloudrun"
+    gotenberg_docker_commands_default:
+      - "gotenberg"
+      - "--chromium-disable-routes=true"
+      - "--api-timeout=300s"
+      - "--uno-listener-restart-threshold=0"
+      - "--uno-listener-restart-threshold=300"
+      - "--uno-listener-start-timeout=300s"
+    gotenberg_paths_folder: "{{ paperless_ngx_name }}"
+    gotenberg_paths_location: "{{ server_appdata_path }}/{{ gotenberg_paths_folder }}/gotenberg"
+
+- name: Tika Role
+  ansible.builtin.import_role:
+    name: tika
+  vars:
+    tika_name: "{{ paperless_ngx_name }}_tika"
+    tika_docker_image_tag: "latest"
+    tika_paths_folder: "{{ paperless_ngx_name }}"
+    tika_paths_location: "{{ server_appdata_path }}/{{ gotenberg_paths_folder }}/gotenberg"
+
+- name: "Generate Secret Key for sessions"
+  ansible.builtin.shell: "openssl rand -base64 45"
+  register: paperless_ngx_secret_key
+
 - name: Add DNS record
   include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
   vars:
@@ -29,3 +84,11 @@
 
 - name: Create Docker container
   include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+
+- name: "Get number of physical processors"
+  ansible.builtin.shell: "grep -c ^processor /proc/cpuinfo"
+  register: paperless_ngx_proc
+
+- name: Print tweaks infos
+  debug:
+    msg: "Your server has {{ paperless_ngx_proc.stdout }} CPU core, you can tweak your config with: https://paperless-ngx.readthedocs.io/en/latest/configuration.html#software-tweaks"

--- a/roles/paperless_ngx/tasks/main.yml
+++ b/roles/paperless_ngx/tasks/main.yml
@@ -1,8 +1,7 @@
 #########################################################################
 # Title:            Sandbox: Paperless Ngx                              #
 # Author(s):        JigSawFr                                            #
-# URL:              https://github.com/paperless-ngx/paperless-ngx      #
-# DOCKER:           https://github.com/linuxserver/docker-paperless-ngx #
+# URL:              https://github.com/saltyorg/Sandbox                 #
 # --                                                                    #
 #########################################################################
 #                   GNU General Public License v3.0                     #

--- a/roles/tika/defaults/main.yml
+++ b/roles/tika/defaults/main.yml
@@ -1,8 +1,7 @@
 ##########################################################################
 # Title:            Sandbox: Apache TIKA | Default Variables             #
 # Author(s):        JigSawFr                                             #
-# URL:              https://tika.apache.org                              #
-# DOCKER:           https://github.com/apache/tika-docker                #
+# URL:              https://github.com/saltyorg/Sandbox                  #
 # --                                                                     #
 ##########################################################################
 #                   GNU General Public License v3.0                      #

--- a/roles/tika/defaults/main.yml
+++ b/roles/tika/defaults/main.yml
@@ -39,7 +39,7 @@ tika_docker_image: "logicalspark/docker-tikaserver:{{ tika_docker_image_tag }}"
 tika_docker_ports_defaults: []
 tika_docker_ports_custom: []
 tika_docker_ports: "{{ tika_docker_ports_defaults
-                        + tika_docker_ports_custom
+                       + tika_docker_ports_custom
                      if (not reverse_proxy_is_enabled)
                      else tika_docker_ports_custom }}"
 
@@ -48,40 +48,40 @@ tika_docker_envs_default:
   TZ: "{{ tz }}"
 tika_docker_envs_custom: {}
 tika_docker_envs: "{{ tika_docker_envs_default
-                       | combine(tika_docker_envs_custom) }}"
+                      | combine(tika_docker_envs_custom) }}"
 
 # Commands
 tika_docker_commands_default: []
 tika_docker_commands_custom: []
 tika_docker_commands: "{{ tika_docker_commands_default
-                           + tika_docker_commands_custom }}"
+                          + tika_docker_commands_custom }}"
 
 # Volumes
 tika_docker_volumes_default:
   - "{{ tika_paths_location }}:/data"
 tika_docker_volumes_custom: []
 tika_docker_volumes: "{{ tika_docker_volumes_default
-                          + tika_docker_volumes_custom }}"
+                         + tika_docker_volumes_custom }}"
 
 # Devices
 tika_docker_devices_default: []
 tika_docker_devices_custom: []
 tika_docker_devices: "{{ tika_docker_devices_default
-                          + tika_docker_devices_custom }}"
+                         + tika_docker_devices_custom }}"
 
 # Hosts
 tika_docker_hosts_default: []
 tika_docker_hosts_custom: []
 tika_docker_hosts: "{{ docker_hosts_common
-                        | combine(tika_docker_hosts_default)
-                        | combine(tika_docker_hosts_custom) }}"
+                       | combine(tika_docker_hosts_default)
+                       | combine(tika_docker_hosts_custom) }}"
 
 # Labels
 tika_docker_labels_default: {}
 tika_docker_labels_custom: {}
 tika_docker_labels: "{{ docker_labels_common
-                         | combine(tika_docker_labels_default)
-                         | combine(tika_docker_labels_custom) }}"
+                        | combine(tika_docker_labels_default)
+                        | combine(tika_docker_labels_custom) }}"
 
 # Hostname
 tika_docker_hostname: "{{ tika_name }}"
@@ -91,20 +91,20 @@ tika_docker_networks_alias: "{{ tika_name }}"
 tika_docker_networks_default: []
 tika_docker_networks_custom: []
 tika_docker_networks: "{{ docker_networks_common
-                           + tika_docker_networks_default
-                           + tika_docker_networks_custom }}"
+                          + tika_docker_networks_default
+                          + tika_docker_networks_custom }}"
 
 # Capabilities
 tika_docker_capabilities_default: []
 tika_docker_capabilities_custom: []
 tika_docker_capabilities: "{{ tika_docker_capabilities_default
-                               + tika_docker_capabilities_custom }}"
+                              + tika_docker_capabilities_custom }}"
 
 # Security Opts
 tika_docker_security_opts_default: []
 tika_docker_security_opts_custom: []
 tika_docker_security_opts: "{{ tika_docker_security_opts_default
-                                + tika_docker_security_opts_custom }}"
+                               + tika_docker_security_opts_custom }}"
 
 # Restart Policy
 tika_docker_restart_policy: always

--- a/roles/tika/defaults/main.yml
+++ b/roles/tika/defaults/main.yml
@@ -1,0 +1,116 @@
+##########################################################################
+# Title:            Sandbox: Apache TIKA | Default Variables             #
+# Author(s):        JigSawFr                                             #
+# URL:              https://tika.apache.org                              #
+# DOCKER:           https://github.com/apache/tika-docker                #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+tika_name: tika
+
+################################
+# Paths
+################################
+
+tika_paths_folder: "{{ tika_name }}"
+tika_paths_location: "{{ server_appdata_path }}/{{ tika_paths_folder }}"
+tika_paths_folders_list:
+  - "{{ tika_paths_location }}"
+
+################################
+# Docker
+################################
+
+# Container
+tika_docker_container: "{{ tika_name }}"
+
+# Image
+tika_docker_image_pull: true
+tika_docker_image_tag: "latest"
+tika_docker_image: "logicalspark/docker-tikaserver:{{ tika_docker_image_tag }}"
+
+# Ports
+tika_docker_ports_defaults: []
+tika_docker_ports_custom: []
+tika_docker_ports: "{{ tika_docker_ports_defaults
+                        + tika_docker_ports_custom
+                     if (not reverse_proxy_is_enabled)
+                     else tika_docker_ports_custom }}"
+
+# Envs
+tika_docker_envs_default:
+  TZ: "{{ tz }}"
+tika_docker_envs_custom: {}
+tika_docker_envs: "{{ tika_docker_envs_default
+                       | combine(tika_docker_envs_custom) }}"
+
+# Commands
+tika_docker_commands_default: []
+tika_docker_commands_custom: []
+tika_docker_commands: "{{ tika_docker_commands_default
+                           + tika_docker_commands_custom }}"
+
+# Volumes
+tika_docker_volumes_default:
+  - "{{ tika_paths_location }}:/data"
+tika_docker_volumes_custom: []
+tika_docker_volumes: "{{ tika_docker_volumes_default
+                          + tika_docker_volumes_custom }}"
+
+# Devices
+tika_docker_devices_default: []
+tika_docker_devices_custom: []
+tika_docker_devices: "{{ tika_docker_devices_default
+                          + tika_docker_devices_custom }}"
+
+# Hosts
+tika_docker_hosts_default: []
+tika_docker_hosts_custom: []
+tika_docker_hosts: "{{ docker_hosts_common
+                        | combine(tika_docker_hosts_default)
+                        | combine(tika_docker_hosts_custom) }}"
+
+# Labels
+tika_docker_labels_default: {}
+tika_docker_labels_custom: {}
+tika_docker_labels: "{{ docker_labels_common
+                         | combine(tika_docker_labels_default)
+                         | combine(tika_docker_labels_custom) }}"
+
+# Hostname
+tika_docker_hostname: "{{ tika_name }}"
+
+# Networks
+tika_docker_networks_alias: "{{ tika_name }}"
+tika_docker_networks_default: []
+tika_docker_networks_custom: []
+tika_docker_networks: "{{ docker_networks_common
+                           + tika_docker_networks_default
+                           + tika_docker_networks_custom }}"
+
+# Capabilities
+tika_docker_capabilities_default: []
+tika_docker_capabilities_custom: []
+tika_docker_capabilities: "{{ tika_docker_capabilities_default
+                               + tika_docker_capabilities_custom }}"
+
+# Security Opts
+tika_docker_security_opts_default: []
+tika_docker_security_opts_custom: []
+tika_docker_security_opts: "{{ tika_docker_security_opts_default
+                                + tika_docker_security_opts_custom }}"
+
+# Restart Policy
+tika_docker_restart_policy: always
+
+# State
+tika_docker_state: started
+
+# User
+tika_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/tika/tasks/main.yml
+++ b/roles/tika/tasks/main.yml
@@ -1,0 +1,15 @@
+##########################################################################
+# Title:            Sandbox: Apache TIKA                                 #
+# Author(s):        JigSawFr                                             #
+# URL:              https://tika.apache.org                              #
+# DOCKER:           https://github.com/apache/tika-docker                #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/tika/tasks/main.yml
+++ b/roles/tika/tasks/main.yml
@@ -1,8 +1,7 @@
 ##########################################################################
 # Title:            Sandbox: Apache TIKA                                 #
 # Author(s):        JigSawFr                                             #
-# URL:              https://tika.apache.org                              #
-# DOCKER:           https://github.com/apache/tika-docker                #
+# URL:              https://github.com/saltyorg/Sandbox                  #
 # --                                                                     #
 ##########################################################################
 #                   GNU General Public License v3.0                      #

--- a/roles/tika/tasks/main.yml
+++ b/roles/tika/tasks/main.yml
@@ -13,4 +13,3 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
-  

--- a/roles/tika/tasks/main.yml
+++ b/roles/tika/tasks/main.yml
@@ -13,3 +13,4 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+  

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -49,6 +49,7 @@
     - { role: gitea, tags: ['gitea'] }
     - { role: glances_web, tags: ['glances-web'] }
     - { role: goplaxt, tags: ['goplaxt'] }
+    - { role: gotenberg, tags: ['gotenberg'] }
     - { role: gotify, tags: ['gotify'] }
     - { role: grafana, tags: ['grafana'] }
     - { role: guacamole, tags: ['guacamole'] }
@@ -82,7 +83,7 @@
     - { role: ombi, tags: ['ombi'] }
     - { role: ombix, tags: ['ombix'] }
     - { role: ouroboros, tags: ['ouroboros'] }
-    - { role: paperless_ngx, tags: ['paperless_ngx'] }
+    - { role: paperless_ngx, tags: ['paperless-ngx'] }
     - { role: plex_autoscan, tags: ['plex_autoscan'] }
     - { role: plex_dupefinder, tags: ['plex_dupefinder'] }
     - { role: plex_meta_manager, tags: ['plex-meta-manager'] }
@@ -117,6 +118,7 @@
     - { role: teamspeak, tags: ['teamspeak'] }
     - { role: telegraf, tags: ['telegraf'] }
     - { role: thelounge, tags: ['thelounge'] }
+    - { role: tika, tags: ['tika'] }
     - { role: traefik_robotstxt, tags: ['traefik_robotstxt'] }
     - { role: transmission, tags: ['transmission'] }
     - { role: transmissionvpn, tags: ['transmissionvpn'] }

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -80,6 +80,7 @@
     - { role: ombi, tags: ['ombi'] }
     - { role: ombix, tags: ['ombix'] }
     - { role: ouroboros, tags: ['ouroboros'] }
+    - { role: paperless_ngx, tags: ['paperless_ngx'] }
     - { role: plex_autoscan, tags: ['plex_autoscan'] }
     - { role: plex_dupefinder, tags: ['plex_dupefinder'] }
     - { role: plex_meta_manager, tags: ['plex-meta-manager'] }


### PR DESCRIPTION
# Description
**[Paperless-ngx](https://github.com/paperless-ngx/paperless-ngx)** is a document management system that transforms your physical documents into a searchable online archive so you can keep, well, less paper.

[Paperless-ngx](https://github.com/paperless-ngx/paperless-ngx) forked from [paperless-ng](https://github.com/jonaswinkler/paperless-ng) to continue the great work and distribute responsibility of supporting and advancing the project among a team of people.

Requested on https://github.com/saltyorg/Sandbox/issues/114

# How Has This Been Tested?

Completely tested and locked versions when needed.

- [x] Main app (paperless) is working
- [x] Ability to upload .PDF documents.
- [x] Ability to upload .DOCX documents. (processed with gutenberg/tika)
- [x] Add generic role for apache/tika (overrided by paperless-ngx)
- [x] Add generic role for gotenberg (overrided by paperless-ngx) (use stateless config)
- [x] Use generic role for redis (overrided by paperless-ngx)
- [x] Use generic role for postgres (overrided by paperless-ngx)
- [x] Secured by Authelia (API managed too)
- [x] Populate default user/pass and activate autologin in app (protected by authelia)
- [x] Generate Secret key for sessions (to avoid default know secret)
- [x] All containers' data are in a dedicated sub-folder of main app in /opt (to avoid multiple and endless list of folders)
- [x] All containers' names are starting with paperless_*
- [x] Give tweaks infos at end-to-end user