### PR TITLE
Notifiarr: Update image link to ghcr

### DIFF
--- a/roles/notifiarr/defaults/main.yml
+++ b/roles/notifiarr/defaults/main.yml
@@ -69,7 +69,7 @@ notifiarr_docker_container: "{{ notifiarr_name }}"
 # Image
 notifiarr_docker_image_pull: true
 notifiarr_docker_image_tag: "latest"
-notifiarr_docker_image: "golift/notifiarr:{{ notifiarr_docker_image_tag }}"
+notifiarr_docker_image: "ghcr.io/notifiarr/notifiarr:{{ notifiarr_docker_image_tag }}"
 
 # Ports
 notifiarr_docker_ports_defaults: []


### PR DESCRIPTION
Due to rate limits and Docker hub taking 80+ minutes to build versus Github taking 15 minutes to build they will be swapping over, stable is yet to be until the next push so I'm only making a draft until then but also gives you a chance to reject early if you don't wanna do this swap at all

![1fb2eda7-5e0d-4bcd-bbb9-ae72617394af](https://github.com/saltyorg/Sandbox/assets/16083155/856e3bec-13ed-4ac1-9314-fbb774e834de)
![3f625490-3607-4c0e-980f-9263fd2beda9](https://github.com/saltyorg/Sandbox/assets/16083155/e530a3d7-c9a0-4a52-a735-f57ef15af42d)
