### PR TITLE
feat(role): add homeassistant

### DIFF
--- a/roles/homeassistant/defaults/main.yml
+++ b/roles/homeassistant/defaults/main.yml
@@ -34,8 +34,8 @@ homeassistant_web_subdomain: "{{ homeassistant_name }}"
 homeassistant_web_domain: "{{ user.domain }}"
 homeassistant_web_port: "8123"
 homeassistant_web_url: "{{ 'https://' + homeassistant_web_subdomain + '.' + homeassistant_web_domain
-               if (reverse_proxy_is_enabled)
-               else 'http://localhost:' + homeassistant_web_port }}"
+                        if (reverse_proxy_is_enabled)
+                        else 'http://localhost:' + homeassistant_web_port }}"
 
 ################################
 # DNS
@@ -71,13 +71,13 @@ homeassistant_docker_envs_default:
   PGID: "{{ gid }}"
 homeassistant_docker_envs_custom: {}
 homeassistant_docker_envs: "{{ homeassistant_docker_envs_default
-                      | combine(homeassistant_docker_envs_custom) }}"
+                               | combine(homeassistant_docker_envs_custom) }}"
 
 # Commands
 homeassistant_docker_commands_default: []
 homeassistant_docker_commands_custom: []
 homeassistant_docker_commands: "{{ homeassistant_docker_commands_default
-                          + homeassistant_docker_commands_custom }}"
+                                   + homeassistant_docker_commands_custom }}"
 
 # Volumes
 homeassistant_docker_volumes_default:
@@ -85,7 +85,7 @@ homeassistant_docker_volumes_default:
   - /etc/localtime:/etc/localtime:ro
 homeassistant_docker_volumes_custom: []
 homeassistant_docker_volumes: "{{ homeassistant_docker_volumes_default
-                         + homeassistant_docker_volumes_custom }}"
+                                  + homeassistant_docker_volumes_custom }}"
 
 # Extended Privileges
 homeassistant_docker_privileged: "yes"
@@ -94,21 +94,21 @@ homeassistant_docker_privileged: "yes"
 homeassistant_docker_devices_default: []
 homeassistant_docker_devices_custom: []
 homeassistant_docker_devices: "{{ homeassistant_docker_devices_default
-                         + homeassistant_docker_devices_custom }}"
+                                  + homeassistant_docker_devices_custom }}"
 
 # Hosts
 homeassistant_docker_hosts_default: []
 homeassistant_docker_hosts_custom: []
 homeassistant_docker_hosts: "{{ docker_hosts_common
-                       | combine(homeassistant_docker_hosts_default)
-                       | combine(homeassistant_docker_hosts_custom) }}"
+                                | combine(homeassistant_docker_hosts_default)
+                                | combine(homeassistant_docker_hosts_custom) }}"
 
 # Labels
 homeassistant_docker_labels_default: {}
 homeassistant_docker_labels_custom: {}
 homeassistant_docker_labels: "{{ docker_labels_common
-                        | combine(homeassistant_docker_labels_default)
-                        | combine(homeassistant_docker_labels_custom) }}"
+                                 | combine(homeassistant_docker_labels_default)
+                                 | combine(homeassistant_docker_labels_custom) }}"
 
 # Hostname
 homeassistant_docker_hostname: "{{ homeassistant_name }}"
@@ -119,7 +119,7 @@ homeassistant_docker_networks: "{{ omit }}"
 homeassistant_docker_capabilities_default: []
 homeassistant_docker_capabilities_custom: []
 homeassistant_docker_capabilities: "{{ homeassistant_docker_capabilities_default
-                              + homeassistant_docker_capabilities_custom }}"
+                                       + homeassistant_docker_capabilities_custom }}"
 
 # Network Mode
 homeassistant_docker_network_mode: "host"
@@ -128,7 +128,7 @@ homeassistant_docker_network_mode: "host"
 homeassistant_docker_security_opts_default: []
 homeassistant_docker_security_opts_custom: []
 homeassistant_docker_security_opts: "{{ homeassistant_docker_security_opts_default
-                               + homeassistant_docker_security_opts_custom }}"
+                                        + homeassistant_docker_security_opts_custom }}"
 
 # Restart Policy
 homeassistant_docker_restart_policy: unless-stopped

--- a/roles/homeassistant/defaults/main.yml
+++ b/roles/homeassistant/defaults/main.yml
@@ -59,7 +59,7 @@ homeassistant_docker_container: "{{ homeassistant_name }}"
 # Image
 homeassistant_docker_image_pull: true
 homeassistant_docker_image_tag: "latest"
