### PR TITLE
feat(role): add plexshare (close #91)

### DIFF
--- a/roles/plexshare/defaults/main.yml
+++ b/roles/plexshare/defaults/main.yml
@@ -92,6 +92,15 @@ plexshare_docker_ports: "{{ plexshare_docker_ports_defaults
 # Envs
 plexshare_docker_envs_default:
   TZ: "{{ tz }}"
+  WEB_DOCUMENT_ROOT: "/app/public"
+  WEB_DOCUMENT_INDEX: "index.php"
+  LOG_STDOUT: "./var/log/plexshare.stdout.log"
+  LOG_STDERR: "./var/log/plexshare.stderr.log"
+  PHP_POST_MAX_SIZE: "20M"
+  PHP_MEMORY_LIMIT: "521M"
+  PHP_MAX_EXECUTION_TIME: "300"
+  PHP_DATE_TIMEZONE: "{{ tz }}"
+  COMPOSER_VERSION: "1"
 plexshare_docker_envs_custom: {}
 plexshare_docker_envs: "{{ plexshare_docker_envs_default
                            | combine(plexshare_docker_envs_custom) }}"

--- a/roles/plexshare/defaults/main.yml
+++ b/roles/plexshare/defaults/main.yml
@@ -1,0 +1,158 @@
+##########################################################################
+# Title:            Sandbox: plexshare | Default Variables               #
+# Author(s):        JigSawFr                                             #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+plexshare_name: plexshare
+
+################################
+# Paths
+################################
+
+plexshare_paths_folder: "{{ plexshare_name }}"
+plexshare_paths_location: "{{ server_appdata_path }}/{{ plexshare_paths_folder }}"
+plexshare_paths_folders_list:
+  - "{{ plexshare_paths_location }}"
+
+################################
+# Web
+################################
+
+plexshare_web_subdomain: "{{ plexshare_name }}"
+plexshare_web_domain: "{{ user.domain }}"
+plexshare_web_port: "80"
+plexshare_web_url: "{{ 'https://' + plexshare_web_subdomain + '.' + plexshare_web_domain
+                    if (reverse_proxy_is_enabled)
+                    else 'http://localhost:' + plexshare_web_port }}"
+
+################################
+# DNS
+################################
+
+plexshare_dns_record: "{{ plexshare_web_subdomain }}"
+plexshare_dns_zone: "{{ plexshare_web_domain }}"
+plexshare_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+plexshare_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+plexshare_traefik_middleware_default: "{{ traefik_default_middleware + ','
+                                          + lookup('vars', plexshare_name + '_traefik_sso_middleware', default=plexshare_traefik_sso_middleware)
+                                       if (lookup('vars', plexshare_name + '_traefik_sso_middleware', default=plexshare_traefik_sso_middleware) | length > 0)
+                                       else traefik_default_middleware }}"
+plexshare_traefik_middleware_custom: ""
+plexshare_traefik_middleware: "{{ plexshare_traefik_middleware_default + ','
+                                  + plexshare_traefik_middleware_custom
+                               if (not plexshare_traefik_middleware_custom.startswith(',') and plexshare_traefik_middleware_custom | length > 0)
+                               else plexshare_traefik_middleware_default
+                                  + plexshare_traefik_middleware_custom }}"
+plexshare_traefik_certresolver: "{{ traefik_default_certresolver }}"
+plexshare_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+plexshare_docker_container: "{{ plexshare_name }}"
+
+# Image
+plexshare_docker_image_pull: true
+plexshare_docker_image_tag: "latest"
+# WAITING ON OFFICIAL DOCKER IMAGE: https://github.com/Chewbaka69/PlexShare/issues/15
+# plexshare_docker_image: "chewbaka69/plexshare:{{ plexshare_docker_image_tag }}"
+
+# Healthcheck
+plexshare_docker_healthcheck:
+  test: ["CMD", "curl", "--fail", "http://localhost:{{ plexshare_web_port }}"]
+  interval: 10s
+  timeout: 5s
+  retries: 10
+  start_period: 10s
+
+# Ports
+plexshare_docker_ports_defaults:
+  - "{{ plexshare_web_port }}"
+plexshare_docker_ports_custom: []
+plexshare_docker_ports: "{{ plexshare_docker_ports_defaults
+                            + plexshare_docker_ports_custom
+                         if (not reverse_proxy_is_enabled)
+                         else plexshare_docker_ports_custom }}"
+
+# Envs
+plexshare_docker_envs_default:
+  TZ: "{{ tz }}"
+plexshare_docker_envs_custom: {}
+plexshare_docker_envs: "{{ plexshare_docker_envs_default
+                           | combine(plexshare_docker_envs_custom) }}"
+
+# Commands
+plexshare_docker_commands_default: []
+plexshare_docker_commands_custom: []
+plexshare_docker_commands: "{{ plexshare_docker_commands_default
+                               + plexshare_docker_commands_custom }}"
+
+# Volumes
+plexshare_docker_volumes_default: []
+plexshare_docker_volumes_custom: []
+plexshare_docker_volumes: "{{ plexshare_docker_volumes_default
+                              + plexshare_docker_volumes_custom }}"
+
+# Devices
+plexshare_docker_devices_default: []
+plexshare_docker_devices_custom: []
+plexshare_docker_devices: "{{ plexshare_docker_devices_default
+                              + plexshare_docker_devices_custom }}"
+
+# Hosts
+plexshare_docker_hosts_default: []
+plexshare_docker_hosts_custom: []
+plexshare_docker_hosts: "{{ docker_hosts_common
+                            | combine(plexshare_docker_hosts_default)
+                            | combine(plexshare_docker_hosts_custom) }}"
+
+# Labels
+plexshare_docker_labels_default: {}
+plexshare_docker_labels_custom: {}
+plexshare_docker_labels: "{{ docker_labels_common
+                             | combine(plexshare_docker_labels_default)
+                             | combine(plexshare_docker_labels_custom) }}"
+
+# Hostname
+plexshare_docker_hostname: "{{ plexshare_name }}"
+
+# Networks
+plexshare_docker_networks_alias: "{{ plexshare_name }}"
+plexshare_docker_networks_default: []
+plexshare_docker_networks_custom: []
+plexshare_docker_networks: "{{ docker_networks_common
+                               + plexshare_docker_networks_default
+                               + plexshare_docker_networks_custom }}"
+
+# Capabilities
+plexshare_docker_capabilities_default: []
+plexshare_docker_capabilities_custom: []
+plexshare_docker_capabilities: "{{ plexshare_docker_capabilities_default
+                                   + plexshare_docker_capabilities_custom }}"
+
+# Security Opts
+plexshare_docker_security_opts_default: []
+plexshare_docker_security_opts_custom: []
+plexshare_docker_security_opts: "{{ plexshare_docker_security_opts_default
+                                    + plexshare_docker_security_opts_custom }}"
+
+# Restart Policy
+plexshare_docker_restart_policy: unless-stopped
+
+# State
+plexshare_docker_state: started

