### PR TITLE
Add Codex

### DIFF
--- a/roles/codex/defaults/main.yml
+++ b/roles/codex/defaults/main.yml
@@ -99,7 +99,6 @@ codex_docker_commands: "{{ lookup('vars', codex_name + '_docker_commands_default
 # Volumes
 codex_docker_volumes_default:
   - "{{ codex_paths_location }}:/config"
-  - "/mnt:/mnt"
 codex_docker_volumes_custom: []
 codex_docker_volumes: "{{ lookup('vars', codex_name + '_docker_volumes_default', default=codex_docker_volumes_default)
                           + lookup('vars', codex_name + '_docker_volumes_custom', default=codex_docker_volumes_custom) }}"

--- a/roles/codex/defaults/main.yml
+++ b/roles/codex/defaults/main.yml
@@ -31,7 +31,7 @@ codex_web_subdomain: "{{ codex_name }}"
 codex_web_domain: "{{ user.domain }}"
 codex_web_port: "9810"
 codex_web_url: "{{ 'https://' + lookup('vars', codex_name + '_web_subdomain', default=codex_web_subdomain)
-                    + '.' + lookup('vars', codex_name + '_web_domain', default=codex_web_domain) }}"
+                   + '.' + lookup('vars', codex_name + '_web_domain', default=codex_web_domain) }}"
 
 ################################
 # DNS

--- a/roles/codex/defaults/main.yml
+++ b/roles/codex/defaults/main.yml
@@ -22,7 +22,6 @@ codex_paths_location: "{{ server_appdata_path }}/{{ codex_paths_folder }}"
 codex_paths_folders_list:
   - "{{ codex_paths_location }}"
   - "{{ codex_paths_location }}/config"
-  - "/mnt/unionfs/Media/Comics"
 
 ################################
 # Web
@@ -100,7 +99,7 @@ codex_docker_commands: "{{ lookup('vars', codex_name + '_docker_commands_default
 # Volumes
 codex_docker_volumes_default:
   - "{{ codex_paths_location }}:/config"
-  - "/mnt/unionfs/Media/Comics:/comics"
+  - "/mnt:/mnt"
 codex_docker_volumes_custom: []
 codex_docker_volumes: "{{ lookup('vars', codex_name + '_docker_volumes_default', default=codex_docker_volumes_default)
                           + lookup('vars', codex_name + '_docker_volumes_custom', default=codex_docker_volumes_custom) }}"

--- a/roles/codex/defaults/main.yml
+++ b/roles/codex/defaults/main.yml
@@ -84,8 +84,8 @@ codex_docker_ports: "{{ lookup('vars', codex_name + '_docker_ports_defaults', de
 
 # Envs
 codex_docker_envs_default:
-  UID: "{{ uid }}"
-  GID: "{{ gid }}"
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
   TZ: "{{ tz }}"
 codex_docker_envs_custom: {}
 codex_docker_envs: "{{ lookup('vars', codex_name + '_docker_envs_default', default=codex_docker_envs_default)
@@ -99,7 +99,7 @@ codex_docker_commands: "{{ lookup('vars', codex_name + '_docker_commands_default
 
 # Volumes
 codex_docker_volumes_default:
-  - "{{ codex_paths_location }}/config:/config"
+  - "{{ codex_paths_location }}:/config"
   - "/mnt/unionfs/Media/Comics:/comics"
 codex_docker_volumes_custom: []
 codex_docker_volumes: "{{ lookup('vars', codex_name + '_docker_volumes_default', default=codex_docker_volumes_default)

