### PR TITLE
Add new role - Puddletag

### DIFF
--- a/roles/puddletag/defaults/main.yml
+++ b/roles/puddletag/defaults/main.yml
@@ -1,0 +1,149 @@
+#########################################################################
+# Title:            Sandbox: Puddletag                                  #
+# Author(s):        CHAIR/Raneydazed                                    #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+
+puddletag_name: puddletag
+
+################################
+# Paths
+################################
+
+puddletag_paths_folder: "{{ puddletag_name }}"
+puddletag_paths_location: "{{ server_appdata_path }}/{{ puddletag_paths_folder }}"
+puddletag_paths_folders_list:
+  - "{{ puddletag_paths_location }}"
+
+################################
+# Web
+################################
+
+puddletag_web_subdomain: "{{ puddletag_name }}"
+puddletag_web_domain: "{{ user.domain }}"
+puddletag_web_port: "8080"
+puddletag_web_url: "{{ 'https://' + puddletag_web_subdomain + '.' + puddletag_web_domain
+                  if (reverse_proxy_is_enabled)
+                  else 'http://localhost:' + puddletag_web_port }}"
+
+################################
+# DNS
+################################
+
+puddletag_dns_record: "{{ puddletag_web_subdomain }}"
+puddletag_dns_zone: "{{ puddletag_web_domain }}"
+puddletag_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+puddletag_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+
+puddletag_traefik_middleware: "{{ traefik_default_middleware + ',' + puddletag_traefik_sso_middleware
+                                if (puddletag_traefik_sso_middleware | length > 0)
+                                else traefik_default_middleware }}"
+puddletag_traefik_certresolver: "{{ traefik_default_certresolver }}"
+puddletag_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+puddletag_docker_container: "{{ puddletag_name }}"
+
+# Image
+puddletag_docker_image_pull: true
+puddletag_docker_image_tag: "latest"
+puddletag_docker_image: "lscr.io/linuxserver/puddletag:{{ puddletag_docker_image_tag }}"
+
+# Ports
+puddletag_docker_ports_defaults:
+  - "{{ puddletag_web_port }}"
+puddletag_docker_ports_custom: []
+puddletag_docker_ports: "{{ puddletag_docker_ports_defaults
+                          + puddletag_docker_ports_custom
+                       if (not reverse_proxy_is_enabled)
+                       else puddletag_docker_ports_custom }}"
+
+# Envs
+puddletag_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+  APPNAME: "puddletag"
+  GUAC_USER: "{{ user.name }}"
+  GUAC_PASS: "{{ user.pass }}"
+puddletag_docker_envs_custom: {}
+puddletag_docker_envs: "{{ puddletag_docker_envs_default
+                         | combine(puddletag_docker_envs_custom) }}"
+
+# Commands
+puddletag_docker_commands_default: []
+puddletag_docker_commands_custom: []
+puddletag_docker_commands: "{{ puddletag_docker_commands_default
+                             + puddletag_docker_commands_custom }}"
+
+# Volumes
+puddletag_docker_volumes_default:
+  - "{{ puddletag_paths_location }}:/config"
+puddletag_docker_volumes_custom: []
+puddletag_docker_volumes: "{{ puddletag_docker_volumes_default
+                            + puddletag_docker_volumes_custom }}"
+
+# Devices
+puddletag_docker_devices_default: []
+puddletag_docker_devices_custom: []
+puddletag_docker_devices: "{{ puddletag_docker_devices_default
+                            + puddletag_docker_devices_custom }}"
+
+# Hosts
+puddletag_docker_hosts_default: []
+puddletag_docker_hosts_custom: []
+puddletag_docker_hosts: "{{ docker_hosts_common
+                          | combine(puddletag_docker_hosts_default)
+                          | combine(puddletag_docker_hosts_custom) }}"
+
+# Labels
+puddletag_docker_labels_default: {}
+puddletag_docker_labels_custom: {}
+puddletag_docker_labels: "{{ docker_labels_common
+                           | combine(puddletag_docker_labels_default)
+                           | combine(puddletag_docker_labels_custom) }}"
+
+# Hostname
+puddletag_docker_hostname: "{{ puddletag_name }}"
+
+# Networks
+puddletag_docker_networks_alias: "{{ puddletag_name }}"
+puddletag_docker_networks_default: []
+puddletag_docker_networks_custom: []
+puddletag_docker_networks: "{{ docker_networks_common
+                             + puddletag_docker_networks_default
+                             + puddletag_docker_networks_custom }}"
+
+# Capabilities
+puddletag_docker_capabilities_default: []
+puddletag_docker_capabilities_custom: []
+puddletag_docker_capabilities: "{{ puddletag_docker_capabilities_default
+                                 + puddletag_docker_capabilities_custom }}"
+
+# Security Opts
+puddletag_docker_security_opts_default: []
+puddletag_docker_security_opts_custom: []
+puddletag_docker_security_opts: "{{ puddletag_docker_security_opts_default
+                                  + puddletag_docker_security_opts_custom }}"
+
+# Restart Policy
+puddletag_docker_restart_policy: unless-stopped
+
+# State
+puddletag_docker_state: started