-homeassistant_docker_image: "ghcr.io/home-assistant/home-assistant:{{ homeassistant_docker_image_tag }}"
+homeassistant_docker_image: "lscr.io/linuxserver/homeassistant:{{ homeassistant_docker_image_tag }}"
 
 # Healthcheck
 homeassistant_docker_healthcheck:

--- a/roles/homeassistant/defaults/main.yml
+++ b/roles/homeassistant/defaults/main.yml
@@ -19,10 +19,7 @@ homeassistant_name: homeassistant
 
 homeassistant_paths_folder: "{{ homeassistant_name }}"
 homeassistant_paths_location: "{{ server_appdata_path }}/{{ homeassistant_paths_folder }}"
-homeassistant_paths_automation_location: "{{ homeassistant_paths_location }}/automations.yaml"
 homeassistant_paths_conf: "{{ homeassistant_paths_location }}/configuration.yaml"
-homeassistant_paths_scene_location: "{{ homeassistant_paths_location }}/scenes.yaml"
-homeassistant_paths_script_location: "{{ homeassistant_paths_location }}/scripts.yaml"
 homeassistant_paths_folders_list:
   - "{{ homeassistant_paths_location }}"
 
@@ -63,6 +60,14 @@ homeassistant_docker_container: "{{ homeassistant_name }}"
 homeassistant_docker_image_pull: true
 homeassistant_docker_image_tag: "latest"
 homeassistant_docker_image: "ghcr.io/home-assistant/home-assistant:{{ homeassistant_docker_image_tag }}"
+
+# Healthcheck
+homeassistant_docker_healthcheck:
+  test: ["CMD", "curl", "--fail", "http://localhost:{{ homeassistant_web_port }}"]
+  interval: 10s
+  timeout: 5s
+  retries: 10
+  start_period: 10s
 
 # Envs
 homeassistant_docker_envs_default:

--- a/roles/homeassistant/defaults/main.yml
+++ b/roles/homeassistant/defaults/main.yml
@@ -45,7 +45,7 @@ homeassistant_dns_proxy: "{{ dns.proxied }}"
 ################################
 # Traefik
 ################################
-homeassistant_traefik_middleware:   "{{ traefik_default_middleware }}"
+homeassistant_traefik_middleware: "{{ traefik_default_middleware }}"
 homeassistant_traefik_certresolver: "{{ traefik_default_certresolver }}"
 homeassistant_traefik_enabled: true
 

