### PR TITLE
Add-mqtt role to sandbox

### DIFF
--- a/roles/mqtt/defaults/main.yml
+++ b/roles/mqtt/defaults/main.yml
@@ -1,0 +1,118 @@
+##########################################################################
+# Title:            Sandbox: mqtt | Default Variables                    #
+# Author(s):        CHAIR/Raneydazed                                     #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+mqtt_name: mqtt
+
+################################
+# Paths
+################################
+
+mqtt_paths_folder: "{{ mqtt_name }}"
+mqtt_paths_location: "{{ server_appdata_path }}/{{ mqtt_paths_folder }}"
+mqtt_paths_folders_list:
+  - "{{ mqtt_paths_location }}/config"
+  - "{{ mqtt_paths_location }}/data"
+  - "{{ mqtt_paths_location }}/log"
+
+################################
+# Docker
+################################
+
+# Container
+mqtt_docker_container: "{{ mqtt_name }}"
+
+# Image
+mqtt_docker_image_pull: true
+mqtt_docker_image_tag: "latest"
+mqtt_docker_image: "eclipse-mosquitto:{{ mqtt_docker_image_tag }}"
+
+# Ports
+mqtt_docker_ports_defaults:
+  - "1883"
+  - "9001"
+
+mqtt_docker_ports: "{{ mqtt_docker_ports_defaults }}"
+
+# Envs
+mqtt_docker_envs_default:
+  TZ: "{{ tz }}"
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+mqtt_docker_envs_custom: {}
+mqtt_docker_envs: "{{ mqtt_docker_envs_default
+                      | combine(mqtt_docker_envs_custom) }}"
+
+# Commands
+mqtt_docker_commands_default: []
+mqtt_docker_commands_custom: []
+mqtt_docker_commands: "{{ mqtt_docker_commands_default
+                          + mqtt_docker_commands_custom }}"
+
+# Volumes
+mqtt_docker_volumes_default:
+  - "{{ mqtt_paths_location }}/config:/mosquitto/config"
+  - "{{ mqtt_paths_location }}/data:/mosquitto/data"
+  - "{{ mqtt_paths_location }}/log:/mosquitto/log"
+  - /etc/localtime:/etc/localtime:ro
+mqtt_docker_volumes_custom: []
+mqtt_docker_volumes: "{{ mqtt_docker_volumes_default
+                         + mqtt_docker_volumes_custom }}"
+
+# Devices
+mqtt_docker_devices_default: []
+mqtt_docker_devices_custom: []
+mqtt_docker_devices: "{{ mqtt_docker_devices_default
+                         + mqtt_docker_devices_custom }}"
+
+# Hosts
+mqtt_docker_hosts_default: []
+mqtt_docker_hosts_custom: []
+mqtt_docker_hosts: "{{ docker_hosts_common
+                       | combine(mqtt_docker_hosts_default)
+                       | combine(mqtt_docker_hosts_custom) }}"
+
+# Labels
+mqtt_docker_labels_default: {}
+mqtt_docker_labels_custom: {}
+mqtt_docker_labels: "{{ docker_labels_common
+                        | combine(mqtt_docker_labels_default)
+                        | combine(mqtt_docker_labels_custom) }}"
+
+# Hostname
+mqtt_docker_hostname: "{{ mqtt_name }}"
+
+# Networks
+mqtt_docker_networks_alias: "{{ mqtt_name }}"
+mqtt_docker_networks_default: []
+mqtt_docker_networks_custom: []
+mqtt_docker_networks: "{{ docker_networks_common
+                          + mqtt_docker_networks_default
+                          + mqtt_docker_networks_custom }}"
+
+# Capabilities
+mqtt_docker_capabilities_default: []
+mqtt_docker_capabilities_custom: []
+mqtt_docker_capabilities: "{{ mqtt_docker_capabilities_default
+                              + mqtt_docker_capabilities_custom }}"
+
+# Security Opts
+mqtt_docker_security_opts_default: []
+mqtt_docker_security_opts_custom: []
+mqtt_docker_security_opts: "{{ mqtt_docker_security_opts_default
+                               + mqtt_docker_security_opts_custom }}"
+
+# Restart Policy
+mqtt_docker_restart_policy: unless-stopped
+
+# State
+mqtt_docker_state: started

--- a/roles/mqtt/defaults/main.yml
+++ b/roles/mqtt/defaults/main.yml
@@ -19,6 +19,7 @@ mqtt_name: mqtt
 
 mqtt_paths_folder: "{{ mqtt_name }}"
 mqtt_paths_location: "{{ server_appdata_path }}/{{ mqtt_paths_folder }}"
+mqtt_paths_config_location: "{{ mqtt_paths_location }}/config/mosquitto.conf"
 mqtt_paths_folders_list:
   - "{{ mqtt_paths_location }}/config"
   - "{{ mqtt_paths_location }}/data"

--- a/roles/mqtt/tasks/main.yml
+++ b/roles/mqtt/tasks/main.yml
@@ -1,0 +1,27 @@
+#########################################################################
+# Title:            Sandbox: mqtt                                       #
+# Author(s):        CHAIR/Raneydazed                                    #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+
+- name: Chown '{{ mqtt_paths_location }}'
+  ansible.builtin.file:
+    path: "{{ mqtt_paths_location }}"
+    state: directory
+    recurse: true
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  when: (not continuous_integration)

--- a/roles/mqtt/tasks/main.yml
+++ b/roles/mqtt/tasks/main.yml
@@ -13,6 +13,21 @@
 - name: Create directories
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
 
+- name: Check if `{{ mqtt_paths_config_location | basename }}` exists
+  ansible.builtin.stat:
+    path: "{{ mqtt_paths_config_location }}"
+  register: mqtt_config
+
+- name: Import default config
+  ansible.builtin.template:
+    src: mosquitto.conf.j2
+    dest: "{{ mqtt_paths_config_location }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0775
+
+  when: (not mqtt_config.stat.exists) and (not continuous_integration)
+
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
 

--- a/roles/mqtt/templates/mosquitto.conf.j2
+++ b/roles/mqtt/templates/mosquitto.conf.j2
@@ -1,0 +1,6 @@
+persistence true
+persistence_location /mosquitto/data/
+log_dest file /mosquitto/log/mosquitto.log
+log_type all
+listener 1883
+allow_anonymous true

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -86,6 +86,7 @@
     - { role: minecraft_bedrock, tags: ['minecraft-bedrock'] }
     - { role: monitorr, tags: ['monitorr'] }
     - { role: moviematch, tags: ['moviematch'] }
+    - { role: mqtt, tags: ['mqtt'] }
     - { role: mylar3, tags: ['mylar3'] }
     - { role: n8n, tags: ['n8n'] }
     - { role: navidrome, tags: ['navidrome'] }


### PR DESCRIPTION
# Description

Adding a role for [mqtt](https://mqtt.org/) aka mosquitto, for use with homeassistant, node red, home bridge, and various other home based applications. 

### From the website: 

MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). It is designed as an extremely lightweight publish/subscribe messaging transport that is ideal for connecting remote devices with a small code footprint and minimal network bandwidth. MQTT today is used in a wide variety of industries, such as automotive, manufacturing, telecommunications, oil and gas, etc.

# How Has This Been Tested?

I tested this pretty widely on my home server for a few months, and after a bit of tweaking the role, I think its ready to go. Obviously feel free to critique, or ask for closure of the pr if you think it unnecesarry. I have tested the role on my home server as well as on my hetzner server. 

- [x] Tested on local home server with home assistant
- [x] Tested on Hetzner server
- [x] Confirmed working container on both servers
