### PR TITLE
Add LinkWarden role

### DIFF
--- a/roles/linkwarden/defaults/main.yml
+++ b/roles/linkwarden/defaults/main.yml
@@ -18,7 +18,7 @@ linkwarden_name: linkwarden
 ################################
 
 linkwarden_postgres_name: "{{ linkwarden_name }}-postgres"
-linkwarden_postgres_docker_env_username: "{{ linkwarden_name }}"
+linkwarden_postgres_docker_env_user: "{{ linkwarden_name }}"
 linkwarden_postgres_docker_env_password: "{{ linkwarden_name }}"
 linkwarden_postgres_docker_env_db: "{{ linkwarden_name }}"
 linkwarden_postgres_docker_image_tag: "16-alpine"
@@ -91,7 +91,7 @@ linkwarden_docker_envs_default:
   STORAGE_FOLDER: "/data"
   NEXTAUTH_SECRET: "{{ linkwarden_secret_key.stdout }}"
   NEXTAUTH_URL: "{{ linkwarden_web_url }}/api/v1/auth"
-  DATABASE_URL: "postgresql://{{ linkwarden_postgres_docker_env_username }}:{{ linkwarden_postgres_docker_env_password }}@{{ linkwarden_postgres_name }}:5432/{{ linkwarden_postgres_docker_env_db }}"
+  DATABASE_URL: "postgresql://{{ linkwarden_postgres_docker_env_user }}:{{ linkwarden_postgres_docker_env_password }}@{{ linkwarden_postgres_name }}:5432/{{ linkwarden_postgres_docker_env_db }}"
 linkwarden_docker_envs_custom: {}
 linkwarden_docker_envs: "{{ linkwarden_docker_envs_default
                             | combine(linkwarden_docker_envs_custom) }}"

