### PR TITLE
Minecraft: fix dns_proxy

### DIFF
--- a/roles/minecraft/tasks/main2.yml
+++ b/roles/minecraft/tasks/main2.yml
@@ -12,6 +12,7 @@
   vars:
     dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
     dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
 
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"


### PR DESCRIPTION
# Description

After deploying the minecraft role several times, the CloudFlare proxy reactivated each time.
After checking the ansible task, I saw that the dns_proxy is not defined. 

# How Has This Been Tested?

- [x] Tested on my  dedicated server 