### PR TITLE
feat(role): add docspell

### DIFF
--- a/roles/docspell/defaults/main.yml
+++ b/roles/docspell/defaults/main.yml
@@ -1,0 +1,175 @@
+##########################################################################
+# Title:            Sandbox: docspell | Default Variables                #
+# Author(s):        JigSawFr                                             #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# URL:              https://github.com/eikek/docspell                    #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+docspell_name: docspell
+
+################################
+# Paths
+################################
+
+docspell_paths_folder: "{{ docspell_name }}"
+docspell_paths_location: "{{ server_appdata_path }}/{{ docspell_paths_folder }}/server"
+docspell_paths_folders_list:
+  - "{{ docspell_paths_location }}"
+
+################################
+# Web
+################################
+
+docspell_web_subdomain: "{{ docspell_name }}"
+docspell_web_domain: "{{ user.domain }}"
+docspell_web_port: "7880"
+docspell_web_url: "{{ 'https://' + docspell_web_subdomain + '.' + docspell_web_domain
+                   if (reverse_proxy_is_enabled)
+                   else 'http://localhost:' + docspell_web_port }}"
+
+################################
+# DNS
+################################
+
+docspell_dns_record: "{{ docspell_web_subdomain }}"
+docspell_dns_zone: "{{ docspell_web_domain }}"
+docspell_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+docspell_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+docspell_traefik_middleware_default: "{{ traefik_default_middleware + ','
+                                           + lookup('vars', docspell_name + '_traefik_sso_middleware', default=docspell_traefik_sso_middleware)
+                                        if (lookup('vars', docspell_name + '_traefik_sso_middleware', default=docspell_traefik_sso_middleware) | length > 0)
+                                        else traefik_default_middleware }}"
+docspell_traefik_middleware_custom: ""
+docspell_traefik_middleware: "{{ docspell_traefik_middleware_default + ','
+                                 + docspell_traefik_middleware_custom
+                              if (not docspell_traefik_middleware_custom.startswith(',') and docspell_traefik_middleware_custom | length > 0)
+                              else docspell_traefik_middleware_default
+                                 + docspell_traefik_middleware_custom }}"
+docspell_traefik_certresolver: "{{ traefik_default_certresolver }}"
+docspell_traefik_enabled: true
+docspell_traefik_api_enabled: true
+docspell_traefik_api_endpoint: "`/api`"
+
+################################
+# Docker
+################################
+
+# Container
+docspell_docker_container: "{{ docspell_name }}"
+
+# Image
+docspell_docker_image_pull: true
+docspell_docker_image_tag: "latest"
+docspell_docker_image: "docspell/restserver:{{ docspell_docker_image_tag }}"
+
+# Healthcheck
+docspell_docker_healthcheck:
+  test: ["CMD", "wget", "--spider", "http://localhost:{{ docspell_web_port }}/api/info/version"]
+  interval: 1m
+  timeout: 10s
+  retries: 2
+  start_period: 30s
+
+# Ports
+docspell_docker_ports_defaults:
+  - "{{ docspell_web_port }}"
+docspell_docker_ports_custom: []
+docspell_docker_ports: "{{ docspell_docker_ports_defaults
+                           + docspell_docker_ports_custom
+                        if (not reverse_proxy_is_enabled)
+                        else docspell_docker_ports_custom }}"
+
+# Envs
+docspell_docker_envs_default:
+  TZ: "{{ tz }}"
+  DOCSPELL_SERVER_INTERNAL__URL: "http://{{ docspell_name }}:{{ docspell_web_port }}"
+  DOCSPELL_SERVER_ADMIN__ENDPOINT_SECRET: "{{ docspell_admin_key.stdout }}"
+  # DOCSPELL_SERVER_AUTH_SERVER__SECRET: ""
+  DOCSPELL_SERVER_BACKEND_JDBC_PASSWORD: "{{ mariadb_docker_envs_mysql_root_password }}"
+  DOCSPELL_SERVER_BACKEND_JDBC_URL: "jdbc:mariadb://{{ docspell_name }}_mariadb:3306/{{ docspell_name }}"
+  DOCSPELL_SERVER_BACKEND_JDBC_USER: "root"
+  DOCSPELL_SERVER_BIND_ADDRESS: "0.0.0.0"
+  DOCSPELL_SERVER_FULL__TEXT__SEARCH_ENABLED: "true"
+  DOCSPELL_SERVER_FULL__TEXT__SEARCH_SOLR_URL: "http://{{ docspell_name }}_solr:{{ solr_docker_env_port }}/solr/{{ docspell_name }}"
+  DOCSPELL_SERVER_INTEGRATION__ENDPOINT_ENABLED: "true"
+  DOCSPELL_SERVER_INTEGRATION__ENDPOINT_HTTP__HEADER_ENABLED: "true"
+  DOCSPELL_SERVER_INTEGRATION__ENDPOINT_HTTP__HEADER_HEADER__VALUE: "{{ docspell_integration_key.stdout }}"
+  DOCSPELL_SERVER_BACKEND_SIGNUP_MODE: "open"
+  DOCSPELL_SERVER_BACKEND_SIGNUP_NEW__INVITE__PASSWORD: "{{ docspell_register_key.stdout }}"
+  DOCSPELL_SERVER_BACKEND_ADDONS_ENABLED: "false"
+docspell_docker_envs_custom: {}
+docspell_docker_envs: "{{ docspell_docker_envs_default
+                          | combine(docspell_docker_envs_custom) }}"
+
+# Commands
+docspell_docker_commands_default: []
+docspell_docker_commands_custom: []
+docspell_docker_commands: "{{ docspell_docker_commands_default
+                              + docspell_docker_commands_custom }}"
+
+# Volumes
+docspell_docker_volumes_default: []
+docspell_docker_volumes_custom: []
+docspell_docker_volumes: "{{ docspell_docker_volumes_default
+                             + docspell_docker_volumes_custom }}"
+
+# Devices
+docspell_docker_devices_default: []
+docspell_docker_devices_custom: []
+docspell_docker_devices: "{{ docspell_docker_devices_default
+                             + docspell_docker_devices_custom }}"
+
+# Hosts
+docspell_docker_hosts_default: []
+docspell_docker_hosts_custom: []
+docspell_docker_hosts: "{{ docker_hosts_common
+                           | combine(docspell_docker_hosts_default)
+                           | combine(docspell_docker_hosts_custom) }}"
+
+# Labels
+docspell_docker_labels_default: {}
+docspell_docker_labels_custom: {}
+docspell_docker_labels: "{{ docker_labels_common
+                            | combine(docspell_docker_labels_default)
+                            | combine(docspell_docker_labels_custom) }}"
+
+# Hostname
+docspell_docker_hostname: "{{ docspell_name }}"
+
+# Networks
+docspell_docker_networks_alias: "{{ docspell_name }}"
+docspell_docker_networks_default: []
+docspell_docker_networks_custom: []
+docspell_docker_networks: "{{ docker_networks_common
+                              + docspell_docker_networks_default
+                              + docspell_docker_networks_custom }}"
+
+# Capabilities
+docspell_docker_capabilities_default: []
+docspell_docker_capabilities_custom: []
+docspell_docker_capabilities: "{{ docspell_docker_capabilities_default
+                                  + docspell_docker_capabilities_custom }}"
+
+# Security Opts
+docspell_docker_security_opts_default: []
+docspell_docker_security_opts_custom: []
+docspell_docker_security_opts: "{{ docspell_docker_security_opts_default
+                                   + docspell_docker_security_opts_custom }}"
+
+# Restart Policy
+docspell_docker_restart_policy: unless-stopped
+
+# State
+docspell_docker_state: started