--- a/roles/linkwarden/defaults/main.yml
+++ b/roles/linkwarden/defaults/main.yml
@@ -1,0 +1,146 @@
+##########################################################################
+# Title:         Sandbox: LinkWarden | Default Variables                 #
+# Author(s):     salty                                                   #
+# URL:           https://github.com/saltyorg/Sandbox                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+linkwarden_name: linkwarden
+
+################################
+# Paths
+################################
+
+linkwarden_paths_folder: "{{ linkwarden_name }}"
+linkwarden_paths_location: "{{ server_appdata_path }}/{{ linkwarden_paths_folder }}"
+linkwarden_paths_folders_list:
+  - "{{ linkwarden_paths_location }}"
+
+################################
+# Web
+################################
+
+linkwarden_web_subdomain: "{{ linkwarden_name }}"
+linkwarden_web_domain: "{{ user.domain }}"
+linkwarden_web_port: "3000"
+linkwarden_web_url: "{{ 'https://' + (linkwarden_web_subdomain + '.'   + linkwarden_web_domain
+                     if (linkwarden_web_subdomain | length > 0)
+                     else linkwarden_web_domain) }}"
+
+################################
+# DNS
+################################
+
+linkwarden_dns_record: "{{ linkwarden_web_subdomain }}"
+linkwarden_dns_zone: "{{ linkwarden_web_domain }}"
+linkwarden_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+linkwarden_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+linkwarden_traefik_middleware_default: "{{ traefik_default_middleware }}"
+linkwarden_traefik_middleware_custom: ""
+linkwarden_traefik_certresolver: "{{ traefik_default_certresolver }}"
+linkwarden_traefik_enabled: true
+linkwarden_traefik_api_enabled: true
+linkwarden_traefik_api_endpoint: "PathPrefix(`/api`)"
+
+################################
+# Docker
+################################
+
+# Container
+linkwarden_docker_container: "{{ linkwarden_name }}"
+
+# Image
+linkwarden_docker_image_pull: true
+linkwarden_docker_image_tag: "latest"
+linkwarden_docker_image: "ghcr.io/linkwarden/linkwarden:{{ linkwarden_docker_image_tag }}"
+
+# Ports
+linkwarden_docker_ports_defaults: []
+linkwarden_docker_ports_custom: []
+linkwarden_docker_ports: "{{ linkwarden_docker_ports_defaults
+                             + linkwarden_docker_ports_custom }}"
+
+# Envs
+linkwarden_docker_envs_default:
+  TZ: "{{ tz }}"
+  NEXT_PUBLIC_CREDENTIALS_ENABLED: "true"
+  STORAGE_FOLDER: "/data"
+  NEXTAUTH_SECRET: "{{ linkwarden_secret_key.stdout }}"
+  NEXTAUTH_URL: "{{ linkwarden_web_url }}/api/v1/auth"
+  DATABASE_URL: "postgresql://{{ user_name }}:{{ postgres_docker_env_password }}@{{ linkwarden_name }}-postgres:5432/saltbox"
+linkwarden_docker_envs_custom: {}
+linkwarden_docker_envs: "{{ linkwarden_docker_envs_default
+                            | combine(linkwarden_docker_envs_custom) }}"
+
+# Commands
+linkwarden_docker_commands_default: []
+linkwarden_docker_commands_custom: []
+linkwarden_docker_commands: "{{ linkwarden_docker_commands_default
+                                + linkwarden_docker_commands_custom }}"
+
+# Volumes
+linkwarden_docker_volumes_default:
+  - "{{ linkwarden_paths_location }}:/data/data"
+linkwarden_docker_volumes_custom: []
+linkwarden_docker_volumes: "{{ linkwarden_docker_volumes_default
+                               + linkwarden_docker_volumes_custom }}"
+
+# Devices
+linkwarden_docker_devices_default: []
+linkwarden_docker_devices_custom: []
+linkwarden_docker_devices: "{{ linkwarden_docker_devices_default
+                               + linkwarden_docker_devices_custom }}"
+
+# Hosts
+linkwarden_docker_hosts_default: []
+linkwarden_docker_hosts_custom: []
+linkwarden_docker_hosts: "{{ docker_hosts_common
+                             | combine(linkwarden_docker_hosts_default)
+                             | combine(linkwarden_docker_hosts_custom) }}"
+
+# Labels
+linkwarden_docker_labels_default: {}
+linkwarden_docker_labels_custom: {}
+linkwarden_docker_labels: "{{ docker_labels_common
+                              | combine(linkwarden_docker_labels_default)
+                              | combine(linkwarden_docker_labels_custom) }}"
+
+# Hostname
+linkwarden_docker_hostname: "{{ linkwarden_name }}"
+
+# Networks
+linkwarden_docker_networks_alias: "{{ linkwarden_name }}"
+linkwarden_docker_networks_default: []
+linkwarden_docker_networks_custom: []
+linkwarden_docker_networks: "{{ docker_networks_common
+                                + linkwarden_docker_networks_default
+                                + linkwarden_docker_networks_custom }}"
+
+# Capabilities
+linkwarden_docker_capabilities_default: []
+linkwarden_docker_capabilities_custom: []
+linkwarden_docker_capabilities: "{{ linkwarden_docker_capabilities_default
+                                    + linkwarden_docker_capabilities_custom }}"
+
+# Security Opts
+linkwarden_docker_security_opts_default: []
+linkwarden_docker_security_opts_custom: []
+linkwarden_docker_security_opts: "{{ linkwarden_docker_security_opts_default
+                                     + linkwarden_docker_security_opts_custom }}"
+
+# Restart Policy
+linkwarden_docker_restart_policy: unless-stopped
+
+# State
+linkwarden_docker_state: started

--- a/roles/linkwarden/defaults/main.yml
+++ b/roles/linkwarden/defaults/main.yml
@@ -78,7 +78,7 @@ linkwarden_docker_envs_default:
   STORAGE_FOLDER: "/data"
   NEXTAUTH_SECRET: "{{ linkwarden_secret_key.stdout }}"
   NEXTAUTH_URL: "{{ linkwarden_web_url }}/api/v1/auth"
-  DATABASE_URL: "postgresql://{{ user_name }}:{{ postgres_docker_env_password }}@{{ linkwarden_name }}-postgres:5432/saltbox"
+  DATABASE_URL: "postgresql://{{ user_name }}:{{ postgres_docker_env_password }}@{{ linkwarden_name }}-postgres:5432/{{ linkwarden_name }}"
 linkwarden_docker_envs_custom: {}
 linkwarden_docker_envs: "{{ linkwarden_docker_envs_default
                             | combine(linkwarden_docker_envs_custom) }}"

