### PR TITLE
Update ES to official repo and tag recommended by TubeArchivist

### DIFF
--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -40,8 +40,8 @@ elasticsearch_docker_container: "{{ elasticsearch_name }}"
 
 # Image
 elasticsearch_docker_image_pull: true
-elasticsearch_docker_image_tag: "8.5.0"
-elasticsearch_docker_image: "docker.elastic.co/elasticsearch/elasticsearch:{{ elasticsearch_docker_image_tag }}"
+elasticsearch_docker_image_tag: "8.11.0"
+elasticsearch_docker_image: "elasticsearch:{{ elasticsearch_docker_image_tag }}"
 
 # Ports
 elasticsearch_docker_ports_defaults: []


### PR DESCRIPTION
This updates the Elasticsearch repo to the official one now on hub as well as the tag tubearchivist recommends although latest is 8.12.0 but I only know 8.11.0 works