### PR TITLE
PlexTraktSync Fix

### DIFF
--- a/roles/plextraktsync/templates/env.j2
+++ b/roles/plextraktsync/templates/env.j2
@@ -1,6 +1,8 @@
 # This is .env file for PlexTraktSync
-PLEX_BASEURL=
-PLEX_LOCALURL={{ 'http://' + plex_docker_networks_alias + ':' + plex_web_port }}
+PLEX_BASEURL={{ 'http://' + plex_docker_networks_alias + ':' + plex_web_port }}
+PLEX_LOCALURL=
 PLEX_TOKEN={{ plex_auth_token | d('') }}
+PLEX_OWNER_TOKEN=
+PLEX_ACCOUNT_TOKEN=
 PLEX_USERNAME={{ plex_host_username | d('') | escape }}
 TRAKT_USERNAME=


### PR DESCRIPTION
A recent update in the project causes the Plex URL to default to `localhost` when `PLEX_BASEURL` is empty in the env file, which causes the container to fail. This works around the issue on a clean install.