### PR TITLE
Add role: Maintainerr

### DIFF
--- a/roles/maintainerr/defaults/main.yml
+++ b/roles/maintainerr/defaults/main.yml
@@ -1,0 +1,185 @@
+##########################################################################
+# Title:         Saltbox: Maintainerr | Default Variables                #
+# Author(s):     dabigc                                                  #
+# URL:           https://github.com/saltyorg/Saltbox                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+maintainerr_instances: ["maintainerr"]
+
+################################
+# Paths
+################################
+
+maintainerr_paths_folder: "{{ maintainerr_name }}"
+maintainerr_paths_location: "{{ server_appdata_path }}/{{ maintainerr_paths_folder }}"
+maintainerr_paths_cache: "{{ maintainerr_paths_location }}/cache"
+maintainerr_paths_folders_list:
+  - "{{ maintainerr_paths_location }}"
+  - "{{ maintainerr_paths_cache }}"
+
+################################
+# Web
+################################
+
+maintainerr_web_subdomain: "{{ maintainerr_name }}"
+maintainerr_web_domain: "{{ user.domain }}"
+maintainerr_web_port: "80"
+maintainerr_web_url: "{{ 'https://' + lookup('vars', maintainerr_name + '_web_subdomain', default=maintainerr_web_subdomain)
+                       + '.' + lookup('vars', maintainerr_name + '_web_domain', default=maintainerr_web_domain) }}"
+
+################################
+# DNS
+################################
+
+maintainerr_dns_record: "{{ lookup('vars', maintainerr_name + '_web_subdomain', default=maintainerr_web_subdomain) }}"
+maintainerr_dns_zone: "{{ lookup('vars', maintainerr_name + '_web_domain', default=maintainerr_web_domain) }}"
+maintainerr_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Settings
+################################
+
+maintainerr_log_level: "info"
+
+################################
+# Traefik
+################################
+
+maintainerr_traefik_themepark_middleware: "{{ ',themepark-' + lookup('vars', maintainerr_name + '_name', default=maintainerr_name)
+                                         if (maintainerr_themepark_enabled and global_themepark_plugin_enabled)
+                                         else '' }}"
+maintainerr_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+maintainerr_traefik_middleware_default: "{{ traefik_default_middleware + ','
+                                         + lookup('vars', maintainerr_name + '_traefik_sso_middleware', default=maintainerr_traefik_sso_middleware)
+                                      if (lookup('vars', maintainerr_name + '_traefik_sso_middleware', default=maintainerr_traefik_sso_middleware) | length > 0)
+                                      else traefik_default_middleware }}"
+maintainerr_traefik_middleware_custom: ""
+maintainerr_traefik_middleware: "{{ maintainerr_traefik_middleware_default + ','
+                                  + maintainerr_traefik_middleware_custom + ','
+                                  + maintainerr_traefik_themepark_middleware
+                               if (not maintainerr_traefik_middleware_custom.startswith(',') and maintainerr_traefik_middleware_custom | length > 0)
+                               else maintainerr_traefik_middleware_default
+                                  + maintainerr_traefik_middleware_custom
+                                  + maintainerr_traefik_themepark_middleware }}"
+
+maintainerr_traefik_certresolver: "{{ traefik_default_certresolver }}"
+maintainerr_traefik_enabled: true
+
+################################
+# THEME
+################################
+
+# Options can be found at https://github.com/gilbN/theme.park
+maintainerr_themepark_enabled: false
+maintainerr_themepark_theme: "{{ global_themepark_theme }}"
+
+################################
+# Docker
+################################
+
+# Container
+maintainerr_docker_container: "{{ maintainerr_name }}"
+
+# Image
+maintainerr_docker_image_pull: true
+maintainerr_docker_image_repo: "jorenn92/maintainerr"
+maintainerr_docker_image_tag: "latest"
+maintainerr_docker_image: "{{ lookup('vars', maintainerr_name + '_docker_image_repo', default=maintainerr_docker_image_repo)
+                            + ':' + lookup('vars', maintainerr_name + '_docker_image_tag', default=maintainerr_docker_image_tag) }}"
+
+# Ports
+maintainerr_docker_ports_defaults: []
+maintainerr_docker_ports_custom: []
+maintainerr_docker_ports: "{{ lookup('vars', maintainerr_name + '_docker_ports_defaults', default=maintainerr_docker_ports_defaults)
+                            + lookup('vars', maintainerr_name + '_docker_ports_custom', default=maintainerr_docker_ports_custom) }}"
+
+# Envs
+maintainerr_docker_envs_default:
+  UMASK: "002"
+  TZ: "{{ tz }}"
+  LOG_LEVEL: "{{ maintainerr_log_level }}"
+maintainerr_docker_envs_custom: {}
+maintainerr_docker_envs: "{{ lookup('vars', maintainerr_name + '_docker_envs_default', default=maintainerr_docker_envs_default)
+                           | combine(lookup('vars', maintainerr_name + '_docker_envs_custom', default=maintainerr_docker_envs_custom)) }}"
+
+# Commands
+maintainerr_docker_commands_default: []
+maintainerr_docker_commands_custom: []
+maintainerr_docker_commands: "{{ lookup('vars', maintainerr_name + '_docker_commands_default', default=maintainerr_docker_commands_default)
+                               + lookup('vars', maintainerr_name + '_docker_docker_commands_custom', default=maintainerr_docker_commands_custom) }}"
+
+# Volumes
+maintainerr_docker_volumes_default:
+  - "{{ maintainerr_paths_location }}:/opt/data"
+maintainerr_docker_volumes_custom: []
+maintainerr_docker_volumes: "{{ lookup('vars', maintainerr_name + '_docker_volumes_default', default=maintainerr_docker_volumes_default)
+                              + lookup('vars', maintainerr_name + '_docker_volumes_custom', default=maintainerr_docker_volumes_custom) }}"
+
+# Devices
+maintainerr_docker_devices_default: []
+maintainerr_docker_devices_custom: []
+maintainerr_docker_devices: "{{ lookup('vars', maintainerr_name + '_docker_devices_default', default=maintainerr_docker_devices_default)
+                              + lookup('vars', maintainerr_name + '_docker_devices_custom', default=maintainerr_docker_devices_custom) }}"
+
+# Hosts
+maintainerr_docker_hosts_default: []
+maintainerr_docker_hosts_custom: []
+maintainerr_docker_hosts: "{{ docker_hosts_common
+                            | combine(lookup('vars', maintainerr_name + '_docker_hosts_default', default=maintainerr_docker_hosts_default))
+                            | combine(lookup('vars', maintainerr_name + '_docker_hosts_custom', default=maintainerr_docker_hosts_custom)) }}"
+
+# Labels
+maintainerr_docker_labels_default: {}
+maintainerr_docker_labels_custom: {}
+maintainerr_docker_labels_themepark:
+  - '{ "traefik.http.middlewares.themepark-{{ lookup("vars", maintainerr_name + "_name", default=maintainerr_name) }}.plugin.themepark.app": "maintainerr" }'
+  - '{ "traefik.http.middlewares.themepark-{{ lookup("vars", maintainerr_name + "_name", default=maintainerr_name) }}.plugin.themepark.theme": "{{ lookup("vars", maintainerr_name + "_themepark_theme", default=maintainerr_themepark_theme) }}" }'
+maintainerr_docker_labels: "{{ docker_labels_common
+                             | combine(lookup('vars', maintainerr_name + '_docker_labels_default', default=maintainerr_docker_labels_default))
+                             | combine((lookup('vars', maintainerr_name + '_docker_labels_themepark', default=maintainerr_docker_labels_themepark)
+                          if (maintainerr_themepark_enabled and global_themepark_plugin_enabled)
+                          else {}),
+                          lookup('vars', maintainerr_name + '_docker_labels_custom', default=maintainerr_docker_labels_custom)) }}"
+
+# Hostname
+maintainerr_docker_hostname: "{{ maintainerr_name }}"
+
+# Network Mode
+maintainerr_docker_network_mode_default: "{{ docker_networks_name_common }}"
+maintainerr_docker_network_mode: "{{ lookup('vars', maintainerr_name + '_docker_network_mode_default', default=maintainerr_docker_network_mode_default) }}"
+
+# Networks
+maintainerr_docker_networks_alias: "{{ maintainerr_name }}"
+maintainerr_docker_networks_default: []
+maintainerr_docker_networks_custom: []
+maintainerr_docker_networks: "{{ docker_networks_common
+                               + lookup('vars', maintainerr_name + '_docker_networks_default', default=maintainerr_docker_networks_default)
+                               + lookup('vars', maintainerr_name + '_docker_networks_custom', default=maintainerr_docker_networks_custom) }}"
+
+# Capabilities
+maintainerr_docker_capabilities_default: []
+maintainerr_docker_capabilities_custom: []
+maintainerr_docker_capabilities: "{{ lookup('vars', maintainerr_name + '_docker_capabilities_default', default=maintainerr_docker_capabilities_default)
+                                   + lookup('vars', maintainerr_name + '_docker_capabilities_custom', default=maintainerr_docker_capabilities_custom) }}"
+
+# Security Opts
+maintainerr_docker_security_opts_default: []
+maintainerr_docker_security_opts_custom: []
+maintainerr_docker_security_opts: "{{ lookup('vars', maintainerr_name + '_docker_security_opts_default', default=maintainerr_docker_security_opts_default)
+                                    + lookup('vars', maintainerr_name + '_docker_security_opts_custom', default=maintainerr_docker_security_opts_custom) }}"
+
+# Restart Policy
+maintainerr_docker_restart_policy: unless-stopped
+
+# State
+maintainerr_docker_state: started
+
+# User
+maintainerr_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/maintainerr/defaults/main.yml
+++ b/roles/maintainerr/defaults/main.yml
@@ -32,7 +32,7 @@ maintainerr_web_subdomain: "{{ maintainerr_name }}"
 maintainerr_web_domain: "{{ user.domain }}"
 maintainerr_web_port: "80"
 maintainerr_web_url: "{{ 'https://' + lookup('vars', maintainerr_name + '_web_subdomain', default=maintainerr_web_subdomain)