--- a/roles/linkwarden/defaults/main.yml
+++ b/roles/linkwarden/defaults/main.yml
@@ -78,7 +78,7 @@ linkwarden_docker_envs_default:
   STORAGE_FOLDER: "/data"
   NEXTAUTH_SECRET: "{{ linkwarden_secret_key.stdout }}"
   NEXTAUTH_URL: "{{ linkwarden_web_url }}/api/v1/auth"
-  DATABASE_URL: "postgresql://{{ user_name }}:{{ postgres_docker_env_password }}@{{ linkwarden_name }}-postgres:5432/{{ linkwarden_name }}"
+  DATABASE_URL: "postgresql://{{ user.name }}:{{ postgres_docker_env_password }}@{{ linkwarden_name }}-postgres:5432/{{ linkwarden_name }}"
 linkwarden_docker_envs_custom: {}
 linkwarden_docker_envs: "{{ linkwarden_docker_envs_default
                             | combine(linkwarden_docker_envs_custom) }}"

--- a/roles/linkwarden/defaults/main.yml
+++ b/roles/linkwarden/defaults/main.yml
@@ -1,6 +1,6 @@
 ##########################################################################
 # Title:         Sandbox: LinkWarden | Default Variables                 #
-# Author(s):     salty                                                   #
+# Author(s):     CHAIR/Raneydazed                                        #
 # URL:           https://github.com/saltyorg/Sandbox                     #
 # --                                                                     #
 ##########################################################################

--- a/roles/linkwarden/defaults/main.yml
+++ b/roles/linkwarden/defaults/main.yml
@@ -14,6 +14,19 @@
 linkwarden_name: linkwarden
 
 ################################
+# Settings
+################################
+
+linkwarden_postgres_name: "{{ linkwarden_name }}-postgres"
+linkwarden_postgres_docker_env_username: "{{ linkwarden_name }}"
+linkwarden_postgres_docker_env_password: "{{ linkwarden_name }}"
+linkwarden_postgres_docker_env_db: "{{ linkwarden_name }}"
+linkwarden_postgres_docker_image_tag: "16-alpine"
+linkwarden_postgres_docker_image_repo: "postgres"
+linkwarden_postgres_paths_folder: "{{ linkwarden_name }}"
+linkwarden_postgres_paths_location: "{{ server_appdata_path }}/{{ postgres_paths_folder }}/postgres"
+
+################################
 # Paths
 ################################
 
@@ -78,7 +91,7 @@ linkwarden_docker_envs_default:
   STORAGE_FOLDER: "/data"
   NEXTAUTH_SECRET: "{{ linkwarden_secret_key.stdout }}"
   NEXTAUTH_URL: "{{ linkwarden_web_url }}/api/v1/auth"
-  DATABASE_URL: "postgresql://{{ user.name }}:{{ postgres_docker_env_password }}@{{ linkwarden_name }}-postgres:5432/{{ linkwarden_name }}"
+  DATABASE_URL: "postgresql://{{ linkwarden_postgres_docker_env_username }}:{{ linkwarden_postgres_docker_env_password }}@{{ linkwarden_postgres_name }}:5432/{{ linkwarden_postgres_docker_env_db }}"
 linkwarden_docker_envs_custom: {}
 linkwarden_docker_envs: "{{ linkwarden_docker_envs_default
                             | combine(linkwarden_docker_envs_custom) }}"

--- a/roles/linkwarden/defaults/main.yml
+++ b/roles/linkwarden/defaults/main.yml
@@ -29,7 +29,7 @@ linkwarden_paths_folders_list:
 linkwarden_web_subdomain: "{{ linkwarden_name }}"
 linkwarden_web_domain: "{{ user.domain }}"
 linkwarden_web_port: "3000"
