### PR TITLE
Remove additional space leading to crash of transmission-daemon

### DIFF
--- a/roles/transmissionvpn/defaults/main.yml
+++ b/roles/transmissionvpn/defaults/main.yml
@@ -89,7 +89,7 @@ transmissionvpn_docker_envs_default:
   OPENVPN_USERNAME: "{{ transmissionvpn.vpn_user | default('username', true) }}"
   OPENVPN_PASSWORD: "{{ transmissionvpn.vpn_pass | default('password', true) }}"
   UMASK_SET: "{{ transmissionvpn_umask_set }}"
-  CREATE_TUN_DEVICE: " {{ transmissionvpn_create_tun_device }}"
+  CREATE_TUN_DEVICE: "{{ transmissionvpn_create_tun_device }}"
   TRANSMISSION_HOME: "{{ transmissionvpn_transmission_home }}"
 
 transmissionvpn_docker_envs_custom: {}

--- a/roles/transmissionvpn/defaults/main.yml
+++ b/roles/transmissionvpn/defaults/main.yml
@@ -90,7 +90,7 @@ transmissionvpn_docker_envs_default:
   OPENVPN_PASSWORD: "{{ transmissionvpn.vpn_pass | default('password', true) }}"
   UMASK_SET: "{{ transmissionvpn_umask_set }}"
   CREATE_TUN_DEVICE: " {{ transmissionvpn_create_tun_device }}"
-  TRANSMISSION_HOME: " {{ transmissionvpn_transmission_home }}"
+  TRANSMISSION_HOME: "{{ transmissionvpn_transmission_home }}"
 
 transmissionvpn_docker_envs_custom: {}
 transmissionvpn_docker_envs: "{{ transmissionvpn_docker_envs_default


### PR DESCRIPTION
Removing additional space as it causes "/etc/transmission/environment-variables.sh: line 20: export: `/opt/transmissionvpn': not a valid identifier" error

With the space, TransmissionVPN would continuously error out on "[2023-02-05 12:26:34.881] transmission-remote:  (http://localhost:9091/transmission/rpc/) Couldn't connect to server" meaning the container would not run. 