-                       + '.' + lookup('vars', maintainerr_name + '_web_domain', default=maintainerr_web_domain) }}"
+                          + '.' + lookup('vars', maintainerr_name + '_web_domain', default=maintainerr_web_domain) }}"
 
 ################################
 # DNS
@@ -53,22 +53,21 @@ maintainerr_log_level: "info"
 ################################
 
 maintainerr_traefik_themepark_middleware: "{{ ',themepark-' + lookup('vars', maintainerr_name + '_name', default=maintainerr_name)
-                                         if (maintainerr_themepark_enabled and global_themepark_plugin_enabled)
-                                         else '' }}"
+                                           if (maintainerr_themepark_enabled and global_themepark_plugin_enabled)
+                                           else '' }}"
 maintainerr_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
 maintainerr_traefik_middleware_default: "{{ traefik_default_middleware + ','
-                                         + lookup('vars', maintainerr_name + '_traefik_sso_middleware', default=maintainerr_traefik_sso_middleware)
-                                      if (lookup('vars', maintainerr_name + '_traefik_sso_middleware', default=maintainerr_traefik_sso_middleware) | length > 0)
-                                      else traefik_default_middleware }}"
+                                            + lookup('vars', maintainerr_name + '_traefik_sso_middleware', default=maintainerr_traefik_sso_middleware)
+                                         if (lookup('vars', maintainerr_name + '_traefik_sso_middleware', default=maintainerr_traefik_sso_middleware) | length > 0)
+                                         else traefik_default_middleware }}"
 maintainerr_traefik_middleware_custom: ""
 maintainerr_traefik_middleware: "{{ maintainerr_traefik_middleware_default + ','
