### PR TITLE
feat(role): add makemkv (#143)

### DIFF
--- a/roles/makemkv/defaults/main.yml
+++ b/roles/makemkv/defaults/main.yml
@@ -21,7 +21,7 @@ makemkv_paths_folder: "{{ makemkv_name }}"
 makemkv_paths_location: "{{ server_appdata_path }}/{{ makemkv_paths_folder }}"
 makemkv_paths_folders_list:
   - "{{ makemkv_paths_location }}"
-  - "/mnt/local/makemkv"
+  - "/mnt/unionfs/makemkv"
 
 ################################
 # Web
@@ -99,8 +99,8 @@ makemkv_docker_commands: "{{ makemkv_docker_commands_default
 # Volumes
 makemkv_docker_volumes_default:
   - "{{ makemkv_paths_location }}:/docker/appdata/makemkv"
-  - "/mnt/local:/storage:ro"
-  - "/mnt/local/makemkv:/output:rw"
+  - "/mnt/unionfs:/storage:ro"
+  - "/mnt/unionfs/makemkv:/output:rw"
 makemkv_docker_volumes_custom: []
 makemkv_docker_volumes: "{{ makemkv_docker_volumes_default
                             + makemkv_docker_volumes_custom }}"

--- a/roles/makemkv/defaults/main.yml
+++ b/roles/makemkv/defaults/main.yml
@@ -1,0 +1,155 @@
+##########################################################################
+# Title:            Sandbox: makemkv | Default Variables                 #
+# Author(s):        JigSawFr                                             #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+makemkv_name: makemkv
+
+################################
+# Paths
+################################
+
+makemkv_paths_folder: "{{ makemkv_name }}"
+makemkv_paths_location: "{{ server_appdata_path }}/{{ makemkv_paths_folder }}"
+makemkv_paths_folders_list:
+  - "{{ makemkv_paths_location }}"
+  - "/mnt/local/makemkv"
+
+################################
+# Web
+################################
+
+makemkv_web_subdomain: "{{ makemkv_name }}"
+makemkv_web_domain: "{{ user.domain }}"
+makemkv_web_port: "5800"
+makemkv_web_url: "{{ 'https://' + makemkv_web_subdomain + '.' + makemkv_web_domain
+                 if (reverse_proxy_is_enabled)
+                 else 'http://localhost:' + makemkv_web_port }}"
+
+################################
+# DNS
+################################
+
+makemkv_dns_record: "{{ makemkv_web_subdomain }}"
+makemkv_dns_zone: "{{ makemkv_web_domain }}"
+makemkv_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+makemkv_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+makemkv_traefik_middleware_default: "{{ traefik_default_middleware + ','
+                                        + lookup('vars', makemkv_name + '_traefik_sso_middleware', default=makemkv_traefik_sso_middleware)
+                                    if (lookup('vars', makemkv_name + '_traefik_sso_middleware', default=makemkv_traefik_sso_middleware) | length > 0)
+                                    else traefik_default_middleware }}"
+makemkv_traefik_middleware_custom: ""
+makemkv_traefik_middleware: "{{ makemkv_traefik_middleware_default + ','
+                                + makemkv_traefik_middleware_custom
+                            if (not makemkv_traefik_middleware_custom.startswith(',') and makemkv_traefik_middleware_custom | length > 0)
+                            else makemkv_traefik_middleware_default
+                                + makemkv_traefik_middleware_custom }}"
+makemkv_traefik_certresolver: "{{ traefik_default_certresolver }}"
+makemkv_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+makemkv_docker_container: "{{ makemkv_name }}"
+
+# Image
+makemkv_docker_image_pull: true
+makemkv_docker_image_tag: "latest"
+makemkv_docker_image: "jlesage/makemkv:{{ makemkv_docker_image_tag }}"
+
+# Ports
+makemkv_docker_ports_defaults:
+  - "{{ makemkv_web_port }}"
+makemkv_docker_ports_custom: []
+makemkv_docker_ports: "{{ makemkv_docker_ports_defaults
+                          + makemkv_docker_ports_custom
+                      if (not reverse_proxy_is_enabled)
+                      else makemkv_docker_ports_custom }}"
+# Envs
+makemkv_docker_envs_default:
+  TZ: "{{ tz }}"
+  USER_ID: "{{ uid }}"
+  GROUP_ID: "{{ gid }}"
+  KEEP_APP_RUNNING: "1"
+makemkv_docker_envs_custom: {}
+makemkv_docker_envs: "{{ makemkv_docker_envs_default
+                         | combine(makemkv_docker_envs_custom) }}"
+
+# Commands
+makemkv_docker_commands_default: []
+makemkv_docker_commands_custom: []
+makemkv_docker_commands: "{{ makemkv_docker_commands_default
+                             + makemkv_docker_commands_custom }}"
+
+# Volumes
+makemkv_docker_volumes_default:
+  - "{{ makemkv_paths_location }}:/docker/appdata/makemkv"
+  - "/mnt/local:/storage:ro"
+  - "/mnt/local/makemkv:/output:rw"
+makemkv_docker_volumes_custom: []
+makemkv_docker_volumes: "{{ makemkv_docker_volumes_default
+                            + makemkv_docker_volumes_custom }}"
+
+# Devices
+makemkv_docker_devices_default: []
+makemkv_docker_devices_custom: []
+makemkv_docker_devices: "{{ makemkv_docker_devices_default
+                            + makemkv_docker_devices_custom }}"
+
+# Hosts
+makemkv_docker_hosts_default: []
+makemkv_docker_hosts_custom: []
+makemkv_docker_hosts: "{{ docker_hosts_common
+                          | combine(makemkv_docker_hosts_default)
+                          | combine(makemkv_docker_hosts_custom) }}"
+
+# Labels
+makemkv_docker_labels_default: {}
+makemkv_docker_labels_custom: {}
+makemkv_docker_labels: "{{ docker_labels_common
+                           | combine(makemkv_docker_labels_default)
+                           | combine(makemkv_docker_labels_custom) }}"
+
+# Hostname
+makemkv_docker_hostname: "{{ makemkv_name }}"
+
+# Networks
+makemkv_docker_networks_alias: "{{ makemkv_name }}"
+makemkv_docker_networks_default: []
+makemkv_docker_networks_custom: []
+makemkv_docker_networks: "{{ docker_networks_common
+                             + makemkv_docker_networks_default
+                             + makemkv_docker_networks_custom }}"
+
+# Capabilities
+makemkv_docker_capabilities_default: []
+makemkv_docker_capabilities_custom: []
+makemkv_docker_capabilities: "{{ makemkv_docker_capabilities_default
+                                 + makemkv_docker_capabilities_custom }}"
+
+# Security Opts
+makemkv_docker_security_opts_default: []
+makemkv_docker_security_opts_custom: []
+makemkv_docker_security_opts: "{{ makemkv_docker_security_opts_default
+                                  + makemkv_docker_security_opts_custom }}"
+
+# Restart Policy
+makemkv_docker_restart_policy: unless-stopped
+
+# State
+makemkv_docker_state: started

