### PR TITLE
cleanup(handbrake): remove redundant task

### DIFF
--- a/roles/handbrake/tasks/main.yml
+++ b/roles/handbrake/tasks/main.yml
@@ -20,11 +20,6 @@
 - name: Create directories
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
 
-- name: Handbrake | Check if path '/dev/dri' exists
-  ansible.builtin.stat:
-    path: "/dev/dri"
-  register: dev_dri
-
 - name: Docker Devices Task
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/set_docker_devices_variable.yml"
   when: (gpu.intel or gpu.nvidia)


### PR DESCRIPTION
Already performed in the included `set_docker_devices_variable.yml`