-                                  + maintainerr_traefik_middleware_custom + ','
-                                  + maintainerr_traefik_themepark_middleware
-                               if (not maintainerr_traefik_middleware_custom.startswith(',') and maintainerr_traefik_middleware_custom | length > 0)
-                               else maintainerr_traefik_middleware_default
-                                  + maintainerr_traefik_middleware_custom
-                                  + maintainerr_traefik_themepark_middleware }}"
-
+                                    + maintainerr_traefik_middleware_custom + ','
+                                    + maintainerr_traefik_themepark_middleware
+                                 if (not maintainerr_traefik_middleware_custom.startswith(',') and maintainerr_traefik_middleware_custom | length > 0)
+                                 else maintainerr_traefik_middleware_default
+                                    + maintainerr_traefik_middleware_custom
+                                    + maintainerr_traefik_themepark_middleware }}"
 maintainerr_traefik_certresolver: "{{ traefik_default_certresolver }}"
 maintainerr_traefik_enabled: true
 
@@ -92,13 +91,13 @@ maintainerr_docker_image_pull: true
 maintainerr_docker_image_repo: "jorenn92/maintainerr"
 maintainerr_docker_image_tag: "latest"
 maintainerr_docker_image: "{{ lookup('vars', maintainerr_name + '_docker_image_repo', default=maintainerr_docker_image_repo)
-                            + ':' + lookup('vars', maintainerr_name + '_docker_image_tag', default=maintainerr_docker_image_tag) }}"
+                              + ':' + lookup('vars', maintainerr_name + '_docker_image_tag', default=maintainerr_docker_image_tag) }}"
 
 # Ports
 maintainerr_docker_ports_defaults: []
 maintainerr_docker_ports_custom: []
 maintainerr_docker_ports: "{{ lookup('vars', maintainerr_name + '_docker_ports_defaults', default=maintainerr_docker_ports_defaults)