-linkwarden_web_url: "{{ 'https://' + (linkwarden_web_subdomain + '.'   + linkwarden_web_domain
+linkwarden_web_url: "{{ 'https://' + (linkwarden_web_subdomain + '.' + linkwarden_web_domain
                      if (linkwarden_web_subdomain | length > 0)
                      else linkwarden_web_domain) }}"
 

--- a/roles/linkwarden/tasks/main.yml
+++ b/roles/linkwarden/tasks/main.yml
@@ -12,7 +12,7 @@
     name: postgres
   vars:
     postgres_instances: ["{{ linkwarden_postgres_name }}"]
-    postgres_docker_env_username: "{{ linkwarden_postgres_docker_env_username }}"
+    postgres_docker_env_user: "{{ linkwarden_postgres_docker_env_user }}"
     postgres_docker_env_password: "{{ linkwarden_postgres_docker_env_password }}"
     postgres_docker_env_db: "{{ linkwarden_postgres_docker_env_db }}"
     postgres_docker_image_tag: "{{ linkwarden_postgres_docker_image_tag }}"

--- a/roles/linkwarden/tasks/main.yml
+++ b/roles/linkwarden/tasks/main.yml
@@ -11,11 +11,14 @@
   ansible.builtin.include_role:
     name: postgres
   vars:
-    postgres_instances: ["{{ linkwarden_name }}-postgres"]
-    postgres_docker_env_db: "{{ linkwarden_name }}"
-    postgres_docker_image_tag: "16-alpine"
-    postgres_paths_folder: "{{ linkwarden_name }}"
-    postgres_paths_location: "{{ server_appdata_path }}/{{ postgres_paths_folder }}/postgres"
+    postgres_instances: ["{{ linkwarden_postgres_name }}"]
+    postgres_docker_env_username: "{{ linkwarden_postgres_docker_env_username }}"
+    postgres_docker_env_password: "{{ linkwarden_postgres_docker_env_password }}"
+    postgres_docker_env_db: "{{ linkwarden_postgres_docker_env_db }}"
+    postgres_docker_image_tag: "{{ linkwarden_postgres_docker_image_tag }}"
+    postgres_docker_image_repo: "{{ linkwarden_postgres_docker_image_repo }}"
+    postgres_paths_folder: "{{ linkwarden_postgres_paths_folder }}"
+    postgres_paths_location: "{{ linkwarden_postgres_paths_location }}"
 
 - name: "Generate Secret Key"
   ansible.builtin.shell: "openssl rand -base64 45"

--- a/roles/linkwarden/tasks/main.yml
+++ b/roles/linkwarden/tasks/main.yml
@@ -1,0 +1,38 @@
+#########################################################################
+# Title:            Sandbox: LInkWarden                                 #
+# Author(s):        CHAIR/Raneydazed                                    #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: PostgreSQL Role
+  ansible.builtin.include_role:
+    name: postgres
+  vars:
+    postgres_instances: ["{{ linkwarden_name }}-postgres"]
+    postgres_docker_env_db: "{{ linkwarden_name }}"
+    postgres_docker_image_tag: "16-alpine"
+    postgres_paths_folder: "{{ linkwarden_name }}"
+    postgres_paths_location: "{{ server_appdata_path }}/{{ postgres_paths_folder }}/postgres"
+
+- name: "Generate Secret Key"
+  ansible.builtin.shell: "openssl rand -base64 45"
+  register: linkwarden_secret_key
+
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -91,6 +91,7 @@
     - { role: krusader, tags: ['krusader'] }
     - { role: lazylibrarian, tags: ['lazylibrarian'] }
     - { role: linkding, tags: ['linkding'] }
+    - { role: linkwarden, tags: ['linkwarden'] }
     - { role: logarr, tags: ['logarr'] }
     - { role: lunasea, tags: ['lunasea'] }
     - { role: makemkv, tags: ['makemkv'] }


### PR DESCRIPTION
Add LinkWarden role with default configs and tasks 

Introduce a new Ansible role for LinkWarden, setting up default
variables for Docker deployment, such as container name, image,
environment variables, and networks. Included tasks handle PostgreSQL dependency, DNS setup, container management, and directory creation. This addition allows for LinkWarden deployment and maintenance in the
Sandbox environment.

<3 GPT

Relevant issue: #324