### PR TITLE
minecraft-bedrock: New Role

### DIFF
--- a/roles/minecraft_bedrock/defaults/main.yml
+++ b/roles/minecraft_bedrock/defaults/main.yml
@@ -24,6 +24,20 @@ minecraft_bedrock_paths_folders_list:
   - "{{ minecraft_bedrock_paths_location }}"
 
 ################################
+# Web
+################################
+
+minecraft_bedrock_web_subdomain: "{{ minecraft_bedrock_name }}"
+minecraft_bedrock_web_domain: "{{ user.domain }}"
+
+################################
+# DNS
+################################
+
+minecraft_bedrock_dns_record: "{{ lookup('vars', minecraft_bedrock_name + '_web_subdomain', default=minecraft_bedrock_web_subdomain) }}"
+minecraft_bedrock_dns_zone: "{{ lookup('vars', minecraft_bedrock_name + '_web_domain', default=minecraft_bedrock_web_domain) }}"
+
+################################
 # Docker
 ################################
 

--- a/roles/minecraft_bedrock/defaults/main.yml
+++ b/roles/minecraft_bedrock/defaults/main.yml
@@ -1,0 +1,112 @@
+##########################################################################
+# Title:         Sandbox: minecraft-bedrock | Default Variables          #
+# Author(s):     nickstarkloff                                           #
+# URL:           https://github.com/saltyorg/Sandbox                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+minecraft_bedrock_name: minecraft-bedrock
+
+################################
+# Paths
+################################
+
+minecraft_bedrock_paths_folder: "{{ minecraft_bedrock_name }}"
+minecraft_bedrock_paths_location: "{{ server_appdata_path }}/{{ minecraft_bedrock_paths_folder }}"
+minecraft_bedrock_paths_folders_list:
+  - "{{ minecraft_bedrock_paths_location }}"
+
+################################
+# Docker
+################################
+
+# Container
+minecraft_bedrock_docker_container: "{{ minecraft_bedrock_name }}"
+
+# Image
+minecraft_bedrock_docker_image_pull: true
+minecraft_bedrock_docker_image_tag: "latest"
+minecraft_bedrock_docker_image: "itzg/minecraft-bedrock-server:{{ minecraft_bedrock_docker_image_tag }}"
+
+# Ports
+minecraft_bedrock_docker_ports_defaults:
+  - "19132:19132/udp"
+minecraft_bedrock_docker_ports: "{{ minecraft_bedrock_docker_ports_defaults }}"
+
+# Envs
+minecraft_bedrock_docker_envs_default:
+  TZ: "{{ tz }}"
+  UID: "{{ uid }}"
+  GID: "{{ gid }}"
+  EULA: "TRUE"
+minecraft_bedrock_docker_envs_custom: {}
+minecraft_bedrock_docker_envs: "{{ minecraft_bedrock_docker_envs_default
+                                   | combine(minecraft_bedrock_docker_envs_custom) }}"
+
+# Commands
+minecraft_bedrock_docker_commands_default: []
+minecraft_bedrock_docker_commands_custom: []
+minecraft_bedrock_docker_commands: "{{ minecraft_bedrock_docker_commands_default
+                                       + minecraft_bedrock_docker_commands_custom }}"
+
+# Volumes
+minecraft_bedrock_docker_volumes_default:
+  - "{{ minecraft_bedrock_paths_location }}:/data"
+minecraft_bedrock_docker_volumes_custom: []
+minecraft_bedrock_docker_volumes: "{{ minecraft_bedrock_docker_volumes_default
+                                      + minecraft_bedrock_docker_volumes_custom }}"
+
+# Devices
+minecraft_bedrock_docker_devices_default: []
+minecraft_bedrock_docker_devices_custom: []
+minecraft_bedrock_docker_devices: "{{ minecraft_bedrock_docker_devices_default
+                                      + minecraft_bedrock_docker_devices_custom }}"
+
+# Hosts
+minecraft_bedrock_docker_hosts_default: []
+minecraft_bedrock_docker_hosts_custom: []
+minecraft_bedrock_docker_hosts: "{{ docker_hosts_common
+                                    | combine(minecraft_bedrock_docker_hosts_default)
+                                    | combine(minecraft_bedrock_docker_hosts_custom) }}"
+
+# Labels
+minecraft_bedrock_docker_labels_default: {}
+minecraft_bedrock_docker_labels_custom: {}
+minecraft_bedrock_docker_labels: "{{ docker_labels_common
+                                     | combine(minecraft_bedrock_docker_labels_default)
+                                     | combine(minecraft_bedrock_docker_labels_custom) }}"
+
+# Hostname
+minecraft_bedrock_docker_hostname: "{{ minecraft_bedrock_name }}"
+
+# Networks
+minecraft_bedrock_docker_networks_alias: "{{ minecraft_bedrock_name }}"
+minecraft_bedrock_docker_networks_default: []
+minecraft_bedrock_docker_networks_custom: []
+minecraft_bedrock_docker_networks: "{{ docker_networks_common
+                                       + minecraft_bedrock_docker_networks_default
+                                       + minecraft_bedrock_docker_networks_custom }}"
+
+# Capabilities
+minecraft_bedrock_docker_capabilities_default: []
+minecraft_bedrock_docker_capabilities_custom: []
+minecraft_bedrock_docker_capabilities: "{{ minecraft_bedrock_docker_capabilities_default
+                                           + minecraft_bedrock_docker_capabilities_custom }}"
+
+# Security Opts
+minecraft_bedrock_docker_security_opts_default: []
+minecraft_bedrock_docker_security_opts_custom: []
+minecraft_bedrock_docker_security_opts: "{{ minecraft_bedrock_docker_security_opts_default
+                                            + minecraft_bedrock_docker_security_opts_custom }}"
+
+# Restart Policy
+minecraft_bedrock_docker_restart_policy: unless-stopped
+
+# State
+minecraft_bedrock_docker_state: started

