### PR TITLE
feat(role): add reposilite

### DIFF
--- a/roles/reposilite/defaults/main.yml
+++ b/roles/reposilite/defaults/main.yml
@@ -46,7 +46,17 @@ reposilite_dns_proxy: "{{ dns.proxied }}"
 # Traefik
 ################################
 
-reposilite_traefik_middleware: "{{ traefik_default_middleware }}"
+reposilite_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+reposilite_traefik_middleware_default: "{{ traefik_default_middleware + ','
+                                          + lookup('vars', reposilite_name + '_traefik_sso_middleware', default=reposilite_traefik_sso_middleware)
+                                       if (lookup('vars', reposilite_name + '_traefik_sso_middleware', default=reposilite_traefik_sso_middleware) | length > 0)
+                                       else traefik_default_middleware }}"
+reposilite_traefik_middleware_custom: ""
+reposilite_traefik_middleware: "{{ reposilite_traefik_middleware_default + ','
+                                  + reposilite_traefik_middleware_custom
+                               if (not reposilite_traefik_middleware_custom.startswith(',') and reposilite_traefik_middleware_custom | length > 0)
+                               else reposilite_traefik_middleware_default
+                                  + reposilite_traefik_middleware_custom }}"
 reposilite_traefik_certresolver: "{{ traefik_default_certresolver }}"
 reposilite_traefik_enabled: true
 

--- a/roles/reposilite/defaults/main.yml
+++ b/roles/reposilite/defaults/main.yml
@@ -74,6 +74,14 @@ reposilite_docker_image_pull: true
 reposilite_docker_image_tag: "latest"
 reposilite_docker_image: "ghcr.io/dzikoysk/reposilite:{{ reposilite_docker_image_tag }}"
 
+# Healthcheck
+reposilite_docker_healthcheck:
+  test: ["CMD", "curl", "--fail", "http://localhost:{{ reposilite_web_port }}"]
+  interval: 10s
+  timeout: 5s
+  retries: 10
+  start_period: 10s
+
 # Ports
 reposilite_docker_ports_defaults:
   - "{{ reposilite_web_port }}"

--- a/roles/reposilite/defaults/main.yml
+++ b/roles/reposilite/defaults/main.yml
@@ -80,6 +80,7 @@ reposilite_docker_envs_default:
   TZ: "{{ tz }}"
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
+  REPOSILITE_OPTS: "--token {{ user.name }}:{{ user.pass }}"
 reposilite_docker_envs_custom: {}
 reposilite_docker_envs: "{{ reposilite_docker_envs_default
                            | combine(reposilite_docker_envs_custom) }}"

--- a/roles/reposilite/defaults/main.yml
+++ b/roles/reposilite/defaults/main.yml
@@ -72,10 +72,7 @@ reposilite_docker_container: "{{ reposilite_name }}"
 # Image
 reposilite_docker_image_pull: true
 reposilite_docker_image_tag: "latest"
-reposilite_docker_image_repo: "dzikoysk/reposilite"
-reposilite_docker_image: "{{ lookup('vars', reposilite_name + '_docker_image_repo', default=reposilite_docker_image_repo)
-                                 + ':' + lookup('vars', reposilite_name + '_docker_image_tag', default=reposilite_docker_image_tag) }}"
-
+reposilite_docker_image: "ghcr.io/dzikoysk/reposilite:{{ reposilite_docker_image_tag }}"
 
 # Ports
 reposilite_docker_ports_defaults:

