### PR TITLE
Add Role: Discoflix

### DIFF
--- a/roles/discoflix/defaults/main.yml
+++ b/roles/discoflix/defaults/main.yml
@@ -45,8 +45,8 @@ discoflix_dns_proxy: "{{ dns.proxied }}"
 
 discoflix_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
 discoflix_traefik_middleware: "{{ traefik_default_middleware + ',' + discoflix_traefik_sso_middleware
-                           if (discoflix_traefik_sso_middleware | length > 0)
-                           else traefik_default_middleware }}"
+                               if (discoflix_traefik_sso_middleware | length > 0)
+                               else traefik_default_middleware }}"
 discoflix_traefik_certresolver: "{{ traefik_default_certresolver }}"
 discoflix_traefik_enabled: true
 ################################
@@ -65,19 +65,19 @@ discoflix_docker_image: "nickheyer/discoflix:{{ discoflix_docker_image_tag }}"
 discoflix_docker_ports_defaults: []
 discoflix_docker_ports_custom: []
 discoflix_docker_ports: "{{ discoflix_docker_ports_defaults
-                          + discoflix_docker_ports_custom }}"
+                            + discoflix_docker_ports_custom }}"
 
 # Envs
 discoflix_docker_envs_default: {"internal_df_url" : "http://{{ discoflix_name }}:{{ discoflix_web_port }}"}
 discoflix_docker_envs_custom: {}
 discoflix_docker_envs: "{{ discoflix_docker_envs_default
-                         | combine(discoflix_docker_envs_custom) }}"
+                           | combine(discoflix_docker_envs_custom) }}"
 
 # Commands
 discoflix_docker_commands_default: []
 discoflix_docker_commands_custom: []
 discoflix_docker_commands: "{{ discoflix_docker_commands_default
-                             + discoflix_docker_commands_custom }}"
+                               + discoflix_docker_commands_custom }}"
 
 # Volumes
 discoflix_docker_volumes_default:
@@ -85,27 +85,27 @@ discoflix_docker_volumes_default:
   - "{{ discoflix_paths_location }}/log:/app/log"
 discoflix_docker_volumes_custom: []
 discoflix_docker_volumes: "{{ discoflix_docker_volumes_default
-                            + discoflix_docker_volumes_custom }}"
+                              + discoflix_docker_volumes_custom }}"
 
 # Devices
 discoflix_docker_devices_default: []
 discoflix_docker_devices_custom: []
 discoflix_docker_devices: "{{ discoflix_docker_devices_default
-                            + discoflix_docker_devices_custom }}"
+                              + discoflix_docker_devices_custom }}"
 
 # Hosts
 discoflix_docker_hosts_default: []
 discoflix_docker_hosts_custom: []
 discoflix_docker_hosts: "{{ docker_hosts_common
-                          | combine(discoflix_docker_hosts_default)
-                          | combine(discoflix_docker_hosts_custom) }}"
+                            | combine(discoflix_docker_hosts_default)
+                            | combine(discoflix_docker_hosts_custom) }}"
 
 # Labels
 discoflix_docker_labels_default: {}
 discoflix_docker_labels_custom: {}
 discoflix_docker_labels: "{{ docker_labels_common
-                           | combine(discoflix_docker_labels_default)
-                           | combine(discoflix_docker_labels_custom) }}"
+                             | combine(discoflix_docker_labels_default)
+                             | combine(discoflix_docker_labels_custom) }}"
 
 # Hostname
 discoflix_docker_hostname: "{{ discoflix_name }}"
@@ -115,8 +115,8 @@ discoflix_docker_networks_alias: "{{ discoflix_name }}"
 discoflix_docker_networks_default: []
 discoflix_docker_networks_custom: []
 discoflix_docker_networks: "{{ docker_networks_common
-                             + discoflix_docker_networks_default
-                             + discoflix_docker_networks_custom }}"
+                               + discoflix_docker_networks_default
+                               + discoflix_docker_networks_custom }}"
 
 # Capabilities
 discoflix_docker_capabilities_default: []
@@ -128,7 +128,7 @@ discoflix_docker_capabilities: "{{ discoflix_docker_capabilities_default
 discoflix_docker_security_opts_default: []
 discoflix_docker_security_opts_custom: []
 discoflix_docker_security_opts: "{{ discoflix_docker_security_opts_default