--- a/roles/makemkv/tasks/main.yml
+++ b/roles/makemkv/tasks/main.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:            Sandbox: makemkv                                    #
+# Author(s):        JigSawFr                                            #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -71,6 +71,7 @@
     - { role: lazylibrarian, tags: ['lazylibrarian'] }
     - { role: linkding, tags: ['linkding'] }
     - { role: logarr, tags: ['logarr'] }
+    - { role: makemkv, tags: ['makemkv'] }
     - { role: mcrouter, tags: ['mcrouter'] }
     - { role: medusa, tags: ['medusa'] }
     - { role: minecraft, tags: ['minecraft'] }


### PR DESCRIPTION
# Description
MakeMKV is your one-click solution to convert video that you own into free and patents-unencumbered format that can be played everywhere. MakeMKV is a format converter, otherwise called "transcoder". It converts the video clips from proprietary (and usually encrypted) disc into a set of MKV files, preserving most information but not changing it in any way. The MKV format can store multiple video/audio tracks with all meta-information and preserve chapters.

Home: https://www.makemkv.com
License purchase: https://www.makemkv.com/buy/
Docs: https://github.com/jlesage/docker-makemkv

# How Has This Been Tested?

- [x] App is working (container alive and answering to requests)
- [x] Populate data in dedicated opt folder
- [x] Secured by Authelia
- [x] Cloudflare subdomain creation
- [x] Ability to use app as intended
- [x] Set TimeZone
- [x] Set custom UID/GID
- [x] Create a custom output folder at "/mnt/local/makemkv".