### PR TITLE
Notifiarr: Starr app Database Checks Requirement

### DIFF
--- a/roles/notifiarr/defaults/main.yml
+++ b/roles/notifiarr/defaults/main.yml
@@ -98,7 +98,7 @@ notifiarr_docker_volumes_custom: []
 notifiarr_docker_volumes: "{{ notifiarr_docker_volumes_default
                               + notifiarr_docker_volumes_custom }}"
 
-#Mounts
+# Mounts
 notifiarr_docker_mounts_default:
   - target: /tmp
     type: tmpfs

--- a/roles/notifiarr/defaults/main.yml
+++ b/roles/notifiarr/defaults/main.yml
@@ -94,6 +94,7 @@ notifiarr_docker_commands: "{{ notifiarr_docker_commands_default
 notifiarr_docker_volumes_default:
   - "{{ notifiarr_paths_location }}:/config"
   - "/var/run/utmp:/var/run/utmp"
+  - "{{ notifiarr_paths_folder }}/tmp:/tmp"
 notifiarr_docker_volumes_custom: []
 notifiarr_docker_volumes: "{{ notifiarr_docker_volumes_default
                               + notifiarr_docker_volumes_custom }}"

--- a/roles/notifiarr/defaults/main.yml
+++ b/roles/notifiarr/defaults/main.yml
@@ -102,6 +102,9 @@ notifiarr_docker_volumes: "{{ notifiarr_docker_volumes_default
 notifiarr_docker_mounts_default:
   - target: /tmp
     type: tmpfs
+notifiarr_docker_mounts_custom: []
+notifiarr_docker_mounts: "{{ notifiarr_docker_mounts_default
+                             + notifiarr_docker_mounts_custom }}"
 
 # Devices
 notifiarr_docker_devices_default: []

--- a/roles/notifiarr/defaults/main.yml
+++ b/roles/notifiarr/defaults/main.yml
@@ -94,10 +94,14 @@ notifiarr_docker_commands: "{{ notifiarr_docker_commands_default
 notifiarr_docker_volumes_default:
   - "{{ notifiarr_paths_location }}:/config"
   - "/var/run/utmp:/var/run/utmp"
-  - "{{ notifiarr_paths_folder }}/tmp:/tmp"
 notifiarr_docker_volumes_custom: []
 notifiarr_docker_volumes: "{{ notifiarr_docker_volumes_default
                               + notifiarr_docker_volumes_custom }}"
+
+#Mounts
+notifiarr_docker_mounts_default:
+  - target: /tmp
+    type: tmpfs
 
 # Devices
 notifiarr_docker_devices_default: []


### PR DESCRIPTION
The database corruption check requires a folder to move and then examine a backup file from the Starr apps which is /tmp by default it doesn't have access to that obviously so this will allow it to use its appdata folder for this purpose

I'm not sure if I did it entirely right I probably did not

https://notifiarr.wiki/en/Client/Configuration#tmp-not-found