-                                  + discoflix_docker_security_opts_custom }}"
+                                    + discoflix_docker_security_opts_custom }}"
 
 # Restart Policy
 discoflix_docker_restart_policy: unless-stopped

--- a/roles/discoflix/defaults/main.yml
+++ b/roles/discoflix/defaults/main.yml
@@ -45,13 +45,10 @@ discoflix_dns_proxy: "{{ dns.proxied }}"
 
 discoflix_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
 discoflix_traefik_middleware: "{{ traefik_default_middleware + ',' + discoflix_traefik_sso_middleware
-                            if (discoflix_traefik_sso_middleware | length > 0)
-                            else traefik_default_middleware }}"
+                           if (discoflix_traefik_sso_middleware | length > 0)
+                           else traefik_default_middleware }}"
 discoflix_traefik_certresolver: "{{ traefik_default_certresolver }}"
 discoflix_traefik_enabled: true
-discoflix_traefik_api_enabled: true
-discoflix_traefik_api_endpoint: "`/join`,`/j`,`/setup`,`/static`"
-
 ################################
 # Docker
 ################################
@@ -68,48 +65,47 @@ discoflix_docker_image: "nickheyer/discoflix:{{ discoflix_docker_image_tag }}"
 discoflix_docker_ports_defaults: []
 discoflix_docker_ports_custom: []
 discoflix_docker_ports: "{{ discoflix_docker_ports_defaults
-                         + discoflix_docker_ports_custom }}"
+                          + discoflix_docker_ports_custom }}"
 
 # Envs
-discoflix_docker_envs_default:
-  APP_URL: "{{ discoflix_web_url }}"
-  DISABLE_BUILTIN_AUTH: "true"
+discoflix_docker_envs_default: {"internal_df_url" : "http://{{ discoflix_name }}:{{ discoflix_web_port }}"}
 discoflix_docker_envs_custom: {}
 discoflix_docker_envs: "{{ discoflix_docker_envs_default
-                        | combine(discoflix_docker_envs_custom) }}"
+                         | combine(discoflix_docker_envs_custom) }}"
 
 # Commands
 discoflix_docker_commands_default: []
 discoflix_docker_commands_custom: []
 discoflix_docker_commands: "{{ discoflix_docker_commands_default
-                            + discoflix_docker_commands_custom }}"
+                             + discoflix_docker_commands_custom }}"
 
 # Volumes
 discoflix_docker_volumes_default:
-  - "{{ discoflix_paths_location }}:/data/database"
+  - "{{ discoflix_paths_location }}/db:/app/data"
+  - "{{ discoflix_paths_location }}/log:/app/log"
 discoflix_docker_volumes_custom: []
 discoflix_docker_volumes: "{{ discoflix_docker_volumes_default
-                           + discoflix_docker_volumes_custom }}"
+                            + discoflix_docker_volumes_custom }}"
 
 # Devices
 discoflix_docker_devices_default: []
 discoflix_docker_devices_custom: []
 discoflix_docker_devices: "{{ discoflix_docker_devices_default
-                           + discoflix_docker_devices_custom }}"
+                            + discoflix_docker_devices_custom }}"
 
 # Hosts
 discoflix_docker_hosts_default: []
 discoflix_docker_hosts_custom: []
 discoflix_docker_hosts: "{{ docker_hosts_common
-                         | combine(discoflix_docker_hosts_default)
-                         | combine(discoflix_docker_hosts_custom) }}"
+                          | combine(discoflix_docker_hosts_default)
+                          | combine(discoflix_docker_hosts_custom) }}"
 
 # Labels
 discoflix_docker_labels_default: {}
 discoflix_docker_labels_custom: {}
 discoflix_docker_labels: "{{ docker_labels_common
-                          | combine(discoflix_docker_labels_default)
-                          | combine(discoflix_docker_labels_custom) }}"
+                           | combine(discoflix_docker_labels_default)
+                           | combine(discoflix_docker_labels_custom) }}"
 
 # Hostname
 discoflix_docker_hostname: "{{ discoflix_name }}"
@@ -119,20 +115,20 @@ discoflix_docker_networks_alias: "{{ discoflix_name }}"
 discoflix_docker_networks_default: []
 discoflix_docker_networks_custom: []
 discoflix_docker_networks: "{{ docker_networks_common
