### PR TITLE
Update minecraft role main.yml

### DIFF
--- a/roles/minecraft/defaults/main.yml
+++ b/roles/minecraft/defaults/main.yml
@@ -36,7 +36,7 @@ minecraft_web_domain: "{{ user.domain }}"
 
 minecraft_dns_record: "{{ lookup('vars', minecraft_name + '_web_subdomain', default=minecraft_web_subdomain) }}"
 minecraft_dns_zone: "{{ minecraft_web_domain }}"
-minecraft_dns_proxy: "false"
+minecraft_dns_proxy: false
 
 ################################
 # Docker

--- a/roles/minecraft/defaults/main.yml
+++ b/roles/minecraft/defaults/main.yml
@@ -36,6 +36,7 @@ minecraft_web_domain: "{{ user.domain }}"
 
 minecraft_dns_record: "{{ lookup('vars', minecraft_name + '_web_subdomain', default=minecraft_web_subdomain) }}"
 minecraft_dns_zone: "{{ minecraft_web_domain }}"
+minecraft_dns_proxy: "false"
 
 ################################
 # Docker


### PR DESCRIPTION
# Description

added `minecraft_dns_proxy: "false"` to DNS section of the role. For anyone that has Proxy enabled, this role will not work at all as is. I'm sure it would be fine if we added it as `minecraft_dns_proxy: "{{ dns.proxied }}"` as long as we update the docs?

# How Has This Been Tested?

- [x] I tested this on 2 different servers