-                            + lookup('vars', maintainerr_name + '_docker_ports_custom', default=maintainerr_docker_ports_custom) }}"
+                              + lookup('vars', maintainerr_name + '_docker_ports_custom', default=maintainerr_docker_ports_custom) }}"
 
 # Envs
 maintainerr_docker_envs_default:
@@ -107,33 +106,33 @@ maintainerr_docker_envs_default:
   LOG_LEVEL: "{{ maintainerr_log_level }}"
 maintainerr_docker_envs_custom: {}
 maintainerr_docker_envs: "{{ lookup('vars', maintainerr_name + '_docker_envs_default', default=maintainerr_docker_envs_default)
-                           | combine(lookup('vars', maintainerr_name + '_docker_envs_custom', default=maintainerr_docker_envs_custom)) }}"
+                             | combine(lookup('vars', maintainerr_name + '_docker_envs_custom', default=maintainerr_docker_envs_custom)) }}"
 
 # Commands
 maintainerr_docker_commands_default: []
 maintainerr_docker_commands_custom: []
 maintainerr_docker_commands: "{{ lookup('vars', maintainerr_name + '_docker_commands_default', default=maintainerr_docker_commands_default)
-                               + lookup('vars', maintainerr_name + '_docker_docker_commands_custom', default=maintainerr_docker_commands_custom) }}"
+                                 + lookup('vars', maintainerr_name + '_docker_docker_commands_custom', default=maintainerr_docker_commands_custom) }}"
 
 # Volumes
 maintainerr_docker_volumes_default:
   - "{{ maintainerr_paths_location }}:/opt/data"
 maintainerr_docker_volumes_custom: []
 maintainerr_docker_volumes: "{{ lookup('vars', maintainerr_name + '_docker_volumes_default', default=maintainerr_docker_volumes_default)
-                              + lookup('vars', maintainerr_name + '_docker_volumes_custom', default=maintainerr_docker_volumes_custom) }}"
+                                + lookup('vars', maintainerr_name + '_docker_volumes_custom', default=maintainerr_docker_volumes_custom) }}"
 
 # Devices
 maintainerr_docker_devices_default: []
 maintainerr_docker_devices_custom: []
 maintainerr_docker_devices: "{{ lookup('vars', maintainerr_name + '_docker_devices_default', default=maintainerr_docker_devices_default)
-                              + lookup('vars', maintainerr_name + '_docker_devices_custom', default=maintainerr_docker_devices_custom) }}"
+                                + lookup('vars', maintainerr_name + '_docker_devices_custom', default=maintainerr_docker_devices_custom) }}"
 
 # Hosts
 maintainerr_docker_hosts_default: []
 maintainerr_docker_hosts_custom: []
 maintainerr_docker_hosts: "{{ docker_hosts_common
-                            | combine(lookup('vars', maintainerr_name + '_docker_hosts_default', default=maintainerr_docker_hosts_default))
-                            | combine(lookup('vars', maintainerr_name + '_docker_hosts_custom', default=maintainerr_docker_hosts_custom)) }}"
+                              | combine(lookup('vars', maintainerr_name + '_docker_hosts_default', default=maintainerr_docker_hosts_default))
+                              | combine(lookup('vars', maintainerr_name + '_docker_hosts_custom', default=maintainerr_docker_hosts_custom)) }}"
 
 # Labels
 maintainerr_docker_labels_default: {}
@@ -142,11 +141,11 @@ maintainerr_docker_labels_themepark:
   - '{ "traefik.http.middlewares.themepark-{{ lookup("vars", maintainerr_name + "_name", default=maintainerr_name) }}.plugin.themepark.app": "maintainerr" }'
   - '{ "traefik.http.middlewares.themepark-{{ lookup("vars", maintainerr_name + "_name", default=maintainerr_name) }}.plugin.themepark.theme": "{{ lookup("vars", maintainerr_name + "_themepark_theme", default=maintainerr_themepark_theme) }}" }'
 maintainerr_docker_labels: "{{ docker_labels_common
-                             | combine(lookup('vars', maintainerr_name + '_docker_labels_default', default=maintainerr_docker_labels_default))
-                             | combine((lookup('vars', maintainerr_name + '_docker_labels_themepark', default=maintainerr_docker_labels_themepark)
-                          if (maintainerr_themepark_enabled and global_themepark_plugin_enabled)
-                          else {}),
-                          lookup('vars', maintainerr_name + '_docker_labels_custom', default=maintainerr_docker_labels_custom)) }}"
+                               | combine(lookup('vars', maintainerr_name + '_docker_labels_default', default=maintainerr_docker_labels_default))
+                               | combine((lookup('vars', maintainerr_name + '_docker_labels_themepark', default=maintainerr_docker_labels_themepark)
+                            if (maintainerr_themepark_enabled and global_themepark_plugin_enabled)
+                            else {}),
+                                lookup('vars', maintainerr_name + '_docker_labels_custom', default=maintainerr_docker_labels_custom)) }}"
 
 # Hostname
 maintainerr_docker_hostname: "{{ maintainerr_name }}"
