### PR TITLE
nextcloud add check_data_directory_permissions when "nextcloud_skip_data_directory_permissions_check: true" specified 

### DIFF
--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -7,22 +7,47 @@
 #                   GNU General Public License v3.0                     #
 #########################################################################
 ---
-- name: MariaDB Role
+- name: Nextcloud | MariaDB Role
   ansible.builtin.include_role:
     name: mariadb
 
-- name: Add DNS record
+- name: Nextcloud | Nextcloud | Add DNS record
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
   vars:
     dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
     dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
     dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
 
-- name: Remove existing Docker container
+- name: Nextcloud | Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 
-- name: Create directories
+- name: Nextcloud | Create directories
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
 
-- name: Create Docker container
+- name: Nextcloud | Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+
+- name: Nextcloud | 'add check_data_directory_permissions flag to nextcloud config/config.php'
+  block:
+
+    - name: Nextcloud | | Set '_nextcloud_config_path' variable
+      ansible.builtin.set_fact:
+        _nextcloud_config_path: "{{ nextcloud_paths_location }}/config/config.php"
+
+    - name: Nextcloud | Wait for 'config.php' to be created
+      ansible.builtin.wait_for:
+        path: "{{ _nextcloud_config_path }}"
+        state: present
+        timeout: 120
+
+    - name: "Nextcloud | set check_data_directory_permissions to false"
+      ansible.builtin.lineinfile:
+        path: "{{ _nextcloud_config_path }}"
+        insertbefore: '^(\s*)\);(\s*)$'
+        search_string: "check_data_directory_permissions"
+        line: "  'check_data_directory_permissions' => false,"
+
+    - name: Restart Docker container
+      ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/restart_docker_container.yml"
+  
+  when: (not continuous_integration) and (nextcloud_skip_data_directory_permissions_check is defined) and (nextcloud_skip_data_directory_permissions_check)


### PR DESCRIPTION

update nextcloud to use flag nextcloud_skip_data_directory_permissions_check to skip data folder permission check

# Description
This for adding `'check_data_directory_permissions' => true,` into config/config.php of nextcloud, to bypass permission check error, which may not always feasible especially under rclone mount. 

the original error reads:
```
Your data directory is readable by other users.
Please change the permissions to 0770 so that the directory cannot be listed by other users.
```
solution: [link](https://github.com/nextcloud/server/blob/c364b0cb193f66ad15e2950c27113b40037d1bf6/config/config.sample.php#L747-L757)

# How Has This Been Tested?

tested the following scenarios
 - clean install nextcloud (check_data_directory_permissions not present in config.php)
 - re-run nextcloud tag with existing check_data_directory_permissions flag 

- [x] This is not a test I performed