--- a/roles/reposilite/defaults/main.yml
+++ b/roles/reposilite/defaults/main.yml
@@ -1,0 +1,149 @@
+#########################################################################
+# Title:            Sandbox: Reposilite                                 #
+# Author(s):        Derek Z                                             #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# URL:              https://github.com/dzikoysk/reposilite              #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+
+reposilite_name: reposilite
+
+################################
+# Paths
+################################
+
+reposilite_paths_folder: "{{ reposilite_name }}"
+reposilite_paths_location: "{{ server_appdata_path }}/{{ reposilite_paths_folder }}"
+reposilite_data_location: "{{ server_appdata_path }}/data"
+reposilite_paths_folders_list:
+  - "{{ reposilite_paths_location }}"
+  - "{{ reposilite_data_location }}"
+
+################################
+# Web
+################################
+
+reposilite_web_subdomain: "{{ reposilite_name }}"
+reposilite_web_domain: "{{ user.domain }}"
+reposilite_web_port: "80"
+reposilite_web_url: "{{ 'https://' + lookup('vars', reposilite_name + '_web_subdomain', default=reposilite_web_subdomain)
+                            + '.' + lookup('vars', reposilite_name + '_web_domain', default=reposilite_web_domain)
+                         if (reverse_proxy_is_enabled)
+                         else 'http://localhost:' + lookup('vars', reposilite_name + '_web_port', default=reposilite_web_port) }}"
+
+################################
+# DNS
+################################
+
+reposilite_dns_record: "{{ reposilite_web_subdomain }}"
+reposilite_dns_zone: "{{ reposilite_web_domain }}"
+reposilite_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+reposilite_traefik_middleware: "{{ traefik_default_middleware }}"
+reposilite_traefik_certresolver: "{{ traefik_default_certresolver }}"
+reposilite_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+reposilite_docker_container: "{{ reposilite_name }}"
+
+# Image
+reposilite_docker_image_pull: true
+reposilite_docker_image_tag: "latest"
+reposilite_docker_image_repo: "dzikoysk/reposilite"
+reposilite_docker_image: "{{ lookup('vars', reposilite_name + '_docker_image_repo', default=reposilite_docker_image_repo)
+                                 + ':' + lookup('vars', reposilite_name + '_docker_image_tag', default=reposilite_docker_image_tag) }}"
+
+
+# Ports
+reposilite_docker_ports_defaults:
+  - "{{ reposilite_web_port }}:8080"
+reposilite_docker_ports_custom: []
+reposilite_docker_ports: "{{ reposilite_docker_ports_defaults
+                            + reposilite_docker_ports_custom
+                         if (not reverse_proxy_is_enabled)
+                         else reposilite_docker_ports_custom }}"
+
+# Envs
+reposilite_docker_envs_default:
+  TZ: "{{ tz }}"
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+reposilite_docker_envs_custom: {}
+reposilite_docker_envs: "{{ reposilite_docker_envs_default
+                           | combine(reposilite_docker_envs_custom) }}"
+
+# Commands
+reposilite_docker_commands_default: []
+reposilite_docker_commands_custom: []
+reposilite_docker_commands: "{{ reposilite_docker_commands_default
+                               + reposilite_docker_commands_custom }}"
+
+# Volumes
+reposilite_docker_volumes_default:
+  - "{{ reposilite_paths_location }}:/app"
+reposilite_docker_volumes_custom: []
+reposilite_docker_volumes: "{{ reposilite_docker_volumes_default
+                              + reposilite_docker_volumes_custom }}"
+
+# Devices
+reposilite_docker_devices_default: []
+reposilite_docker_devices_custom: []
+reposilite_docker_devices: "{{ reposilite_docker_devices_default
+                              + reposilite_docker_devices_custom }}"
+
+# Hosts
+reposilite_docker_hosts_default: []
+reposilite_docker_hosts_custom: []
+reposilite_docker_hosts: "{{ docker_hosts_common
+                            | combine(reposilite_docker_hosts_default)
+                            | combine(reposilite_docker_hosts_custom) }}"
+
+# Labels
+reposilite_docker_labels_default: {}
+reposilite_docker_labels_custom: {}
+reposilite_docker_labels: "{{ docker_labels_common
+                             | combine(reposilite_docker_labels_default)
+                             | combine(reposilite_docker_labels_custom) }}"
+
+# Hostname
+reposilite_docker_hostname: "{{ reposilite_name }}"
+
+# Networks
+reposilite_docker_networks_alias: "{{ reposilite_name }}"
+reposilite_docker_networks_default: []
+reposilite_docker_networks_custom: []
+reposilite_docker_networks: "{{ docker_networks_common
+                               + reposilite_docker_networks_default
+                               + reposilite_docker_networks_custom }}"
+
+# Capabilities
+reposilite_docker_capabilities_default: []
+reposilite_docker_capabilities_custom: []
+reposilite_docker_capabilities: "{{ reposilite_docker_capabilities_default
+                                   + reposilite_docker_capabilities_custom }}"
+
+# Security Opts
+reposilite_docker_security_opts_default: []
+reposilite_docker_security_opts_custom: []
+reposilite_docker_security_opts: "{{ reposilite_docker_security_opts_default
+                                    + reposilite_docker_security_opts_custom }}"
+
+# Restart Policy
+reposilite_docker_restart_policy: unless-stopped
+
+# State
+reposilite_docker_state: started