--- a/roles/homeassistant/defaults/main.yml
+++ b/roles/homeassistant/defaults/main.yml
@@ -1,0 +1,137 @@
+##########################################################################
+# Title:         Sandbox: Homeassistant | Default Variables              #
+# Author(s):     CHAIR/Raneydazed                                        #
+# URL:           https://github.com/saltyorg/Sandbox                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+homeassistant_name: homeassistant
+
+################################
+# Paths
+################################
+
+homeassistant_paths_folder: "{{ homeassistant_name }}"
+homeassistant_paths_location: "{{ server_appdata_path }}/{{ homeassistant_paths_folder }}"
+homeassistant_paths_automation_location: "{{ homeassistant_paths_location }}/automations.yaml"
+homeassistant_paths_conf: "{{ homeassistant_paths_location }}/configuration.yaml"
+homeassistant_paths_scene_location: "{{ homeassistant_paths_location }}/scenes.yaml"
+homeassistant_paths_script_location: "{{ homeassistant_paths_location }}/scripts.yaml"
+homeassistant_paths_folders_list:
+  - "{{ homeassistant_paths_location }}"
+
+################################
+# Web
+################################
+
+homeassistant_web_subdomain: "{{ homeassistant_name }}"
+homeassistant_web_domain: "{{ user.domain }}"
+homeassistant_web_port: "8123"
+homeassistant_web_url: "{{ 'https://' + homeassistant_web_subdomain + '.' + homeassistant_web_domain
+               if (reverse_proxy_is_enabled)
+               else 'http://localhost:' + homeassistant_web_port }}"
+
+################################
+# DNS
+################################
+
+homeassistant_dns_record: "{{ homeassistant_web_subdomain }}"
+homeassistant_dns_zone: "{{ homeassistant_web_domain }}"
+homeassistant_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+homeassistant_traefik_middleware:   "{{ traefik_default_middleware }}"
+homeassistant_traefik_certresolver: "{{ traefik_default_certresolver }}"
+homeassistant_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+homeassistant_docker_container: "{{ homeassistant_name }}"
+
+# Image
+homeassistant_docker_image_pull: true
+homeassistant_docker_image_tag: "latest"
+homeassistant_docker_image: "ghcr.io/home-assistant/home-assistant:{{ homeassistant_docker_image_tag }}"
+
+# Envs
+homeassistant_docker_envs_default:
+  TZ: "{{ tz }}"
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+homeassistant_docker_envs_custom: {}
+homeassistant_docker_envs: "{{ homeassistant_docker_envs_default
+                      | combine(homeassistant_docker_envs_custom) }}"
+
+# Commands
+homeassistant_docker_commands_default: []
+homeassistant_docker_commands_custom: []
+homeassistant_docker_commands: "{{ homeassistant_docker_commands_default
+                          + homeassistant_docker_commands_custom }}"
+
+# Volumes
+homeassistant_docker_volumes_default:
+  - "{{ homeassistant_paths_location }}:/config"
+  - /etc/localtime:/etc/localtime:ro
+homeassistant_docker_volumes_custom: []
+homeassistant_docker_volumes: "{{ homeassistant_docker_volumes_default
+                         + homeassistant_docker_volumes_custom }}"
+
+# Extended Privileges
+homeassistant_docker_privileged: "yes"
+
+# Devices
+homeassistant_docker_devices_default: []
+homeassistant_docker_devices_custom: []
+homeassistant_docker_devices: "{{ homeassistant_docker_devices_default
+                         + homeassistant_docker_devices_custom }}"
+
+# Hosts
+homeassistant_docker_hosts_default: []
+homeassistant_docker_hosts_custom: []
+homeassistant_docker_hosts: "{{ docker_hosts_common
+                       | combine(homeassistant_docker_hosts_default)
+                       | combine(homeassistant_docker_hosts_custom) }}"
+
+# Labels
+homeassistant_docker_labels_default: {}
+homeassistant_docker_labels_custom: {}
+homeassistant_docker_labels: "{{ docker_labels_common
+                        | combine(homeassistant_docker_labels_default)
+                        | combine(homeassistant_docker_labels_custom) }}"
+
+# Hostname
+homeassistant_docker_hostname: "{{ homeassistant_name }}"
+
+homeassistant_docker_networks: "{{ omit }}"
+
+# Capabilities
+homeassistant_docker_capabilities_default: []
+homeassistant_docker_capabilities_custom: []
+homeassistant_docker_capabilities: "{{ homeassistant_docker_capabilities_default
+                              + homeassistant_docker_capabilities_custom }}"
+
+# Network Mode
+homeassistant_docker_network_mode: "host"
+
+# Security Opts
+homeassistant_docker_security_opts_default: []
+homeassistant_docker_security_opts_custom: []
+homeassistant_docker_security_opts: "{{ homeassistant_docker_security_opts_default
+                               + homeassistant_docker_security_opts_custom }}"
+
+# Restart Policy
+homeassistant_docker_restart_policy: unless-stopped
+
+# State
+homeassistant_docker_state: started