-                            + discoflix_docker_networks_default
-                            + discoflix_docker_networks_custom }}"
+                             + discoflix_docker_networks_default
+                             + discoflix_docker_networks_custom }}"
 
 # Capabilities
 discoflix_docker_capabilities_default: []
 discoflix_docker_capabilities_custom: []
 discoflix_docker_capabilities: "{{ discoflix_docker_capabilities_default
-                                + discoflix_docker_capabilities_custom }}"
+                                 + discoflix_docker_capabilities_custom }}"
 
 # Security Opts
 discoflix_docker_security_opts_default: []
 discoflix_docker_security_opts_custom: []
 discoflix_docker_security_opts: "{{ discoflix_docker_security_opts_default
-                                 + discoflix_docker_security_opts_custom }}"
+                                  + discoflix_docker_security_opts_custom }}"
 
 # Restart Policy
 discoflix_docker_restart_policy: unless-stopped

--- a/roles/discoflix/defaults/main.yml
+++ b/roles/discoflix/defaults/main.yml
@@ -1,0 +1,141 @@
+##########################################################################
+# Title:         Sandbox: DiscoFlix | Default Variables                  #
+# Author(s):     nickheyer                                               #
+# URL:           https://github.com/saltyorg/Sandbox                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+discoflix_name: discoflix
+
+################################
+# Paths
+################################
+
+discoflix_paths_folder: "{{ discoflix_name }}"
+discoflix_paths_location: "{{ server_appdata_path }}/{{ discoflix_paths_folder }}"
+discoflix_paths_folders_list:
+  - "{{ discoflix_paths_location }}"
+
+################################
+# Web
+################################
+
+discoflix_web_subdomain: "{{ discoflix_name }}"
+discoflix_web_domain: "{{ user.domain }}"
+discoflix_web_port: "5454"
+discoflix_web_url: "{{ 'https://' + discoflix_web_subdomain + '.' + discoflix_web_domain }}"
+
+################################
+# DNS
+################################
+
+discoflix_dns_record: "{{ discoflix_web_subdomain }}"
+discoflix_dns_zone: "{{ discoflix_web_domain }}"
+discoflix_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+discoflix_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+discoflix_traefik_middleware: "{{ traefik_default_middleware + ',' + discoflix_traefik_sso_middleware
+                            if (discoflix_traefik_sso_middleware | length > 0)
+                            else traefik_default_middleware }}"
+discoflix_traefik_certresolver: "{{ traefik_default_certresolver }}"
+discoflix_traefik_enabled: true
+discoflix_traefik_api_enabled: true
+discoflix_traefik_api_endpoint: "`/join`,`/j`,`/setup`,`/static`"
+
+################################
+# Docker
+################################
+
+# Container
+discoflix_docker_container: "{{ discoflix_name }}"
+
+# Image
+discoflix_docker_image_pull: true
+discoflix_docker_image_tag: "latest"
+discoflix_docker_image: "nickheyer/discoflix:{{ discoflix_docker_image_tag }}"
+
+# Ports
+discoflix_docker_ports_defaults: []
+discoflix_docker_ports_custom: []
+discoflix_docker_ports: "{{ discoflix_docker_ports_defaults
+                         + discoflix_docker_ports_custom }}"
+
+# Envs
+discoflix_docker_envs_default:
+  APP_URL: "{{ discoflix_web_url }}"
+  DISABLE_BUILTIN_AUTH: "true"
+discoflix_docker_envs_custom: {}
+discoflix_docker_envs: "{{ discoflix_docker_envs_default
+                        | combine(discoflix_docker_envs_custom) }}"
+
+# Commands
+discoflix_docker_commands_default: []
+discoflix_docker_commands_custom: []
+discoflix_docker_commands: "{{ discoflix_docker_commands_default
+                            + discoflix_docker_commands_custom }}"
+
+# Volumes
+discoflix_docker_volumes_default:
+  - "{{ discoflix_paths_location }}:/data/database"
+discoflix_docker_volumes_custom: []
+discoflix_docker_volumes: "{{ discoflix_docker_volumes_default
+                           + discoflix_docker_volumes_custom }}"
+
+# Devices
+discoflix_docker_devices_default: []
+discoflix_docker_devices_custom: []
+discoflix_docker_devices: "{{ discoflix_docker_devices_default
+                           + discoflix_docker_devices_custom }}"
+
+# Hosts
+discoflix_docker_hosts_default: []
+discoflix_docker_hosts_custom: []
+discoflix_docker_hosts: "{{ docker_hosts_common
+                         | combine(discoflix_docker_hosts_default)
+                         | combine(discoflix_docker_hosts_custom) }}"
+
+# Labels
+discoflix_docker_labels_default: {}
+discoflix_docker_labels_custom: {}
+discoflix_docker_labels: "{{ docker_labels_common
+                          | combine(discoflix_docker_labels_default)
+                          | combine(discoflix_docker_labels_custom) }}"
+
+# Hostname
+discoflix_docker_hostname: "{{ discoflix_name }}"
+
+# Networks
+discoflix_docker_networks_alias: "{{ discoflix_name }}"
+discoflix_docker_networks_default: []
+discoflix_docker_networks_custom: []
+discoflix_docker_networks: "{{ docker_networks_common
+                            + discoflix_docker_networks_default
+                            + discoflix_docker_networks_custom }}"
+
+# Capabilities
+discoflix_docker_capabilities_default: []
+discoflix_docker_capabilities_custom: []
+discoflix_docker_capabilities: "{{ discoflix_docker_capabilities_default
+                                + discoflix_docker_capabilities_custom }}"
+
+# Security Opts
+discoflix_docker_security_opts_default: []
+discoflix_docker_security_opts_custom: []
+discoflix_docker_security_opts: "{{ discoflix_docker_security_opts_default
+                                 + discoflix_docker_security_opts_custom }}"
+
+# Restart Policy
+discoflix_docker_restart_policy: unless-stopped
+
+# State
+discoflix_docker_state: started