--- a/roles/reposilite/defaults/main.yml
+++ b/roles/reposilite/defaults/main.yml
@@ -1,6 +1,6 @@
 #########################################################################
 # Title:            Sandbox: Reposilite                                 #
-# Author(s):        Derek Z                                             #
+# Author(s):        Derek Z, JigSawFr                                   #
 # URL:              https://github.com/saltyorg/Sandbox                 #
 # URL:              https://github.com/dzikoysk/reposilite              #
 # --                                                                    #
@@ -71,9 +71,9 @@ reposilite_docker_ports_defaults:
   - "{{ reposilite_web_port }}"
 reposilite_docker_ports_custom: []
 reposilite_docker_ports: "{{ reposilite_docker_ports_defaults
-                            + reposilite_docker_ports_custom
-                         if (not reverse_proxy_is_enabled)
-                         else reposilite_docker_ports_custom }}"
+                             + reposilite_docker_ports_custom
+                          if (not reverse_proxy_is_enabled)
+                          else reposilite_docker_ports_custom }}"
 
 # Envs
 reposilite_docker_envs_default:
@@ -83,40 +83,40 @@ reposilite_docker_envs_default:
   REPOSILITE_OPTS: "--token {{ user.name }}:{{ user.pass }}"
 reposilite_docker_envs_custom: {}
 reposilite_docker_envs: "{{ reposilite_docker_envs_default
-                           | combine(reposilite_docker_envs_custom) }}"
+                            | combine(reposilite_docker_envs_custom) }}"
 
 # Commands
 reposilite_docker_commands_default: []
 reposilite_docker_commands_custom: []
 reposilite_docker_commands: "{{ reposilite_docker_commands_default
-                               + reposilite_docker_commands_custom }}"
+                                + reposilite_docker_commands_custom }}"
 
 # Volumes
 reposilite_docker_volumes_default:
   - "{{ reposilite_paths_location }}:/app/data"
 reposilite_docker_volumes_custom: []
 reposilite_docker_volumes: "{{ reposilite_docker_volumes_default
-                              + reposilite_docker_volumes_custom }}"
+                               + reposilite_docker_volumes_custom }}"
 
 # Devices
 reposilite_docker_devices_default: []
 reposilite_docker_devices_custom: []
 reposilite_docker_devices: "{{ reposilite_docker_devices_default
-                              + reposilite_docker_devices_custom }}"
+                               + reposilite_docker_devices_custom }}"
 
 # Hosts
 reposilite_docker_hosts_default: []
 reposilite_docker_hosts_custom: []
 reposilite_docker_hosts: "{{ docker_hosts_common
-                            | combine(reposilite_docker_hosts_default)
-                            | combine(reposilite_docker_hosts_custom) }}"
+                             | combine(reposilite_docker_hosts_default)
+                             | combine(reposilite_docker_hosts_custom) }}"
 
 # Labels
 reposilite_docker_labels_default: {}
 reposilite_docker_labels_custom: {}
 reposilite_docker_labels: "{{ docker_labels_common