--- a/roles/homeassistant/tasks/main.yml
+++ b/roles/homeassistant/tasks/main.yml
@@ -1,0 +1,114 @@
+#########################################################################
+# Title:         Sandbox: Homeassistant                                 #
+# Author(s):     CHAIR/Raneydazed                                       #
+# URL:           https://github.com/saltyorg/Saltbox                    #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: "Check if '{{ homeassistant_paths_conf | basename }}' exists"
+  ansible.builtin.stat:
+    path: "{{ homeassistant_paths_conf }}"
+  register: homeassistant_config
+
+- name: Settings | New `{{ homeassistant_paths_conf | basename }}` tasks
+  block:
+
+    - name: "Import '{{ homeassistant_paths_conf | basename }}' if it doesnt exist"
+      ansible.builtin.template:
+        src: configuration.yaml.j2
+        dest: "{{ homeassistant_paths_conf }}"
+        owner: "{{ user.name }}"
+        group: "{{ user.name }}"
+        mode: 0775
+  when: not homeassistant_config.stat.exists
+
+- name: "Check if '{{ homeassistant_paths_automation_location | basename }}' exists"
+  ansible.builtin.stat:
+    path: "{{ homeassistant_paths_automation_location }}"
+  register: homeassistant_automation_config
+
+- name: Settings | New `{{ homeassistant_paths_automation_location | basename }}` tasks
+  block:
+
+  - name: "Import '{{ homeassistant_paths_automation_location | basename }}' if it doesnt exist"
+    ansible.builtin.command: "touch '{{ homeassistant_paths_automation_location }}'"
+    ignore_errors: true
+  when: not homeassistant_automation_config.stat.exists
+
+- name: "Check if '{{ homeassistant_paths_scene_location | basename }}' exists"
+  ansible.builtin.stat:
+    path: "{{ homeassistant_paths_scene_location }}"
+  register: homeassistant_scene_config
+
+- name: Settings | New `{{ homeassistant_paths_scene_location | basename }}` tasks
+  block:
+
+  - name: "Import '{{ homeassistant_paths_scene_location | basename }}' if it doesnt exist"
+    ansible.builtin.command: "touch '{{ homeassistant_paths_scene_location }}'"
+    ignore_errors: true
+  when: not homeassistant_scene_config.stat.exists
+
+- name: "Check if '{{ homeassistant_paths_script_location | basename }}' exists"
+  ansible.builtin.stat:
+    path: "{{ homeassistant_paths_script_location }}"
+  register: homeassistant_script_config
+
+- name: Settings | New `{{ homeassistant_paths_script_location | basename }}` tasks
+  block:
+
+  - name: "Import '{{ homeassistant_paths_script_location | basename }}' if it doesnt exist"
+    ansible.builtin.command: "touch '{{ homeassistant_paths_script_location }}'"
+    ignore_errors: true
+  when: not homeassistant_script_config.stat.exists
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+
+- name: Wait for 'configuration.yaml' to be created
+  ansible.builtin.wait_for:
+    path: "{{ homeassistant_paths_conf }}"
+    state: present
+  when: (not continuous_integration)
+
+- name: Wait for 'automations.yaml' to be created
+  ansible.builtin.wait_for:
+    path: "{{ homeassistant_paths_automation_location }}"
+    state: present
+  when: (not continuous_integration)
+
+- name: Wait for 'scenes.yaml' to be created
+  ansible.builtin.wait_for:
+    path: "{{ homeassistant_paths_scene_location }}"
+    state: present
+  when: (not continuous_integration)
+
+- name: Wait for 'scripts.yaml' to be created
+  ansible.builtin.wait_for:
+    path: "{{ homeassistant_paths_script_location }}"
+    state: present
+  when: (not continuous_integration)
+
+- name: Chown '{{ homeassistant_paths_location }}'
+  ansible.builtin.file:
+    path: "{{ homeassistant_paths_location }}"
+    state: directory
+    recurse: true
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  when: (not continuous_integration)

--- a/roles/homeassistant/tasks/main.yml
+++ b/roles/homeassistant/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: Settings | New `{{ homeassistant_paths_conf | basename }}` tasks
   block:
 
-    - name: "Import '{{ homeassistant_paths_conf | basename }}' if it doesnt exist"
+    - name: "Create '{{ homeassistant_paths_conf | basename }}' if it doesnt exist"
       ansible.builtin.template:
         src: configuration.yaml.j2
         dest: "{{ homeassistant_paths_conf }}"
@@ -37,69 +37,12 @@
         mode: 0775
   when: not homeassistant_config.stat.exists
 
-- name: "Check if '{{ homeassistant_paths_automation_location | basename }}' exists"
-  ansible.builtin.stat:
-    path: "{{ homeassistant_paths_automation_location }}"
-  register: homeassistant_automation_config
-
-- name: Settings | New `{{ homeassistant_paths_automation_location | basename }}` tasks
-  block:
-
-  - name: "Import '{{ homeassistant_paths_automation_location | basename }}' if it doesnt exist"
-    ansible.builtin.command: "touch '{{ homeassistant_paths_automation_location }}'"
-    ignore_errors: true
-  when: not homeassistant_automation_config.stat.exists
-
-- name: "Check if '{{ homeassistant_paths_scene_location | basename }}' exists"
-  ansible.builtin.stat:
-    path: "{{ homeassistant_paths_scene_location }}"
-  register: homeassistant_scene_config
-
-- name: Settings | New `{{ homeassistant_paths_scene_location | basename }}` tasks
-  block:
-
-  - name: "Import '{{ homeassistant_paths_scene_location | basename }}' if it doesnt exist"
-    ansible.builtin.command: "touch '{{ homeassistant_paths_scene_location }}'"
-    ignore_errors: true
-  when: not homeassistant_scene_config.stat.exists
-
-- name: "Check if '{{ homeassistant_paths_script_location | basename }}' exists"
-  ansible.builtin.stat:
-    path: "{{ homeassistant_paths_script_location }}"
-  register: homeassistant_script_config
-
-- name: Settings | New `{{ homeassistant_paths_script_location | basename }}` tasks
-  block:
-
-  - name: "Import '{{ homeassistant_paths_script_location | basename }}' if it doesnt exist"
-    ansible.builtin.command: "touch '{{ homeassistant_paths_script_location }}'"
-    ignore_errors: true
-  when: not homeassistant_script_config.stat.exists
-
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
 
 - name: Wait for 'configuration.yaml' to be created
   ansible.builtin.wait_for:
     path: "{{ homeassistant_paths_conf }}"