--- a/roles/puddletag/defaults/main.yml
+++ b/roles/puddletag/defaults/main.yml
@@ -70,7 +70,7 @@ puddletag_docker_ports_defaults:
   - "{{ puddletag_web_port }}"
 puddletag_docker_ports_custom: []
 puddletag_docker_ports: "{{ puddletag_docker_ports_defaults
-                          + puddletag_docker_ports_custom
+                            + puddletag_docker_ports_custom
                           if (not reverse_proxy_is_enabled)
                           else puddletag_docker_ports_custom }}"
 
@@ -84,40 +84,40 @@ puddletag_docker_envs_default:
   GUAC_PASS: "{{ user.pass | hash('md5') }}"
 puddletag_docker_envs_custom: {}
 puddletag_docker_envs: "{{ puddletag_docker_envs_default
-                         | combine(puddletag_docker_envs_custom) }}"
+                           | combine(puddletag_docker_envs_custom) }}"
 
 # Commands
 puddletag_docker_commands_default: []
 puddletag_docker_commands_custom: []
 puddletag_docker_commands: "{{ puddletag_docker_commands_default
-                             + puddletag_docker_commands_custom }}"
+                               + puddletag_docker_commands_custom }}"
 
 # Volumes
 puddletag_docker_volumes_default:
   - "{{ puddletag_paths_location }}:/config"
 puddletag_docker_volumes_custom: []
 puddletag_docker_volumes: "{{ puddletag_docker_volumes_default
-                            + puddletag_docker_volumes_custom }}"
+                              + puddletag_docker_volumes_custom }}"
 
 # Devices
 puddletag_docker_devices_default: []
 puddletag_docker_devices_custom: []
 puddletag_docker_devices: "{{ puddletag_docker_devices_default
-                            + puddletag_docker_devices_custom }}"
+                              + puddletag_docker_devices_custom }}"
 
 # Hosts
 puddletag_docker_hosts_default: []
 puddletag_docker_hosts_custom: []
 puddletag_docker_hosts: "{{ docker_hosts_common
-                          | combine(puddletag_docker_hosts_default)
-                          | combine(puddletag_docker_hosts_custom) }}"
+                            | combine(puddletag_docker_hosts_default)
+                            | combine(puddletag_docker_hosts_custom) }}"
 
 # Labels
 puddletag_docker_labels_default: {}
 puddletag_docker_labels_custom: {}
 puddletag_docker_labels: "{{ docker_labels_common
-                           | combine(puddletag_docker_labels_default)
-                           | combine(puddletag_docker_labels_custom) }}"
+                             | combine(puddletag_docker_labels_default)
+                             | combine(puddletag_docker_labels_custom) }}"
 
 # Hostname
 puddletag_docker_hostname: "{{ puddletag_name }}"
@@ -127,20 +127,20 @@ puddletag_docker_networks_alias: "{{ puddletag_name }}"
 puddletag_docker_networks_default: []
 puddletag_docker_networks_custom: []
 puddletag_docker_networks: "{{ docker_networks_common
-                             + puddletag_docker_networks_default
-                             + puddletag_docker_networks_custom }}"
+                               + puddletag_docker_networks_default
+                               + puddletag_docker_networks_custom }}"
 
 # Capabilities
 puddletag_docker_capabilities_default: []
 puddletag_docker_capabilities_custom: []
 puddletag_docker_capabilities: "{{ puddletag_docker_capabilities_default
-                                 + puddletag_docker_capabilities_custom }}"
+                                   + puddletag_docker_capabilities_custom }}"
 
 # Security Opts
 puddletag_docker_security_opts_default: []
 puddletag_docker_security_opts_custom: []
 puddletag_docker_security_opts: "{{ puddletag_docker_security_opts_default
-                                  + puddletag_docker_security_opts_custom }}"
+                                    + puddletag_docker_security_opts_custom }}"
 
 # Restart Policy
 puddletag_docker_restart_policy: unless-stopped

