### PR TITLE
fix(tqm): add doc link to role

### DIFF
--- a/roles/tqm/tasks/main.yml
+++ b/roles/tqm/tasks/main.yml
@@ -57,7 +57,7 @@
 
 - name: "Fail when 'config.yml' is not present"
   ansible.builtin.fail:
-    msg: "You need to setup your config file. link_to_docs here"
+    msg: "You need to setup your config file. https://docs.saltbox.dev/sandbox/apps/tqm/"
   when: (not tqm_config.stat.exists) and (not continuous_integration)
 
 - name: Fail if 'download_client' has not been set


### PR DESCRIPTION
# Changes
Added doc url to tqm [docs](https://docs.saltbox.dev/sandbox/apps/tqm/) in the fail message when config is not present in app directory. 