-                             | combine(reposilite_docker_labels_default)
-                             | combine(reposilite_docker_labels_custom) }}"
+                              | combine(reposilite_docker_labels_default)
+                              | combine(reposilite_docker_labels_custom) }}"
 
 # Hostname
 reposilite_docker_hostname: "{{ reposilite_name }}"
@@ -126,20 +126,20 @@ reposilite_docker_networks_alias: "{{ reposilite_name }}"
 reposilite_docker_networks_default: []
 reposilite_docker_networks_custom: []
 reposilite_docker_networks: "{{ docker_networks_common
-                               + reposilite_docker_networks_default
-                               + reposilite_docker_networks_custom }}"
+                                + reposilite_docker_networks_default
+                                + reposilite_docker_networks_custom }}"
 
 # Capabilities
 reposilite_docker_capabilities_default: []
 reposilite_docker_capabilities_custom: []
 reposilite_docker_capabilities: "{{ reposilite_docker_capabilities_default
-                                   + reposilite_docker_capabilities_custom }}"
+                                    + reposilite_docker_capabilities_custom }}"
 
 # Security Opts
 reposilite_docker_security_opts_default: []
 reposilite_docker_security_opts_custom: []
 reposilite_docker_security_opts: "{{ reposilite_docker_security_opts_default
-                                    + reposilite_docker_security_opts_custom }}"
+                                     + reposilite_docker_security_opts_custom }}"
 
 # Restart Policy
 reposilite_docker_restart_policy: unless-stopped

--- a/roles/reposilite/defaults/main.yml
+++ b/roles/reposilite/defaults/main.yml
@@ -59,6 +59,8 @@ reposilite_traefik_middleware: "{{ reposilite_traefik_middleware_default + ','
                                   + reposilite_traefik_middleware_custom }}"
 reposilite_traefik_certresolver: "{{ traefik_default_certresolver }}"
 reposilite_traefik_enabled: true
+reposilite_traefik_api_enabled: true
+reposilite_traefik_api_endpoint: "`/api`"
 
 ################################
 # Docker

--- a/roles/reposilite/defaults/main.yml
+++ b/roles/reposilite/defaults/main.yml
@@ -20,10 +20,8 @@ reposilite_name: reposilite
 
 reposilite_paths_folder: "{{ reposilite_name }}"
 reposilite_paths_location: "{{ server_appdata_path }}/{{ reposilite_paths_folder }}"
-reposilite_data_location: "{{ server_appdata_path }}/data"
 reposilite_paths_folders_list:
   - "{{ reposilite_paths_location }}"
-  - "{{ reposilite_data_location }}"
 
 ################################
 # Web
@@ -31,7 +29,7 @@ reposilite_paths_folders_list:
 
 reposilite_web_subdomain: "{{ reposilite_name }}"
 reposilite_web_domain: "{{ user.domain }}"
-reposilite_web_port: "80"
+reposilite_web_port: "8080"
 reposilite_web_url: "{{ 'https://' + lookup('vars', reposilite_name + '_web_subdomain', default=reposilite_web_subdomain)
                             + '.' + lookup('vars', reposilite_name + '_web_domain', default=reposilite_web_domain)
                          if (reverse_proxy_is_enabled)
@@ -70,7 +68,7 @@ reposilite_docker_image: "{{ lookup('vars', reposilite_name + '_docker_image_rep
 
 # Ports
 reposilite_docker_ports_defaults:
-  - "{{ reposilite_web_port }}:8080"
+  - "{{ reposilite_web_port }}"
 reposilite_docker_ports_custom: []
 reposilite_docker_ports: "{{ reposilite_docker_ports_defaults
                             + reposilite_docker_ports_custom
@@ -94,7 +92,7 @@ reposilite_docker_commands: "{{ reposilite_docker_commands_default
 
 # Volumes
 reposilite_docker_volumes_default:
