### PR TITLE
fix(paperless): replace autologin with remote-user, add allowed hosts entries

### DIFF
--- a/roles/paperless_ngx/defaults/main.yml
+++ b/roles/paperless_ngx/defaults/main.yml
@@ -104,7 +104,7 @@ paperless_ngx_docker_envs_default:
   PAPERLESS_TIKA_ENABLED: "1"
   PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://{{ paperless_ngx_name }}_gotenberg:3000
   PAPERLESS_TIKA_ENDPOINT: "http://{{ paperless_ngx_name }}_tika:9998"
-  PAPERLESS_AUTO_LOGIN_USERNAME: "{{ user.name }}"
+  PAPERLESS_ENABLE_HTTP_REMOTE_USER: "true"
   PAPERLESS_ADMIN_USER: "{{ user.name }}"
   PAPERLESS_ADMIN_PASSWORD: "{{ user.pass }}"
   PAPERLESS_SECRET_KEY: "{{ paperless_ngx_secret_key.stdout }}"

--- a/roles/paperless_ngx/defaults/main.yml
+++ b/roles/paperless_ngx/defaults/main.yml
@@ -108,6 +108,9 @@ paperless_ngx_docker_envs_default:
   PAPERLESS_ADMIN_USER: "{{ user.name }}"
   PAPERLESS_ADMIN_PASSWORD: "{{ user.pass }}"
   PAPERLESS_SECRET_KEY: "{{ paperless_ngx_secret_key.stdout }}"
+  PAPERLESS_ALLOWED_HOSTS: "*"
+  PAPERLESS_CORS_ALLOWED_HOSTS: "http://127.0.0.1,http://::1,http://traefik,http://{{ paperless_ngx_name }},{{ paperless_ngx_web_url }}"
+  PAPERLESS_CSRF_TRUSTED_ORIGINS: "http://127.0.0.1,http://::1,http://traefik,http://{{ paperless_ngx_name }},{{ paperless_ngx_web_url }}"
 paperless_ngx_docker_envs_custom: {}
 paperless_ngx_docker_envs: "{{ paperless_ngx_docker_envs_default
                                | combine(paperless_ngx_docker_envs_custom) }}"


### PR DESCRIPTION
Fix problems with mobile apps (iOS/Android) and usage of API.

Auto Login is replaced with Remote-User (bug encountered for API usage: https://github.com/paperless-ngx/paperless-ngx/issues/2075)