--- a/roles/discoflix/defaults/main.yml
+++ b/roles/discoflix/defaults/main.yml
@@ -68,7 +68,7 @@ discoflix_docker_ports: "{{ discoflix_docker_ports_defaults
                             + discoflix_docker_ports_custom }}"
 
 # Envs
-discoflix_docker_envs_default: {"internal_df_url" : "http://{{ discoflix_name }}:{{ discoflix_web_port }}"}
+discoflix_docker_envs_default: {"internal_df_url":"http://{{ discoflix_name }}:{{ discoflix_web_port }}"}
 discoflix_docker_envs_custom: {}
 discoflix_docker_envs: "{{ discoflix_docker_envs_default
                            | combine(discoflix_docker_envs_custom) }}"

--- a/roles/discoflix/tasks/main.yml
+++ b/roles/discoflix/tasks/main.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:         Sandbox: DiscoFlix                                     #
+# Author(s):     nickheyer                                              #
+# URL:           https://github.com/saltyorg/Sandbox                    #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -42,6 +42,7 @@
     - { role: dashy, tags: ['dashy'] }
     - { role: deemix, tags: ['deemix'] }
     - { role: delugevpn, tags: ['delugevpn'] }
+    - { role: discoflix, tags: ['discoflix'] }
     - { role: docspell, tags: ['docspell'] }
     - { role: doplarr, tags: ['doplarr'] }
     - { role: dozzle, tags: ['dozzle'] }


### PR DESCRIPTION
# Description

DiscoFlix is not only a Discord request bot that interfaces with Radarr & Sonarr, it's also a user management system, a REST API/DB, and a sleek WebUI - all of which run great with Sandbox.

For now, there are no default configurations provided to the DiscoFlix app upon install. Here is an example of how you would config for Radarr and Sonarr in Saltbox: 

![image](https://github.com/saltyorg/Sandbox/assets/60236014/33d404ea-cf3b-425a-8617-250d9a6f0c56)

Github: https://github.com/nickheyer/DiscoFlix
Docker Hub URL: https://hub.docker.com/repository/docker/nickheyer/discoflix
Docker Image: nickheyer/discoflix

# How Has This Been Tested?

These changes were tested on two machines:
1. A media server running saltbox that is currently in use
2. A second machine that I have setup for development

Currently unit/integration testing is not implemented for DiscoFlix, however I have a range of manual tests that I perform on each commit. The manual testing scope includes:
1. Changing values in the DB and WebUI while expecting either verbose error messages or continued operation.
2. Confirming appropriate permissible actions for each user depending on their level of permissions, ie: Owner, Developer, Admin, User, Non-user, etc.
3. Confirming user and server discovery via bot client works as intended.
4. and quite a bit more in terms of specific test cases.
