### PR TITLE
fix(code-server): mount the correct folders inside the container

### DIFF
--- a/roles/code_server/defaults/main.yml
+++ b/roles/code_server/defaults/main.yml
@@ -24,7 +24,7 @@ code_server_paths_folders_list:
   - "{{ code_server_paths_location }}/project"
   - "{{ code_server_paths_location }}/.config"
   - "{{ code_server_paths_location }}/.local"
-  
+
 ################################
 # Web
 ################################

--- a/roles/code_server/defaults/main.yml
+++ b/roles/code_server/defaults/main.yml
@@ -23,7 +23,8 @@ code_server_paths_folders_list:
   - "{{ code_server_paths_location }}"
   - "{{ code_server_paths_location }}/project"
   - "{{ code_server_paths_location }}/.config"
-
+  - "{{ code_server_paths_location }}/.local"
+  
 ################################
 # Web
 ################################
@@ -87,6 +88,7 @@ code_server_docker_commands: "{{ code_server_docker_commands_default
 code_server_docker_volumes_default:
   - "{{ code_server_paths_location }}/project:/home/coder/project"
   - "{{ code_server_paths_location }}/.config:/home/coder/.config"
+  - "{{ code_server_paths_location }}/.local:/home/coder/.local"
   - "{{ server_appdata_path }}:/host_opt"
 code_server_docker_volumes_custom: []
 code_server_docker_volumes: "{{ code_server_docker_volumes_default

--- a/roles/code_server/defaults/main.yml
+++ b/roles/code_server/defaults/main.yml
@@ -23,7 +23,6 @@ code_server_paths_folders_list:
   - "{{ code_server_paths_location }}"
   - "{{ code_server_paths_location }}/project"
   - "{{ code_server_paths_location }}/.config"
-  - "{{ code_server_paths_location }}/.local"
 
 ################################
 # Web
@@ -86,9 +85,8 @@ code_server_docker_commands: "{{ code_server_docker_commands_default
 
 # Volumes
 code_server_docker_volumes_default:
-  - "{{ code_server_paths_location }}/project:/home/code_server/project"
-  - "{{ code_server_paths_location }}/.config:/home/code_server/.config"
-  - "{{ code_server_paths_location }}/.local:/home/code_server/.local"
+  - "{{ code_server_paths_location }}/project:/home/coder/project"
+  - "{{ code_server_paths_location }}/.config:/home/coder/.config"
   - "{{ server_appdata_path }}:/host_opt"
 code_server_docker_volumes_custom: []
 code_server_docker_volumes: "{{ code_server_docker_volumes_default


### PR DESCRIPTION
# Description

As discussed in #sandbox-dev, the default bind mounts inside the container for the code-server role are currently wrong, this PR corrects them.
`/home/code-server/[...]` paths have been renamed to `/home/coder/[...]` while the `.local` one has been removed since it's not mentioned in the [official docs](https://coder.com/docs/code-server/latest/install#docker).

# How has this been tested?

Untested.