@@ -160,20 +159,20 @@ maintainerr_docker_networks_alias: "{{ maintainerr_name }}"
 maintainerr_docker_networks_default: []
 maintainerr_docker_networks_custom: []
 maintainerr_docker_networks: "{{ docker_networks_common
-                               + lookup('vars', maintainerr_name + '_docker_networks_default', default=maintainerr_docker_networks_default)
-                               + lookup('vars', maintainerr_name + '_docker_networks_custom', default=maintainerr_docker_networks_custom) }}"
+                                 + lookup('vars', maintainerr_name + '_docker_networks_default', default=maintainerr_docker_networks_default)
+                                 + lookup('vars', maintainerr_name + '_docker_networks_custom', default=maintainerr_docker_networks_custom) }}"
 
 # Capabilities
 maintainerr_docker_capabilities_default: []
 maintainerr_docker_capabilities_custom: []
 maintainerr_docker_capabilities: "{{ lookup('vars', maintainerr_name + '_docker_capabilities_default', default=maintainerr_docker_capabilities_default)
-                                   + lookup('vars', maintainerr_name + '_docker_capabilities_custom', default=maintainerr_docker_capabilities_custom) }}"
+                                     + lookup('vars', maintainerr_name + '_docker_capabilities_custom', default=maintainerr_docker_capabilities_custom) }}"
 
 # Security Opts
 maintainerr_docker_security_opts_default: []
 maintainerr_docker_security_opts_custom: []
 maintainerr_docker_security_opts: "{{ lookup('vars', maintainerr_name + '_docker_security_opts_default', default=maintainerr_docker_security_opts_default)
-                                    + lookup('vars', maintainerr_name + '_docker_security_opts_custom', default=maintainerr_docker_security_opts_custom) }}"
+                                      + lookup('vars', maintainerr_name + '_docker_security_opts_custom', default=maintainerr_docker_security_opts_custom) }}"
 
 # Restart Policy
 maintainerr_docker_restart_policy: unless-stopped

--- a/roles/maintainerr/tasks/main.yml
+++ b/roles/maintainerr/tasks/main.yml
@@ -1,0 +1,16 @@
+#########################################################################
+# Title:         Saltbox: Maintainerr Role                              #
+# Author(s):     dabigc                                                 #
+# URL:           https://github.com/saltyorg/Saltbox                    #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Execute Maintainerr roles"
+  ansible.builtin.include_tasks: main2.yml
+  vars:
+    maintainerr_name: "{{ role }}"
+  with_items: "{{ maintainerr_instances }}"
+  loop_control:
+    loop_var: role

--- a/roles/maintainerr/tasks/main2.yml
+++ b/roles/maintainerr/tasks/main2.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:            Saltbox: Maintainerr                                #
+# Author(s):        dabigc                                              #
+# URL:              https://github.com/saltyorg/Saltbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -88,6 +88,7 @@
     - { role: linkding, tags: ['linkding'] }
     - { role: logarr, tags: ['logarr'] }
     - { role: lunasea, tags: ['lunasea'] }
+    - { role: maintainerr, tags: ['maintainerr'] }
     - { role: makemkv, tags: ['makemkv'] }
     - { role: mcrouter, tags: ['mcrouter'] }
     - { role: medusa, tags: ['medusa'] }


### PR DESCRIPTION
# Description
Maintainerr makes managing your media easy. Create custom rules with parameters across different services, show matching media on the Plex home screen for a given amount of days and handle the deletion.

Github Repository: https://github.com/jorenn92/Maintainerr
Docker image: [jorenn92/maintainerr](https://hub.docker.com/r/jorenn92/maintainerr)

# How Has This Been Tested?
- [x]  App is working as expected. (Container is alive and answering requests)
- [x]  App uses a dedicated folder in /opt directory.
- [x]  App secured by Authelia SSO authentication system.
- [x]  A subdomain is correctly created for the web-ui. (via Cloudflare)
- [x]  Custom TimeZone is set to the container and application.
- [x]  Custom UID/GID is set to the container to run under Saltbox user.

# To be done
Create a docs page entry for this new role