--- a/roles/plexshare/defaults/main.yml
+++ b/roles/plexshare/defaults/main.yml
@@ -69,8 +69,7 @@ plexshare_docker_container: "{{ plexshare_name }}"
 # Image
 plexshare_docker_image_pull: true
 plexshare_docker_image_tag: "latest"
-# WAITING ON OFFICIAL DOCKER IMAGE: https://github.com/Chewbaka69/PlexShare/issues/15
-# plexshare_docker_image: "chewbaka69/plexshare:{{ plexshare_docker_image_tag }}"
+plexshare_docker_image: "chewbaka/plexshare:{{ plexshare_docker_image_tag }}"
 
 # Healthcheck
 plexshare_docker_healthcheck:

--- a/roles/plexshare/defaults/main.yml
+++ b/roles/plexshare/defaults/main.yml
@@ -100,6 +100,7 @@ plexshare_docker_envs_default:
   PHP_MAX_EXECUTION_TIME: "300"
   PHP_DATE_TIMEZONE: "{{ tz }}"
   COMPOSER_VERSION: "1"
+  BASE_URL: "{{ plexshare_web_url }}/"
 plexshare_docker_envs_custom: {}
 plexshare_docker_envs: "{{ plexshare_docker_envs_default
                            | combine(plexshare_docker_envs_custom) }}"