--- a/roles/docspell/tasks/main.yml
+++ b/roles/docspell/tasks/main.yml
@@ -1,0 +1,88 @@
+#########################################################################
+# Title:            Sandbox: docspell                                   #
+# Author(s):        JigSawFr                                            #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# URL:              https://github.com/eikek/docspell                   #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Check if db folder exists
+  ansible.builtin.stat:
+    path: "{{ server_appdata_path }}/{{ docspell_paths_folder }}/mariadb"
+  register: stat_docspell_db_folder
+
+- name: MariaDB Role
+  ansible.builtin.include_role:
+    name: mariadb
+  vars:
+    mariadb_name: "{{ docspell_name }}_mariadb"  # Remove when instance support merged into Saltbox
+    mariadb_instances: ["{{ docspell_name }}_mariadb"]
+    mariadb_paths_folder: "{{ docspell_name }}"
+    mariadb_paths_location: "{{ server_appdata_path }}/{{ docspell_paths_folder }}/mariadb"
+
+- name: Create docspell database
+  ansible.builtin.command: "docker exec {{ docspell_name }}_mariadb mysql -u root -p{{ mariadb_docker_envs_mysql_root_password }} -e 'create schema {{ docspell_name }} DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'"
+  when: not stat_docspell_db_folder.stat.exists
+
+- name: Solr Role
+  ansible.builtin.include_role:
+    name: solr
+  vars:
+    solr_name: "{{ docspell_name }}_solr"
+    solr_docker_env_core_name: "{{ docspell_name }}"
+    solr_paths_folder: "{{ docspell_name }}"
+    solr_paths_location: "{{ server_appdata_path }}/{{ solr_paths_folder }}/solr"
+
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: "Generate Secret Key for registration"
+  ansible.builtin.shell: "openssl rand -hex 20"
+  register: docspell_register_key
+
+- name: "Generate Secret Key for integration endpoint"
+  ansible.builtin.shell: "openssl rand -hex 30"
+  register: docspell_integration_key
+
+- name: "Generate Secret Key for admin endpoint"
+  ansible.builtin.shell: "openssl rand -hex 30"
+  register: docspell_admin_key
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container (docspell-server)
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+
+- name: Create Docker container (docspell-worker)
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+  vars:
+    docspell_docker_container: "{{ docspell_name }}_joex"
+    docspell_docker_image: "docspell/joex:latest"
+    docspell_web_port: "7878"
+    docspell_docker_envs:
+      TZ: "{{ tz }}"
+      DOCSPELL_JOEX_APP__ID: "joex"
+      DOCSPELL_JOEX_PERIODIC__SCHEDULER_NAME: "joex"
+      DOCSPELL_JOEX_SCHEDULER_NAME: "joex"
+      DOCSPELL_JOEX_BASE__URL: "http://{{ docspell_docker_container }}:{{ docspell_web_port }}"
+      DOCSPELL_JOEX_BIND_ADDRESS: "0.0.0.0"
+      DOCSPELL_JOEX_FULL__TEXT__SEARCH_ENABLED: "true"
+      DOCSPELL_JOEX_FULL__TEXT__SEARCH_SOLR_URL: "http://{{ docspell_name }}_solr:{{ solr_docker_env_port }}/solr/{{ docspell_name }}"
+      DOCSPELL_JOEX_JDBC_PASSWORD: "{{ mariadb_docker_envs_mysql_root_password }}"
+      DOCSPELL_JOEX_JDBC_URL: "jdbc:mariadb://{{ docspell_name }}_mariadb:3306/{{ docspell_name }}"
+      DOCSPELL_JOEX_JDBC_USER: "root"
+      DOCSPELL_JOEX_ADDONS_EXECUTOR__CONFIG_RUNNER: "docker,trivial"
+      DOCSPELL_JOEX_CONVERT_HTML__CONVERTER: "weasyprint"
+    docspell_docker_labels: "{{ omit }}"
+    docspell_docker_volumes:
+      - /tmp:/tmp

