### PR TITLE
feat(role): add factorio

### DIFF
--- a/roles/factorio/defaults/main.yml
+++ b/roles/factorio/defaults/main.yml
@@ -29,11 +29,6 @@ factorio_paths_folders_list:
 factorio_web_subdomain: "{{ factorio_name }}"
 factorio_web_domain: "{{ user.domain }}"
 factorio_web_port: ""
-factorio_web_scheme: "https"
-factorio_web_serverstransport: "skipverify@file"
-factorio_web_url: "{{ 'https://' + (factorio_web_subdomain + '.' + factorio_web_domain
-                if (factorio_web_subdomain | length > 0)
-                else factorio_web_domain) }}"
 
 ################################
 # DNS
@@ -41,19 +36,7 @@ factorio_web_url: "{{ 'https://' + (factorio_web_subdomain + '.' + factorio_web_
 
 factorio_dns_record: "{{ factorio_web_subdomain }}"
 factorio_dns_zone: "{{ factorio_web_domain }}"
-factorio_dns_proxy: "{{ dns.proxied }}"
-
-################################
-# Traefik
-################################
-
-factorio_traefik_sso_middleware: ""
-factorio_traefik_middleware_default: "{{ traefik_default_middleware }}"
-factorio_traefik_middleware_custom: ""
-factorio_traefik_certresolver: "{{ traefik_default_certresolver }}"
-factorio_traefik_enabled: true
-factorio_traefik_api_enabled: false
-factorio_traefik_api_endpoint: ""
+factorio_dns_proxy: false
 
 ################################
 # Docker

--- a/roles/factorio/defaults/main.yml
+++ b/roles/factorio/defaults/main.yml
@@ -1,0 +1,147 @@
+#########################################################################
+# Title:            Sandbox: Factorio | Default Variables               #
+# Author(s):        plebeian                                            #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+
+factorio_name: factorio
+
+################################
+# Paths
+################################
+
+factorio_paths_folder: "{{ factorio_name }}"
+factorio_paths_location: "{{ server_appdata_path }}/{{ factorio_paths_folder }}"
+factorio_paths_folders_list:
+  - "{{ factorio_paths_location }}"
+
+################################
+# Web
+################################
+
+factorio_web_subdomain: "{{ factorio_name }}"
+factorio_web_domain: "{{ user.domain }}"
+factorio_web_port: ""
+factorio_web_scheme: "https"
+factorio_web_serverstransport: "skipverify@file"
+factorio_web_url: "{{ 'https://' + (factorio_web_subdomain + '.' + factorio_web_domain
+                if (factorio_web_subdomain | length > 0)
+                else factorio_web_domain) }}"
+
+################################
+# DNS
+################################
+
+factorio_dns_record: "{{ factorio_web_subdomain }}"
+factorio_dns_zone: "{{ factorio_web_domain }}"
+factorio_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+factorio_traefik_sso_middleware: ""
+factorio_traefik_middleware_default: "{{ traefik_default_middleware }}"
+factorio_traefik_middleware_custom: ""
+factorio_traefik_certresolver: "{{ traefik_default_certresolver }}"
+factorio_traefik_enabled: true
+factorio_traefik_api_enabled: false
+factorio_traefik_api_endpoint: ""
+
+################################
+# Docker
+################################
+
+# Container
+factorio_docker_container: "{{ factorio_name }}"
+
+# Image
+factorio_docker_image_pull: true
+factorio_docker_image_tag: "experimental"
+factorio_docker_image: "goofball222/factorio:{{ factorio_docker_image_tag }}"
+
+# Ports
+factorio_docker_ports_defaults:
+  - "27015:27015/tcp"
+  - "34197:34197/udp"
+factorio_docker_ports_custom: []
+factorio_docker_ports: "{{ factorio_docker_ports_defaults
+                        + factorio_docker_ports_custom }}"
+
+# Envs
+factorio_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+factorio_docker_envs_custom: {}
+factorio_docker_envs: "{{ factorio_docker_envs_default
+                       | combine(factorio_docker_envs_custom) }}"
+
+# Commands
+factorio_docker_commands_default: []
+factorio_docker_commands_custom: []
+factorio_docker_commands: "{{ factorio_docker_commands_default
+                           + factorio_docker_commands_custom }}"
+
+# Volumes
+factorio_docker_volumes_default:
+  - "{{ factorio_paths_location }}:/factorio"
+factorio_docker_volumes_custom: []
+factorio_docker_volumes: "{{ factorio_docker_volumes_default
+                          + factorio_docker_volumes_custom }}"
+
+# Devices
+factorio_docker_devices_default: []
+factorio_docker_devices_custom: []
+factorio_docker_devices: "{{ factorio_docker_devices_default
+                          + factorio_docker_devices_custom }}"
+
+# Hosts
+factorio_docker_hosts_default: []
+factorio_docker_hosts_custom: []
+factorio_docker_hosts: "{{ docker_hosts_common
+                        | combine(factorio_docker_hosts_default)
+                        | combine(factorio_docker_hosts_custom) }}"
+
+# Labels
+factorio_docker_labels_default: {}
+factorio_docker_labels_custom: {}
+factorio_docker_labels: "{{ docker_labels_common
+                         | combine(factorio_docker_labels_default)
+                         | combine(factorio_docker_labels_custom) }}"
+
+# Hostname
+factorio_docker_hostname: "{{ factorio_name }}"
+
+# Networks
+factorio_docker_networks_alias: "{{ factorio_name }}"
+factorio_docker_networks_default: []
+factorio_docker_networks_custom: []
+factorio_docker_networks: "{{ docker_networks_common
+                           + factorio_docker_networks_default
+                           + factorio_docker_networks_custom }}"
+
+# Capabilities
+factorio_docker_capabilities_default: []
+factorio_docker_capabilities_custom: []
+factorio_docker_capabilities: "{{ factorio_docker_capabilities_default
+                               + factorio_docker_capabilities_custom }}"
+
+# Security Opts
+factorio_docker_security_opts_default: []
+factorio_docker_security_opts_custom: []
+factorio_docker_security_opts: "{{ factorio_docker_security_opts_default
+                                + factorio_docker_security_opts_custom }}"
+
+# Restart Policy
+factorio_docker_restart_policy: unless-stopped
+
+# State
+factorio_docker_state: started

--- a/roles/factorio/tasks/main.yml
+++ b/roles/factorio/tasks/main.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:            Sandbox: Factorio                                   #
+# Author(s):        plebeian                                            #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -48,6 +48,7 @@
     - { role: elasticsearch, tags: ['elasticsearch'] }
     - { role: embystat, tags: ['embystat'] }
     - { role: epms, tags: ['epms'] }
+    - { role: factorio, tags: ['factorio'] }
     - { role: filebot, tags: ['filebot'] }
     - { role: filebrowser, tags: ['filebrowser'] }
     - { role: filezilla, tags: ['filezilla'] }


### PR DESCRIPTION
# Description

Adds a a role to deploy a Factorio headless server. Will boot a fresh game with files at `/opt/factorio` if that folder is empty, otherwise will load the save if there is one. Additional configuration through `server-settings.json` as per the Factorio headless server [documentation](https://wiki.factorio.com/Multiplayer). 

[Docker image](https://hub.docker.com/r/goofball222/factorio).

Will try to make documentation soon.

# How Has This Been Tested?

- [X] Tested on my Sandbox install and tested connectivity to the game server