--- a/roles/plexshare/tasks/main.yml
+++ b/roles/plexshare/tasks/main.yml
@@ -8,6 +8,25 @@
 #########################################################################
 # Repository: https://github.com/Chewbaka69/PlexShare/blob/master/docker-compose.yml
 ---
+- name: Check if db folder exists
+  ansible.builtin.stat:
+    path: "{{ server_appdata_path }}/{{ plexshare_paths_folder }}/mariadb"
+  register: stat_plexshare_db_folder
+
+- name: MariaDB Role
+  ansible.builtin.include_role:
+    name: mariadb
+  vars:
+    mariadb_name: "{{ plexshare_name }}_mariadb"  # Remove when instance support merged into Saltbox
+    mariadb_instances: ["{{ plexshare_name }}_mariadb"]
+    mariadb_docker_image_tag: "latest"
+    mariadb_paths_folder: "{{ plexshare_name }}"
+    mariadb_paths_location: "{{ server_appdata_path }}/{{ plexshare_paths_folder }}/mariadb"
+
+- name: Create plexshare database
+  ansible.builtin.command: "docker exec {{ plexshare_name }}_mariadb mysql -u root -p{{ mariadb_docker_envs_mysql_root_password }} -e 'create schema plexshare DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'"
+  when: not stat_plexshare_db_folder.stat.exists
+
 - name: Add DNS record
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
   vars:

--- a/roles/plexshare/tasks/main.yml
+++ b/roles/plexshare/tasks/main.yml
@@ -1,0 +1,29 @@
+#########################################################################
+# Title:            Sandbox: plexshare                                  #
+# Author(s):        JigSawFr                                            #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+# Repository: https://github.com/Chewbaka69/PlexShare/blob/master/docker-compose.yml
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+
+- name: Print Tweaking Info
+  ansible.builtin.debug:
+    msg: "For custom docker envs, please visit: https://github.com/Chewbaka69/PlexShare"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -104,6 +104,7 @@
     - { role: plex_credits_detect, tags: ['plex_credits_detect'] }
     - { role: plex_patrol, tags: ['plex_patrol'] }
     - { role: plex_utills, tags: ['plex_utills'] }
+    - { role: plexshare, tags: ['plexshare'] }
     - { role: plextraktsync, tags: ['plextraktsync'] }
     - { role: privatebin, tags: ['privatebin'] }
     - { role: puddletag, tags: ['puddletag'] }


### PR DESCRIPTION
# Description
With this web application, anyone can create an account directly this app. Every body can add his PlexServer to the list. When you are connected by default you have access to all servers. But the admin can manage permission by user or by library like limit of number streaming, the quality and other

With only one interface and without plex.tv registration, everybody can have access to the libraries of all the servers you have registered.

- **Homepage:** https://chewbaka69.github.io/PlexShare/
- **Github Repository:** https://github.com/Chewbaka69/PlexShare
- **Docker Repository:** https://hub.docker.com/r/chewbaka/plexshare
- **Documentation:** https://github.com/Chewbaka69/PlexShare/wiki

# How Has This Been Tested?

- [x] App is working as expected. (_Container is alive and answering to requests_)
- [x] App use a dedicated folder in `/opt` directory.
- [x] App secured by Authelia SSO authentication system.
- [x] A subdomain is correctly created for the web-ui. (_via Cloudflare_)
- [x] Custom TimeZone is set to the container and application.
- [ ] Custom UID/GID is set to the container to run under Saltbox user.
- [x] Healthcheck is added to the container.

Close #91