--- a/roles/docspell/tasks/main.yml
+++ b/roles/docspell/tasks/main.yml
@@ -23,8 +23,12 @@
     mariadb_paths_location: "{{ server_appdata_path }}/{{ docspell_paths_folder }}/mariadb"
 
 - name: Create docspell database
-  ansible.builtin.command: "docker exec {{ docspell_name }}_mariadb mysql -u root -p{{ mariadb_docker_envs_mysql_root_password }} -e 'create schema {{ docspell_name }} DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'"
-  when: not stat_docspell_db_folder.stat.exists
+  community.mysql.mysql_db:
+    name: "{{ docspell_name }}"
+    login_host: "{{ docspell_name }}_mariadb"
+    login_user: "root"
+    login_password: "{{ mariadb_docker_envs_mysql_root_password }}"
+    state: present
 
 - name: Solr Role
   ansible.builtin.include_role:

--- a/roles/solr/defaults/main.yml
+++ b/roles/solr/defaults/main.yml
@@ -1,0 +1,136 @@
+##########################################################################
+# Title:            Sandbox: solr | Default Variables                    #
+# Author(s):        JigSawFr                                             #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# URL:              https://github.com/apache/solr                       #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+solr_name: solr
+
+################################
+# Paths
+################################
+
+solr_paths_folder: "{{ solr_name }}"
+solr_paths_location: "{{ server_appdata_path }}/{{ solr_paths_folder }}"
+solr_paths_folders_list:
+  - "{{ solr_paths_location }}"
+
+################################
+# Settings
+################################
+
+# solr_docker_env_password: "solr147"
+solr_docker_env_port: "8983"
+solr_docker_env_core_name: "{{ solr_name }}"
+
+################################
+# Docker
+################################
+
+# Container
+solr_docker_container: "{{ solr_name }}"
+
+# Image
+solr_docker_image_pull: true
+solr_docker_image_tag: "latest"
+solr_docker_image: "solr:{{ solr_docker_image_tag }}"
+
+# Healthcheck
+solr_docker_healthcheck:
+  test: ["CMD", "curl", "-f", "http://localhost:{{ solr_docker_env_port }}/solr/{{ solr_docker_env_core_name }}/admin/ping"]
+  interval: 1m
+  timeout: 10s
+  retries: 5
+  start_period: 30s
+
+# Ports
+solr_docker_ports_defaults: []
+solr_docker_ports_custom: []
+solr_docker_ports: "{{ solr_docker_ports_defaults
+                       + solr_docker_ports_custom
+                    if (not reverse_proxy_is_enabled)
+                    else solr_docker_ports_custom }}"
+
+# Envs
+solr_docker_envs_default:
+  TZ: "{{ tz }}"
+  SOLR_HOST: "{{ solr_name }}"
+  # SOLR_UID: "{{ uid }}"
+  # SOLR_GID: "{{ gid }}"
+solr_docker_envs_custom: {}
+solr_docker_envs: "{{ solr_docker_envs_default
+                      | combine(solr_docker_envs_custom) }}"
+
+# Commands
+solr_docker_commands_default:
+  - "solr-precreate {{ solr_docker_env_core_name }}"
+solr_docker_commands_custom: []
+solr_docker_commands: "{{ solr_docker_commands_default
+                          + solr_docker_commands_custom }}"
+
+# Volumes
+solr_docker_volumes_default: []
+#  - "{{ solr_paths_location }}:/var/solr/data"
+solr_docker_volumes_custom: []
+solr_docker_volumes: "{{ solr_docker_volumes_default
+                         + solr_docker_volumes_custom }}"
+
+# Devices
+solr_docker_devices_default: []
+solr_docker_devices_custom: []
+solr_docker_devices: "{{ solr_docker_devices_default
+                         + solr_docker_devices_custom }}"
+
+# Hosts
+solr_docker_hosts_default: []
+solr_docker_hosts_custom: []
+solr_docker_hosts: "{{ docker_hosts_common
+                       | combine(solr_docker_hosts_default)
+                       | combine(solr_docker_hosts_custom) }}"
+
+# Labels
+solr_docker_labels_default: {}
+solr_docker_labels_custom: {}
+solr_docker_labels: "{{ docker_labels_common
+                        | combine(solr_docker_labels_default)
+                        | combine(solr_docker_labels_custom) }}"
+
+# Hostname
+solr_docker_hostname: "{{ solr_name }}"
+
+# Networks
+solr_docker_networks_alias: "{{ solr_name }}"
+solr_docker_networks_default: []
+solr_docker_networks_custom: []
+solr_docker_networks: "{{ docker_networks_common
+                          + solr_docker_networks_default
+                          + solr_docker_networks_custom }}"
+
+# Capabilities
+solr_docker_capabilities_default: []
+solr_docker_capabilities_custom: []
+solr_docker_capabilities: "{{ solr_docker_capabilities_default
+                              + solr_docker_capabilities_custom }}"
+
+# Security Opts
+solr_docker_security_opts_default: []
+solr_docker_security_opts_custom: []
+solr_docker_security_opts: "{{ solr_docker_security_opts_default
+                               + solr_docker_security_opts_custom }}"
+
+# Restart Policy
+solr_docker_restart_policy: always
+
+# State
+solr_docker_state: started
+
+# User
+# solr_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/solr/tasks/main.yml
+++ b/roles/solr/tasks/main.yml
@@ -1,0 +1,17 @@
+##########################################################################
+# Title:            Sandbox: Gotenberg                                   #
+# Author(s):        JigSawFr                                             #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -122,6 +122,7 @@
     - { role: rocketchat, tags: ['rocketchat'] }
     - { role: sabthrottle, tags: ['sabthrottle'] }
     - { role: sarotate, tags: ['sarotate'] }
