### PR TITLE
[thelounge] Enable access to uploads

### DIFF
--- a/roles/thelounge/defaults/main.yml
+++ b/roles/thelounge/defaults/main.yml
@@ -56,6 +56,8 @@ thelounge_traefik_middleware: "{{ thelounge_traefik_middleware_default + ','
                                   + thelounge_traefik_middleware_custom }}"
 thelounge_traefik_certresolver: "{{ traefik_default_certresolver }}"
 thelounge_traefik_enabled: true
+thelounge_traefik_api_enabled: true
+thelounge_traefik_api_endpoint: "`/uploads`"
 
 ################################
 # Docker


### PR DESCRIPTION
Adds api endpoint `/uploads`.

# Description

Discord user Muppet requested that uploads be available outside of authelia when configured.
https://discord.com/channels/853755447970758686/944260106852368384/1095130701524914226

# How Has This Been Tested?

- [x] Tested on my production installation of The Lounge.