--- a/roles/minecraft_bedrock/defaults/main.yml
+++ b/roles/minecraft_bedrock/defaults/main.yml
@@ -12,6 +12,7 @@
 ################################
 
 minecraft_bedrock_name: minecraft-bedrock
+minecraft_bedrock_version: "LATEST"
 
 ################################
 # Paths
@@ -45,6 +46,7 @@ minecraft_bedrock_docker_envs_default:
   UID: "{{ uid }}"
   GID: "{{ gid }}"
   EULA: "TRUE"
+  VERSION: "{{ minecraft_bedrock_version }}"
 minecraft_bedrock_docker_envs_custom: {}
 minecraft_bedrock_docker_envs: "{{ minecraft_bedrock_docker_envs_default
                                    | combine(minecraft_bedrock_docker_envs_custom) }}"

--- a/roles/minecraft_bedrock/tasks/main.yml
+++ b/roles/minecraft_bedrock/tasks/main.yml
@@ -10,6 +10,25 @@
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+
+- name: Add SRV record
+  community.general.cloudflare_dns:
+    zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    type: SRV
+    proto: udp
+    service: minecraft
+    value: "{{ lookup('vars', role_name + '_dns_record') }}.{{ lookup('vars', role_name + '_dns_zone') }}"
+    port: 19132
+    account_api_token: "{{ cloudflare.api }}"
+    account_email: "{{ cloudflare.email }}"
+  when: cloudflare_is_enabled
+
 - name: Create directories
   ansible.builtin.file:
     path: "{{ item }}"

--- a/roles/minecraft_bedrock/tasks/main.yml
+++ b/roles/minecraft_bedrock/tasks/main.yml
@@ -1,0 +1,23 @@
+#########################################################################
+# Title:            Sandbox: minecraft-bedrock                          #
+# Author(s):        nickstarkloff                                       #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/minecraft_bedrock/tasks/main.yml
+++ b/roles/minecraft_bedrock/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Add SRV record
   community.general.cloudflare_dns:
-    zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    zone: "{{ _dns_tasker_zone }}"
     record: "{{ lookup('vars', role_name + '_dns_record') }}"
     type: SRV
     proto: udp

--- a/roles/settings/tasks/subtasks/finish.yml
+++ b/roles/settings/tasks/subtasks/finish.yml
@@ -8,7 +8,7 @@
 #########################################################################
 ---
 - name: "Finish | Check 'settings-updater.py' for new settings"
-  ansible.builtin.debug: # noaq jinja[invalid]
+  ansible.builtin.debug: # noqa jinja[invalid]
     msg:
       - "The 'settings_updater.py' script updated the following
           file{{ files_updated_successfully | pluralize }}: '{{ files_updated_successfully | difference(['ansible.cfg']) | join(', ') | trim }}'"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -71,6 +71,7 @@
     - { role: mcrouter, tags: ['mcrouter'] }
     - { role: medusa, tags: ['medusa'] }
     - { role: minecraft, tags: ['minecraft'] }
+    - { role: minecraft-bedrock, tags: ['minecraft-bedrock'] }
     - { role: monitorr, tags: ['monitorr'] }
     - { role: moviematch, tags: ['moviematch'] }
     - { role: mylar3, tags: ['mylar3'] }

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -71,7 +71,7 @@
     - { role: mcrouter, tags: ['mcrouter'] }
     - { role: medusa, tags: ['medusa'] }
     - { role: minecraft, tags: ['minecraft'] }
-    - { role: minecraft-bedrock, tags: ['minecraft-bedrock'] }
+    - { role: minecraft_bedrock, tags: ['minecraft-bedrock'] }
     - { role: monitorr, tags: ['monitorr'] }
     - { role: moviematch, tags: ['moviematch'] }
     - { role: mylar3, tags: ['mylar3'] }


### PR DESCRIPTION
# Description

The existing **minecraft** role is only for the Java version of Minecraft. This role is for the Minecraft Bedrock Edition. (the multi-platform version)

For this server you need to expose a UDP port. You can access the server via the server IP and the default port 19132.

You can create a SRV entry that maps the server IP and UDP port to a subdomain.
_Is it possible to do this automatically via Ansible?_

- [itzg/minecraft-bedrock-server](https://hub.docker.com/r/itzg/minecraft-bedrock-server)

You can select a specific server version by overwriting this variable: `minecraft_bedrock_version`


# How Has This Been Tested?

Tested on my own server.