### PR TITLE
feat(role): add valheim server

### DIFF
--- a/roles/valheim/defaults/main.yml
+++ b/roles/valheim/defaults/main.yml
@@ -1,0 +1,133 @@
+##########################################################################
+# Title:         Sandbox: valheim | Default Variables                    #
+# Author(s):     scarabyte                                               #
+# URL:           https://github.com/saltyorg/Sandbox                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+valheim_name: valheim
+valheim_version: "LATEST"
+valheim_password: "{{ lookup('community.general.random_string') }}"
+
+################################
+# Paths
+################################
+
+valheim_paths_folder: "{{ valheim_name }}"
+valheim_paths_location: "{{ server_appdata_path }}/{{ valheim_paths_folder }}"
+valheim_paths_folders_list:
+  - "{{ valheim_paths_location }}"
+
+################################
+# Web
+################################
+
+valheim_web_subdomain: "{{ valheim_name }}"
+valheim_web_domain: "{{ user.domain }}"
+
+################################
+# DNS
+################################
+
+valheim_dns_record: "{{ lookup('vars', valheim_name + '_web_subdomain', default=valheim_web_subdomain) }}"
+valheim_dns_zone: "{{ lookup('vars', valheim_name + '_web_domain', default=valheim_web_domain) }}"
+valheim_dns_proxy: false
+
+################################
+# Docker
+################################
+
+# Container
+valheim_docker_container: "{{ valheim_name }}"
+
+# Image
+valheim_docker_image_pull: true
+valheim_docker_image_tag: "latest"
+valheim_docker_image: "mbround18/valheim:{{ valheim_docker_image_tag }}"
+
+# Ports
+valheim_docker_ports_defaults:
+  - "2456:2456/udp"
+  - "2457:2457/udp"
+  - "2458:2458/udp"
+valheim_docker_ports: "{{ valheim_docker_ports_defaults }}"
+
+# Envs
+valheim_docker_envs_default:
+  TZ: "{{ tz }}"
+  UID: "{{ uid }}"
+  GID: "{{ gid }}"
+  PUBLIC: "0"
+  PASSWORD: "{{ valheim_password }}"
+valheim_docker_envs_custom: {}
+valheim_docker_envs: "{{ valheim_docker_envs_default
+                                   | combine(valheim_docker_envs_custom) }}"
+
+# Commands
+valheim_docker_commands_default: []
+valheim_docker_commands_custom: []
+valheim_docker_commands: "{{ valheim_docker_commands_default
+                                       + valheim_docker_commands_custom }}"
+
+# Volumes
+valheim_docker_volumes_default:
+  - "{{ valheim_paths_location }}/saves:/home/steam/.config/unity3d/IronGate/Valheim"
+  - "{{ valheim_paths_location }}/server:/home/steam/valheim"
+valheim_docker_volumes_custom: []
+valheim_docker_volumes: "{{ valheim_docker_volumes_default
+                                      + valheim_docker_volumes_custom }}"
+
+# Devices
+valheim_docker_devices_default: []
+valheim_docker_devices_custom: []
+valheim_docker_devices: "{{ valheim_docker_devices_default
+                                      + valheim_docker_devices_custom }}"
+
+# Hosts
+valheim_docker_hosts_default: []
+valheim_docker_hosts_custom: []
+valheim_docker_hosts: "{{ docker_hosts_common
+                                    | combine(valheim_docker_hosts_default)
+                                    | combine(valheim_docker_hosts_custom) }}"
+
+# Labels
+valheim_docker_labels_default: {}
+valheim_docker_labels_custom: {}
+valheim_docker_labels: "{{ docker_labels_common
+                                     | combine(valheim_docker_labels_default)
+                                     | combine(valheim_docker_labels_custom) }}"
+
+# Hostname
+valheim_docker_hostname: "{{ valheim_name }}"
+
+# Networks
+valheim_docker_networks_alias: "{{ valheim_name }}"
+valheim_docker_networks_default: []
+valheim_docker_networks_custom: []
+valheim_docker_networks: "{{ docker_networks_common
+                                       + valheim_docker_networks_default
+                                       + valheim_docker_networks_custom }}"
+
+# Capabilities
+valheim_docker_capabilities_default: []
+valheim_docker_capabilities_custom: []
+valheim_docker_capabilities: "{{ valheim_docker_capabilities_default
+                                           + valheim_docker_capabilities_custom }}"
+
+# Security Opts
+valheim_docker_security_opts_default: []
+valheim_docker_security_opts_custom: []
+valheim_docker_security_opts: "{{ valheim_docker_security_opts_default
+                                            + valheim_docker_security_opts_custom }}"
+
+# Restart Policy
+valheim_docker_restart_policy: unless-stopped
+
+# State
+valheim_docker_state: started

--- a/roles/valheim/defaults/main.yml
+++ b/roles/valheim/defaults/main.yml
@@ -13,7 +13,6 @@
 
 valheim_name: valheim
 valheim_version: "LATEST"
-valheim_password: "{{ lookup('community.general.random_string') }}"
 
 ################################
 # Paths
@@ -64,7 +63,7 @@ valheim_docker_envs_default:
   UID: "{{ uid }}"
   GID: "{{ gid }}"
   PUBLIC: "0"
-  PASSWORD: "{{ valheim_password }}"
+  PASSWORD: "{{ lookup('community.general.random_string') }}"
 valheim_docker_envs_custom: {}
 valheim_docker_envs: "{{ valheim_docker_envs_default
                                    | combine(valheim_docker_envs_custom) }}"

--- a/roles/valheim/tasks/main.yml
+++ b/roles/valheim/tasks/main.yml
@@ -1,0 +1,37 @@
+#########################################################################
+# Title:            Sandbox: valheim                                    #
+# Author(s):        scarabyte                                           #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Add SRV record
+  community.general.cloudflare_dns:
+    zone: "{{ _dns_tasker_zone }}"
+    record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    type: SRV
+    proto: udp
+    service: minecraft
+    value: "{{ lookup('vars', role_name + '_dns_record') }}.{{ lookup('vars', role_name + '_dns_zone') }}"
+    port: 19132
+    account_api_token: "{{ cloudflare.api }}"
+    account_email: "{{ cloudflare.email }}"
+  when: cloudflare_is_enabled
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -169,6 +169,7 @@
     - { role: unifi_network_application, tags: ['unifi-network-application'] }
     - { role: unmanic, tags: ['unmanic'] }
     - { role: uptime_kuma, tags: ['uptime-kuma'] }
+    - { role: valheim, tags: ['valheim'] }
     - { role: varken, tags: ['varken'] }
     - { role: vaultwarden, tags: ['vaultwarden'] }
     - { role: vnstat, tags: ['vnstat'] }


### PR DESCRIPTION
# Description

Role for creating a simple valheim server using a docker image ([mbround18/valheim](https://github.com/mbround18/valheim-docker)). Files are stored in `/opt/valheim` with saves in `/opt/valheim/saves` and server files in `/opt/valheim/server`.

# How Has This Been Tested?
- [x] Can connect to server
- [x] Continued to run without errors