-    state: present
-  when: (not continuous_integration)
-
-- name: Wait for 'automations.yaml' to be created
-  ansible.builtin.wait_for:
-    path: "{{ homeassistant_paths_automation_location }}"
-    state: present
-  when: (not continuous_integration)
-
-- name: Wait for 'scenes.yaml' to be created
-  ansible.builtin.wait_for:
-    path: "{{ homeassistant_paths_scene_location }}"
-    state: present
-  when: (not continuous_integration)
-
-- name: Wait for 'scripts.yaml' to be created
-  ansible.builtin.wait_for:
-    path: "{{ homeassistant_paths_script_location }}"
     state: present
   when: (not continuous_integration)
 

--- a/roles/homeassistant/templates/configuration.yaml.j2
+++ b/roles/homeassistant/templates/configuration.yaml.j2
@@ -1,0 +1,30 @@
+
+# Loads default set of integrations. Do not remove.
+default_config:
+
+# Add the /tmp folder
+homeassistant:
+  allowlist_external_dirs:
+  - "/tmp"
+
+frontend:
+  themes: !include_dir_merge_named themes
+
+# Add cloud integration
+
+cloud:
+
+# Text to speech
+tts:
+  - platform: google_translate
+
+script: !include scripts.yaml
+automation: !include automations.yaml
+scene: !include scenes.yaml
+
+# Http entry for traefik
+http:
+  use_x_forwarded_for: true
+  trusted_proxies:
+    - 172.19.0.0/24
+    - fd00:dead:beef::/48

--- a/roles/homeassistant/templates/configuration.yaml.j2
+++ b/roles/homeassistant/templates/configuration.yaml.j2
@@ -18,9 +18,11 @@ cloud:
 tts:
   - platform: google_translate
 
-script: !include scripts.yaml
-automation: !include automations.yaml
-scene: !include scenes.yaml
+# Uncomment below for script automation and scene integration
+
+# script: !include scripts.yaml
+# automation: !include automations.yaml
+# scene: !include scenes.yaml
 
 # Http entry for traefik
 http:

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -59,6 +59,7 @@
     - { role: handbrake, tags: ['handbrake'] }
     - { role: healthchecks, tags: ['healthchecks'] }
     - { role: heimdall, tags: ['heimdall'] }
+    - { role: homeassistant, tags: ['homeassistant'] }
     - { role: homebox, tags: ['homebox'] }
     - { role: influxdb, tags: ['influxdb'] }
     - { role: invoiceninjav5, tags: ['invoiceninja'] }


### PR DESCRIPTION
# Description

This PR is for Home assistant, it is open source home automation that puts local control and privacy first. Its powered by a worldwide community of tinkerers and DIY enthusiasts. Perfect to run on a Raspberry Pi or a local server. Docker compose: 

```yaml
version: '3'
services:
  homeassistant:
    container_name: homeassistant
    image: "lscr.io/linuxserver/homeassistant:stable"
    volumes:
      - /opt/homeassistant:/config
      - /etc/localtime:/etc/localtime:ro
    restart: unless-stopped
    privileged: true
    network_mode: host
```

It connects to LAN devices just fine, and is connectable after initial setup on lan IP, ie `192.168.1.xx:8123`

# Doccumentations 

I will create the docs post haste!

# How Has This Been Tested?

I tested it many times on my local server, removing files and the directory multiple times. Salty gave me a hand with it a few times, figuring out what would allow host mode. Requires newest update of sb and traefik. To allow for the role to work with docker network mode: host. 