-  - "{{ reposilite_paths_location }}:/app"
+  - "{{ reposilite_paths_location }}:/app/data"
 reposilite_docker_volumes_custom: []
 reposilite_docker_volumes: "{{ reposilite_docker_volumes_default
                               + reposilite_docker_volumes_custom }}"

--- a/roles/reposilite/defaults/main.yml
+++ b/roles/reposilite/defaults/main.yml
@@ -30,10 +30,9 @@ reposilite_paths_folders_list:
 reposilite_web_subdomain: "{{ reposilite_name }}"
 reposilite_web_domain: "{{ user.domain }}"
 reposilite_web_port: "8080"
-reposilite_web_url: "{{ 'https://' + lookup('vars', reposilite_name + '_web_subdomain', default=reposilite_web_subdomain)
-                            + '.' + lookup('vars', reposilite_name + '_web_domain', default=reposilite_web_domain)
-                         if (reverse_proxy_is_enabled)
-                         else 'http://localhost:' + lookup('vars', reposilite_name + '_web_port', default=reposilite_web_port) }}"
+reposilite_web_url: "{{ 'https://' + reposilite_web_subdomain + '.' + reposilite_web_domain
+                     if (reverse_proxy_is_enabled)
+                     else 'http://localhost:' + preposilite_web_port }}"
 
 ################################
 # DNS

--- a/roles/reposilite/tasks/main.yml
+++ b/roles/reposilite/tasks/main.yml
@@ -1,6 +1,6 @@
 #########################################################################
 # Title:            Sandbox: Reposilite                                 #
-# Author(s):        Derek Z                                             #
+# Author(s):        Derek Z, JigSawFr                                   #
 # URL:              https://github.com/saltyorg/Sandbox                 #
 # URL:              https://github.com/dzikoysk/reposilite              #
 # --                                                                    #
@@ -23,3 +23,7 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+
+- name: Add curl package for healthcheck
+  ansible.builtin.command: "docker exec {{ lookup('vars', role_name + '_name') }} /bin/bash -c 'apt-get update && apt-get install -y curl'"
+  ignore_errors: true

--- a/roles/reposilite/tasks/main.yml
+++ b/roles/reposilite/tasks/main.yml
@@ -1,0 +1,25 @@
+#########################################################################
+# Title:            Sandbox: Reposilite                                 #
+# Author(s):        Derek Z                                             #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# URL:              https://github.com/dzikoysk/reposilite              #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -112,6 +112,7 @@
     - { role: qbittorrentvpn, tags: ['qbittorrentvpn'] }
     - { role: rdtclient, tags: ['rdtclient'] }
     - { role: recyclarr, tags: ['recyclarr'] }
+    - { role: reposilite, tags: ['reposilite'] }
     - { role: requestrr, tags: ['requestrr'] }
     - { role: requestrrx, tags: ['requestrrx'] }
     - { role: resiliosync, tags: ['resiliosync'] }


### PR DESCRIPTION
# Description

Lightweight and easy-to-use repository manager for Maven based artifacts in JVM ecosystem.

Simple, extensible, scalable and self-hosted alternative to managers like Nexus, Archiva or Artifactory, with reduced resources consumption written in Kotlin 📦

https://reposilite.com/

It would be greatly appreciated if you create a sandbox documentation page yourself and do a PR into the [docs repo](https://github.com/saltyorg/docs).  You, as the person creating the role, have presumably used the thing and are presumably familiar with any setup steps required.  Anyone else here would need to research that.


# How Has This Been Tested?

Ran locally and tested login with specified user account/password in avd_setting.yml.

However, currently the docker image uses a hard-coded user/group id of 999:999, which may cause inconvenience for users with an externally mounted data folder. This has been raised with the original author, and presumably will be fixed.

- [ ] This is not a test I performed
- [ ] I did not read the paragraph above this before checking this box
- [ ] I have now checked three boxes without reading any of the text