--- a/roles/puddletag/defaults/main.yml
+++ b/roles/puddletag/defaults/main.yml
@@ -30,8 +30,8 @@ puddletag_web_subdomain: "{{ puddletag_name }}"
 puddletag_web_domain: "{{ user.domain }}"
 puddletag_web_port: "8080"
 puddletag_web_url: "{{ 'https://' + puddletag_web_subdomain + '.' + puddletag_web_domain
-                  if (reverse_proxy_is_enabled)
-                  else 'http://localhost:' + puddletag_web_port }}"
+                    if (reverse_proxy_is_enabled)
+                    else 'http://localhost:' + puddletag_web_port }}"
 
 ################################
 # DNS
@@ -48,8 +48,8 @@ puddletag_dns_proxy: "{{ dns.proxied }}"
 puddletag_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
 
 puddletag_traefik_middleware: "{{ traefik_default_middleware + ',' + puddletag_traefik_sso_middleware
-                                if (puddletag_traefik_sso_middleware | length > 0)
-                                else traefik_default_middleware }}"
+                               if (puddletag_traefik_sso_middleware | length > 0)
+                               else traefik_default_middleware }}"
 puddletag_traefik_certresolver: "{{ traefik_default_certresolver }}"
 puddletag_traefik_enabled: true
 

--- a/roles/puddletag/defaults/main.yml
+++ b/roles/puddletag/defaults/main.yml
@@ -63,7 +63,7 @@ puddletag_docker_container: "{{ puddletag_name }}"
 # Image
 puddletag_docker_image_pull: true
 puddletag_docker_image_tag: "latest"
-puddletag_docker_image: "lscr.io/linuxserver/puddletag:{{ puddletag_docker_image_tag }}"
+puddletag_docker_image: "xirg/docker-puddletag:{{ puddletag_docker_image_tag }}"
 
 # Ports
 puddletag_docker_ports_defaults:
@@ -71,17 +71,17 @@ puddletag_docker_ports_defaults:
 puddletag_docker_ports_custom: []
 puddletag_docker_ports: "{{ puddletag_docker_ports_defaults
                           + puddletag_docker_ports_custom
-                       if (not reverse_proxy_is_enabled)
-                       else puddletag_docker_ports_custom }}"
+                          if (not reverse_proxy_is_enabled)
+                          else puddletag_docker_ports_custom }}"
 
 # Envs
 puddletag_docker_envs_default:
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
   TZ: "{{ tz }}"
-  APPNAME: "puddletag"
+  APPNAME: "{{ puddletag_name }}"
   GUAC_USER: "{{ user.name }}"
-  GUAC_PASS: "{{ user.pass }}"
+  GUAC_PASS: "{{ user.pass | hash('md5') }}"
 puddletag_docker_envs_custom: {}
 puddletag_docker_envs: "{{ puddletag_docker_envs_default
                          | combine(puddletag_docker_envs_custom) }}"

--- a/roles/puddletag/defaults/main.yml
+++ b/roles/puddletag/defaults/main.yml
@@ -71,8 +71,8 @@ puddletag_docker_ports_defaults:
 puddletag_docker_ports_custom: []
 puddletag_docker_ports: "{{ puddletag_docker_ports_defaults
                             + puddletag_docker_ports_custom
-                          if (not reverse_proxy_is_enabled)
-                          else puddletag_docker_ports_custom }}"
+                         if (not reverse_proxy_is_enabled)
+                         else puddletag_docker_ports_custom }}"
 
 # Envs
 puddletag_docker_envs_default:

--- a/roles/puddletag/tasks/main.yml
+++ b/roles/puddletag/tasks/main.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:            Sandbox: Puddletag                                  #
+# Author(s):        CHAIR/Raneydazed                                    #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -102,6 +102,7 @@
     - { role: plex_utills, tags: ['plex_utills'] }
     - { role: plextraktsync, tags: ['plextraktsync'] }
     - { role: privatebin, tags: ['privatebin'] }
+    - { role: puddletag, tags: ['puddletag'] }
     - { role: pyload, tags: ['pyload'] }
     - { role: python_plexlibrary, tags: ['python-plexlibrary'] }
     - { role: qbit_manage, tags: ['qbit_manage'] }


### PR DESCRIPTION
# Description
[Puddletag](https://docs.puddletag.net/) is an audio tag editor (primarily created) for GNU/Linux similar to the Windows program, Mp3tag. Unlike most taggers for GNU/Linux, it uses a spreadsheet-like layout so that all the tags you want to edit by hand are visible and easily editable.




# How Has This Been Tested?

I've tested it on my remote server, and my local/home server. 
[x] I did indeed tick a box. 
