### PR TITLE
Change Komga docker port to the new Komga default.

### DIFF
--- a/roles/komga/defaults/main.yml
+++ b/roles/komga/defaults/main.yml
@@ -29,7 +29,7 @@ komga_paths_folders_list:
 
 komga_web_subdomain: "{{ komga_name }}"
 komga_web_domain: "{{ user.domain }}"
-komga_web_port: "8080"
+komga_web_port: "25600"
 komga_web_url: "{{ 'https://' + komga_web_subdomain + '.' + komga_web_domain }}"
 
 ################################


### PR DESCRIPTION
# Description

[Komga has changed their default port from 8080 to 25600](https://komga.org/installation/upgrade.html), to make sure there aren't any issues we can either change the docker port, like I've done here, or pre-create a config specifying the 8080 server port and move it to /opt/komga. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.  You can use the checkboxes below or delete them as you wish.

- [x] Ran the role on my server with this change to verify it did not cause any issues. 