+    - { role: solr, tags: ['solr'] }
     - { role: speedtest, tags: ['speedtest'] }
     - { role: sqlitebrowser, tags: ['sqlitebrowser'] }
     - { role: sshwifty, tags: ['sshwifty'] }

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -37,6 +37,7 @@
     - { role: comixed, tags: ['comixed'] }
     - { role: deemix, tags: ['deemix'] }
     - { role: delugevpn, tags: ['delugevpn'] }
+    - { role: docspell, tags: ['docspell'] }
     - { role: doplarr, tags: ['doplarr'] }
     - { role: dozzle, tags: ['dozzle'] }
     - { role: elasticsearch, tags: ['elasticsearch'] }


### PR DESCRIPTION
# Description
Docspell is a personal document organizer. Or sometimes called a "Document Management System" (DMS). You'll need a scanner to convert your papers into files. Docspell can then assist in organizing the resulting mess 😉. It can unify your files from scanners, emails and other sources. It is targeted for home use, i.e. families, households and also for smaller groups/companies.

You can associate tags, set correspondends and lots of other predefined and custom metadata. If your documents are associated with such meta data, you can quickly find them later using the search feature. But adding this manually is a tedious task. Docspell can help by suggesting correspondents, guessing tags or finding dates using machine learning. It can learn metadata from existing documents and find things using NLP. This makes adding metadata to your documents a lot easier. For machine learning, it relies on the free (GPL) [Stanford Core NLP library](https://github.com/stanfordnlp/CoreNLP).

Docspell also runs OCR (if needed) on your documents, can provide fulltext search and has great e-mail integration. Everything is accessible via a REST/HTTP api. A mobile friendly SPA web application is the default user interface. An [Android app](https://github.com/docspell/android-client) exists for conveniently uploading files from your phone/tablet and a [cli](https://github.com/docspell/dsc). The [feature overview](https://docspell.org/#feature-selection) lists some more points.

- **Homepage:** https://docspell.org/
- **Github Repository:** https://github.com/eikek/docspell
- **Documentation:** https://docspell.org/docs/

# How Has This Been Tested?

- [x] App is working as expected. (_Container is alive and answering to requests_)
- [x] App use a dedicated folder in `/opt` directory.
- [x] App secured by Authelia SSO authentication system.
- [x] A subdomain is correctly created for the web-ui. (_via Cloudflare_)
- [x] Custom TimeZone is set to the container and application.
- [x] Custom UID/GID is set to the container to run under Saltbox user.
- [x] Healthcheck is added to the container.
- [x] Add a custom sub-role: Apache Solr