### PR TITLE
use authelia for `stash` by default

### DIFF
--- a/roles/stash/defaults/main.yml
+++ b/roles/stash/defaults/main.yml
@@ -48,7 +48,7 @@ stash_dns_proxy: "{{ dns.proxied }}"
 # Traefik
 ################################
 
-stash_traefik_sso_middleware: ""
+stash_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
 stash_traefik_middleware_default: "{{ traefik_default_middleware + ','
                                       + lookup('vars', stash_name + '_traefik_sso_middleware', default=stash_traefik_sso_middleware)
                                    if (lookup('vars', stash_name + '_traefik_sso_middleware', default=stash_traefik_sso_middleware) | length > 0)


### PR DESCRIPTION
# Description

Stash is an organizer for porn. 
Since no sane person would want their personal porn collection accessible by anyone on the internet, the default should be to protect it with authelia.
Currently, the stash role isn't protected by authelia and the built-in auth isn't configured. This means that any rando can potentially take destructive actions like deleting stash's database or deleting files. 
This PR addresses this by adding authelia to `stash` in the defaults.

# How Has This Been Tested?

Since this is a one-line trivial edit I've not tested it.
