### PR TITLE
Update homepage image URL

### DIFF
--- a/roles/homepage/defaults/main.yml
+++ b/roles/homepage/defaults/main.yml
@@ -75,7 +75,7 @@ homepage_docker_container: "{{ homepage_name }}"
 # Image
 homepage_docker_image_pull: true
 homepage_docker_image_tag: "latest"
-homepage_docker_image: "ghcr.io/benphelps/homepage:{{ homepage_docker_image_tag }}"
+homepage_docker_image: "ghcr.io/gethomepage/homepage:{{ homepage_docker_image_tag }}"
 
 # Ports
 homepage_docker_ports_defaults: []


### PR DESCRIPTION
As per the following link the below changes have been made 
https://gethomepage.dev/v0.7.2/more/homepage-move/

`image: ghcr.io/benphelps/homepage:latest to image: ghcr.io/gethomepage/homepage:latest.`