--- a/roles/codex/defaults/main.yml
+++ b/roles/codex/defaults/main.yml
@@ -1,0 +1,155 @@
+##########################################################################
+# Title:            Sandbox: Codex            | Default Variables        #
+# Author(s):        CHAIR/Raneydazed                                     #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+codex_name: codex
+
+################################
+# Paths
+################################
+
+codex_paths_folder: "{{ codex_name }}"
+codex_paths_location: "{{ server_appdata_path }}/{{ codex_paths_folder }}"
+codex_paths_folders_list:
+  - "{{ codex_paths_location }}"
+  - "{{ codex_paths_location }}/config"
+  - "/mnt/unionfs/Media/Comics"
+
+################################
+# Web
+################################
+
+codex_web_subdomain: "{{ codex_name }}"
+codex_web_domain: "{{ user.domain }}"
+codex_web_port: "9810"
+codex_web_url: "{{ 'https://' + lookup('vars', codex_name + '_web_subdomain', default=codex_web_subdomain)
+                    + '.' + lookup('vars', codex_name + '_web_domain', default=codex_web_domain) }}"
+
+################################
+# DNS
+################################
+
+codex_dns_record: "{{ lookup('vars', codex_name + '_web_subdomain', default=codex_web_subdomain) }}"
+codex_dns_zone: "{{ lookup('vars', codex_name + '_web_domain', default=codex_web_domain) }}"
+codex_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+codex_traefik_sso_middleware: ""
+
+codex_traefik_middleware_default: "{{ traefik_default_middleware + ','
+                                      + lookup('vars', codex_name + '_traefik_sso_middleware', default=codex_traefik_sso_middleware)
+                                   if (lookup('vars', codex_name + '_traefik_sso_middleware', default=codex_traefik_sso_middleware) | length > 0)
+                                   else traefik_default_middleware }}"
+codex_traefik_middleware_custom: ""
+codex_traefik_middleware: "{{ codex_traefik_middleware_default + ','
+                              + codex_traefik_middleware_custom
+                           if (not codex_traefik_middleware_custom.startswith(',') and codex_traefik_middleware_custom | length > 0)
+                           else codex_traefik_middleware_default
+                              + codex_traefik_middleware_custom }}"
+
+codex_traefik_certresolver: "{{ traefik_default_certresolver }}"
+codex_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+codex_docker_container: "{{ codex_name }}"
+
+# Image
+codex_docker_image_pull: true
+codex_docker_image_repo: "docker.io/ajslater/codex"
+codex_docker_image_tag: "latest"
+codex_docker_image: "{{ lookup('vars', codex_name + '_docker_image_repo', default=codex_docker_image_repo)
+                        + ':' + lookup('vars', codex_name + '_docker_image_tag', default=codex_docker_image_tag) }}"
+
+# Ports
+codex_docker_ports_defaults: []
+codex_docker_ports_custom: []
+codex_docker_ports: "{{ lookup('vars', codex_name + '_docker_ports_defaults', default=codex_docker_ports_defaults)
+                        + lookup('vars', codex_name + '_docker_ports_custom', default=codex_docker_ports_custom) }}"
+
+# Envs
+codex_docker_envs_default:
+  UID: "{{ uid }}"
+  GID: "{{ gid }}"
+  TZ: "{{ tz }}"
+codex_docker_envs_custom: {}
+codex_docker_envs: "{{ lookup('vars', codex_name + '_docker_envs_default', default=codex_docker_envs_default)
+                       | combine(lookup('vars', codex_name + '_docker_envs_custom', default=codex_docker_envs_custom)) }}"
+
+# Commands
+codex_docker_commands_default: []
+codex_docker_commands_custom: []
+codex_docker_commands: "{{ lookup('vars', codex_name + '_docker_commands_default', default=codex_docker_commands_default)
+                           + lookup('vars', codex_name + '_docker_docker_commands_custom', default=codex_docker_commands_custom) }}"
+
+# Volumes
+codex_docker_volumes_default:
+  - "{{ codex_paths_location }}/config:/config"
+  - "/mnt/unionfs/Media/Comics:/comics"
+codex_docker_volumes_custom: []
+codex_docker_volumes: "{{ lookup('vars', codex_name + '_docker_volumes_default', default=codex_docker_volumes_default)
+                          + lookup('vars', codex_name + '_docker_volumes_custom', default=codex_docker_volumes_custom) }}"
+
+# Devices
+codex_docker_devices_default: []
+codex_docker_devices_custom: []
+codex_docker_devices: "{{ lookup('vars', codex_name + '_docker_devices_default', default=codex_docker_devices_default)
+                          + lookup('vars', codex_name + '_docker_devices_custom', default=codex_docker_devices_custom) }}"
+
+# Hosts
+codex_docker_hosts_default: []
+codex_docker_hosts_custom: []
+codex_docker_hosts: "{{ docker_hosts_common
+                        | combine(lookup('vars', codex_name + '_docker_hosts_default', default=codex_docker_hosts_default))
+                        | combine(lookup('vars', codex_name + '_docker_hosts_custom', default=codex_docker_hosts_custom)) }}"
+
+# Labels
+codex_docker_labels_default: {}
+codex_docker_labels_custom: {}
+codex_docker_labels: "{{ docker_labels_common
+                         | combine(lookup('vars', codex_name + '_docker_labels_default', default=codex_docker_labels_default))
+                         | combine(lookup('vars', codex_name + '_docker_labels_custom', default=codex_docker_labels_custom)) }}"
+
+# Hostname
+codex_docker_hostname: "{{ codex_name }}"
+
+# Networks
+codex_docker_networks_alias: "{{ codex_name }}"
+codex_docker_networks_default: []
+codex_docker_networks_custom: []
+codex_docker_networks: "{{ docker_networks_common
+                           + lookup('vars', codex_name + '_docker_networks_default', default=codex_docker_networks_default)
+                           + lookup('vars', codex_name + '_docker_networks_custom', default=codex_docker_networks_custom) }}"
+
+# Capabilities
+codex_docker_capabilities_default: []
+codex_docker_capabilities_custom: []
+codex_docker_capabilities: "{{ lookup('vars', codex_name + '_docker_capabilities_default', default=codex_docker_capabilities_default)
+                               + lookup('vars', codex_name + '_docker_capabilities_custom', default=codex_docker_capabilities_custom) }}"
+
+# Security Opts
+codex_docker_security_opts_default: []
+codex_docker_security_opts_custom: []
+codex_docker_security_opts: "{{ lookup('vars', codex_name + '_docker_security_opts_default', default=codex_docker_security_opts_default)
+                                + lookup('vars', codex_name + '_docker_security_opts_custom', default=codex_docker_security_opts_custom) }}"
+
+# Restart Policy
+codex_docker_restart_policy: unless-stopped
+
+# State
+codex_docker_state: started

--- a/roles/codex/tasks/main.yml
+++ b/roles/codex/tasks/main.yml
@@ -1,0 +1,24 @@
+##########################################################################
+# Title:            Sandbox: Codex                                       #
+# Author(s):        CHAIR/Raneydazed                                     #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -36,6 +36,7 @@
     - { role: changedetection, tags: ['changedetection'] }
     - { role: cherry, tags: ['cherry'] }
     - { role: coder, tags: ['coder'] }
+    - { role: codex, tags: ['codex'] }
     - { role: code_server, tags: ['code_server'] }
     - { role: comicstreamer, tags: ['comicstreamer'] }
     - { role: comixed, tags: ['comixed'] }


### PR DESCRIPTION
# Description

Adding Codex, as recently requested. It adds the volume, `/comics` to `/mnt/unionfs/Media/Comics` as currently written. 

# How Has This Been Tested?

Installed via docker compose initially, then installed via saltbox_mod. That is how I'm currently running it. Works fine and I've not gotten any errors so far. the user mapping seems to be working fine, and its still scanning my comic directory. 

- [x] Tested on my feeder, and tested on my aio/mediabox.