### PR TITLE
Add Grocy and Barcode Buddy

### DIFF
--- a/roles/barcodebuddy/defaults/main.yml
+++ b/roles/barcodebuddy/defaults/main.yml
@@ -1,0 +1,141 @@
+##########################################################################
+# Title:         Sandbox: Barcode Buddy | Default Variables              #
+# Author(s):     edzeg                                                   #
+# URL:           https://github.com/Forceu/barcodebuddy                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+barcodebuddy_name: barcodebuddy
+
+################################
+# Paths
+################################
+
+barcodebuddy_paths_folder: "{{ barcodebuddy_name }}"
+barcodebuddy_paths_location: "{{ server_appdata_path }}/{{ barcodebuddy_paths_folder }}"
+barcodebuddy_paths_folders_list:
+  - "{{ barcodebuddy_paths_location }}"
+
+################################
+# Web
+################################
+
+barcodebuddy_web_subdomain: "{{ barcodebuddy_name }}"
+barcodebuddy_web_domain: "{{ user.domain }}"
+barcodebuddy_web_port: "80"
+barcodebuddy_web_url: "{{ 'https://' + (barcodebuddy_web_subdomain + '.' + barcodebuddy_web_domain
+                if (barcodebuddy_web_subdomain | length > 0)
+                else barcodebuddy_web_domain) }}"
+
+################################
+# DNS
+################################
+
+barcodebuddy_dns_record: "{{ barcodebuddy_web_subdomain }}"
+barcodebuddy_dns_zone: "{{ barcodebuddy_web_domain }}"
+barcodebuddy_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+barcodebuddy_traefik_sso_middleware: ""
+barcodebuddy_traefik_middleware_default: "{{ traefik_default_middleware }}"
+barcodebuddy_traefik_middleware_custom: ""
+barcodebuddy_traefik_certresolver: "{{ traefik_default_certresolver }}"
+barcodebuddy_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+barcodebuddy_docker_container: "{{ barcodebuddy_name }}"
+
+# Image
+barcodebuddy_docker_image_pull: true
+barcodebuddy_docker_image_tag: "latest"
+barcodebuddy_docker_image: "f0rc3/barcodebuddy:{{ barcodebuddy_docker_image_tag }}"
+
+# Ports
+barcodebuddy_docker_ports_defaults: []
+barcodebuddy_docker_ports_custom: []
+barcodebuddy_docker_ports: "{{ barcodebuddy_docker_ports_defaults
+                        + barcodebuddy_docker_ports_custom }}"
+
+# Envs
+barcodebuddy_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+barcodebuddy_docker_envs_custom: {}
+barcodebuddy_docker_envs: "{{ barcodebuddy_docker_envs_default
+                       | combine(barcodebuddy_docker_envs_custom) }}"
+
+# Commands
+barcodebuddy_docker_commands_default: []
+barcodebuddy_docker_commands_custom: []
+barcodebuddy_docker_commands: "{{ barcodebuddy_docker_commands_default
+                           + barcodebuddy_docker_commands_custom }}"
+
+# Volumes
+barcodebuddy_docker_volumes_default:
+  - "{{ barcodebuddy_paths_location }}:/config"
+barcodebuddy_docker_volumes_custom: []
+barcodebuddy_docker_volumes: "{{ barcodebuddy_docker_volumes_default
+                          + barcodebuddy_docker_volumes_custom }}"
+
+# Devices
+barcodebuddy_docker_devices_default: []
+barcodebuddy_docker_devices_custom: []
+barcodebuddy_docker_devices: "{{ barcodebuddy_docker_devices_default
+                          + barcodebuddy_docker_devices_custom }}"
+
+# Hosts
+barcodebuddy_docker_hosts_default: {}
+barcodebuddy_docker_hosts_custom: {}
+barcodebuddy_docker_hosts: "{{ docker_hosts_common
+                        | combine(barcodebuddy_docker_hosts_default)
+                        | combine(barcodebuddy_docker_hosts_custom) }}"
+
+# Labels
+barcodebuddy_docker_labels_default: {}
+barcodebuddy_docker_labels_custom: {}
+barcodebuddy_docker_labels: "{{ docker_labels_common
+                         | combine(barcodebuddy_docker_labels_default)
+                         | combine(barcodebuddy_docker_labels_custom) }}"
+
+# Hostname
+barcodebuddy_docker_hostname: "{{ barcodebuddy_name }}"
+
+# Networks
+barcodebuddy_docker_networks_alias: "{{ barcodebuddy_name }}"
+barcodebuddy_docker_networks_default: []
+barcodebuddy_docker_networks_custom: []
+barcodebuddy_docker_networks: "{{ docker_networks_common
+                           + barcodebuddy_docker_networks_default
+                           + barcodebuddy_docker_networks_custom }}"
+
+# Capabilities
+barcodebuddy_docker_capabilities_default: []
+barcodebuddy_docker_capabilities_custom: []
+barcodebuddy_docker_capabilities: "{{ barcodebuddy_docker_capabilities_default
+                               + barcodebuddy_docker_capabilities_custom }}"
+
+# Security Opts
+barcodebuddy_docker_security_opts_default: []
+barcodebuddy_docker_security_opts_custom: []
+barcodebuddy_docker_security_opts: "{{ barcodebuddy_docker_security_opts_default
+                                + barcodebuddy_docker_security_opts_custom }}"
+
+# Restart Policy
+barcodebuddy_docker_restart_policy: unless-stopped
+
+# State
+barcodebuddy_docker_state: started

--- a/roles/barcodebuddy/defaults/main.yml
+++ b/roles/barcodebuddy/defaults/main.yml
@@ -30,8 +30,8 @@ barcodebuddy_web_subdomain: "{{ barcodebuddy_name }}"
 barcodebuddy_web_domain: "{{ user.domain }}"
 barcodebuddy_web_port: "80"
 barcodebuddy_web_url: "{{ 'https://' + (barcodebuddy_web_subdomain + '.' + barcodebuddy_web_domain
-                if (barcodebuddy_web_subdomain | length > 0)
-                else barcodebuddy_web_domain) }}"
+                       if (barcodebuddy_web_subdomain | length > 0)
+                       else barcodebuddy_web_domain) }}"
 
 ################################
 # DNS
@@ -67,7 +67,7 @@ barcodebuddy_docker_image: "f0rc3/barcodebuddy:{{ barcodebuddy_docker_image_tag 
 barcodebuddy_docker_ports_defaults: []
 barcodebuddy_docker_ports_custom: []
 barcodebuddy_docker_ports: "{{ barcodebuddy_docker_ports_defaults
-                        + barcodebuddy_docker_ports_custom }}"
+                               + barcodebuddy_docker_ports_custom }}"
 
 # Envs
 barcodebuddy_docker_envs_default:
@@ -76,40 +76,40 @@ barcodebuddy_docker_envs_default:
   TZ: "{{ tz }}"
 barcodebuddy_docker_envs_custom: {}
 barcodebuddy_docker_envs: "{{ barcodebuddy_docker_envs_default
-                       | combine(barcodebuddy_docker_envs_custom) }}"
+                              | combine(barcodebuddy_docker_envs_custom) }}"
 
 # Commands
 barcodebuddy_docker_commands_default: []
 barcodebuddy_docker_commands_custom: []
 barcodebuddy_docker_commands: "{{ barcodebuddy_docker_commands_default
-                           + barcodebuddy_docker_commands_custom }}"
+                                  + barcodebuddy_docker_commands_custom }}"
 
 # Volumes
 barcodebuddy_docker_volumes_default:
   - "{{ barcodebuddy_paths_location }}:/config"
 barcodebuddy_docker_volumes_custom: []
 barcodebuddy_docker_volumes: "{{ barcodebuddy_docker_volumes_default
-                          + barcodebuddy_docker_volumes_custom }}"
+                                 + barcodebuddy_docker_volumes_custom }}"
 
 # Devices
 barcodebuddy_docker_devices_default: []
 barcodebuddy_docker_devices_custom: []
 barcodebuddy_docker_devices: "{{ barcodebuddy_docker_devices_default
-                          + barcodebuddy_docker_devices_custom }}"
+                                 + barcodebuddy_docker_devices_custom }}"
 
 # Hosts
 barcodebuddy_docker_hosts_default: {}
 barcodebuddy_docker_hosts_custom: {}
 barcodebuddy_docker_hosts: "{{ docker_hosts_common
-                        | combine(barcodebuddy_docker_hosts_default)
-                        | combine(barcodebuddy_docker_hosts_custom) }}"
+                               | combine(barcodebuddy_docker_hosts_default)
+                               | combine(barcodebuddy_docker_hosts_custom) }}"
 
 # Labels
 barcodebuddy_docker_labels_default: {}
 barcodebuddy_docker_labels_custom: {}
 barcodebuddy_docker_labels: "{{ docker_labels_common
-                         | combine(barcodebuddy_docker_labels_default)
-                         | combine(barcodebuddy_docker_labels_custom) }}"
+                                | combine(barcodebuddy_docker_labels_default)
+                                | combine(barcodebuddy_docker_labels_custom) }}"
 
 # Hostname
 barcodebuddy_docker_hostname: "{{ barcodebuddy_name }}"
@@ -119,20 +119,20 @@ barcodebuddy_docker_networks_alias: "{{ barcodebuddy_name }}"
 barcodebuddy_docker_networks_default: []
 barcodebuddy_docker_networks_custom: []
 barcodebuddy_docker_networks: "{{ docker_networks_common
-                           + barcodebuddy_docker_networks_default
-                           + barcodebuddy_docker_networks_custom }}"
+                                  + barcodebuddy_docker_networks_default
+                                  + barcodebuddy_docker_networks_custom }}"
 
 # Capabilities
 barcodebuddy_docker_capabilities_default: []
 barcodebuddy_docker_capabilities_custom: []
 barcodebuddy_docker_capabilities: "{{ barcodebuddy_docker_capabilities_default
-                               + barcodebuddy_docker_capabilities_custom }}"
+                                      + barcodebuddy_docker_capabilities_custom }}"
 
 # Security Opts
 barcodebuddy_docker_security_opts_default: []
 barcodebuddy_docker_security_opts_custom: []
 barcodebuddy_docker_security_opts: "{{ barcodebuddy_docker_security_opts_default
-                                + barcodebuddy_docker_security_opts_custom }}"
+                                       + barcodebuddy_docker_security_opts_custom }}"
 
 # Restart Policy
 barcodebuddy_docker_restart_policy: unless-stopped

--- a/roles/barcodebuddy/tasks/main.yml
+++ b/roles/barcodebuddy/tasks/main.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:            Sandbox: Barcode Buddy                              #
+# Author(s):        edzeg                                               #
+# URL:              https://github.com/Forceu/barcodebuddy              #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/barcodebuddy/tasks/main.yml
+++ b/roles/barcodebuddy/tasks/main.yml
@@ -22,3 +22,4 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+  

--- a/roles/barcodebuddy/tasks/main.yml
+++ b/roles/barcodebuddy/tasks/main.yml
@@ -22,4 +22,3 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
-  

--- a/roles/grocy/defaults/main.yml
+++ b/roles/grocy/defaults/main.yml
@@ -1,0 +1,141 @@
+##########################################################################
+# Title:         Sandbox: Grocy | Default Variables                      #
+# Author(s):     edzeg                                                   #
+# URL:           https://grocy.info/                                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+grocy_name: grocy
+
+################################
+# Paths
+################################
+
+grocy_paths_folder: "{{ grocy_name }}"
+grocy_paths_location: "{{ server_appdata_path }}/{{ grocy_paths_folder }}"
+grocy_paths_folders_list:
+  - "{{ grocy_paths_location }}"
+
+################################
+# Web
+################################
+
+grocy_web_subdomain: "{{ grocy_name }}"
+grocy_web_domain: "{{ user.domain }}"
+grocy_web_port: "80"
+grocy_web_url: "{{ 'https://' + (grocy_web_subdomain + '.' + grocy_web_domain
+                if (grocy_web_subdomain | length > 0)
+                else grocy_web_domain) }}"
+
+################################
+# DNS
+################################
+
+grocy_dns_record: "{{ grocy_web_subdomain }}"
+grocy_dns_zone: "{{ grocy_web_domain }}"
+grocy_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+grocy_traefik_sso_middleware: ""
+grocy_traefik_middleware_default: "{{ traefik_default_middleware }}"
+grocy_traefik_middleware_custom: ""
+grocy_traefik_certresolver: "{{ traefik_default_certresolver }}"
+grocy_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+grocy_docker_container: "{{ grocy_name }}"
+
+# Image
+grocy_docker_image_pull: true
+grocy_docker_image_tag: "latest"
+grocy_docker_image: "lscr.io/linuxserver/grocy:{{ grocy_docker_image_tag }}"
+
+# Ports
+grocy_docker_ports_defaults: []
+grocy_docker_ports_custom: []
+grocy_docker_ports: "{{ grocy_docker_ports_defaults
+                        + grocy_docker_ports_custom }}"
+
+# Envs
+grocy_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+grocy_docker_envs_custom: {}
+grocy_docker_envs: "{{ grocy_docker_envs_default
+                       | combine(grocy_docker_envs_custom) }}"
+
+# Commands
+grocy_docker_commands_default: []
+grocy_docker_commands_custom: []
+grocy_docker_commands: "{{ grocy_docker_commands_default
+                           + grocy_docker_commands_custom }}"
+
+# Volumes
+grocy_docker_volumes_default:
+  - "{{ grocy_paths_location }}:/config"
+grocy_docker_volumes_custom: []
+grocy_docker_volumes: "{{ grocy_docker_volumes_default
+                          + grocy_docker_volumes_custom }}"
+
+# Devices
+grocy_docker_devices_default: []
+grocy_docker_devices_custom: []
+grocy_docker_devices: "{{ grocy_docker_devices_default
+                          + grocy_docker_devices_custom }}"
+
+# Hosts
+grocy_docker_hosts_default: {}
+grocy_docker_hosts_custom: {}
+grocy_docker_hosts: "{{ docker_hosts_common
+                        | combine(grocy_docker_hosts_default)
+                        | combine(grocy_docker_hosts_custom) }}"
+
+# Labels
+grocy_docker_labels_default: {}
+grocy_docker_labels_custom: {}
+grocy_docker_labels: "{{ docker_labels_common
+                         | combine(grocy_docker_labels_default)
+                         | combine(grocy_docker_labels_custom) }}"
+
+# Hostname
+grocy_docker_hostname: "{{ grocy_name }}"
+
+# Networks
+grocy_docker_networks_alias: "{{ grocy_name }}"
+grocy_docker_networks_default: []
+grocy_docker_networks_custom: []
+grocy_docker_networks: "{{ docker_networks_common
+                           + grocy_docker_networks_default
+                           + grocy_docker_networks_custom }}"
+
+# Capabilities
+grocy_docker_capabilities_default: []
+grocy_docker_capabilities_custom: []
+grocy_docker_capabilities: "{{ grocy_docker_capabilities_default
+                               + grocy_docker_capabilities_custom }}"
+
+# Security Opts
+grocy_docker_security_opts_default: []
+grocy_docker_security_opts_custom: []
+grocy_docker_security_opts: "{{ grocy_docker_security_opts_default
+                                + grocy_docker_security_opts_custom }}"
+
+# Restart Policy
+grocy_docker_restart_policy: unless-stopped
+
+# State
+grocy_docker_state: started

--- a/roles/grocy/tasks/main.yml
+++ b/roles/grocy/tasks/main.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:            Sandbox: Grocy                                      #
+# Author(s):        edzeg                                               #
+# URL:              https://grocy.info/                                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/grocy/tasks/main.yml
+++ b/roles/grocy/tasks/main.yml
@@ -22,3 +22,4 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+  

--- a/roles/grocy/tasks/main.yml
+++ b/roles/grocy/tasks/main.yml
@@ -22,4 +22,3 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
-  

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -27,6 +27,7 @@
     - { role: archivebox, tags: ['archivebox'] }
     - { role: aria2_ng, tags: ['aria2-ng'] }
     - { role: audiobookshelf, tags: ['audiobookshelf'] }
+    - { role: barcodebuddy, tags: ['barcodebuddy'] }
     - { role: beets, tags: ['beets'] }
     - { role: booksonic, tags: ['booksonic'] }
     - { role: bookstack, tags: ['bookstack'] }
@@ -72,6 +73,7 @@
     - { role: goplaxt, tags: ['goplaxt'] }
     - { role: gotenberg, tags: ['gotenberg'] }
     - { role: gotify, tags: ['gotify'] }
+    - { role: grocy, tags: ['grocy'] }
     - { role: guacamole, tags: ['guacamole'] }
     - { role: handbrake, tags: ['handbrake'] }
     - { role: healthchecks, tags: ['healthchecks'] }


### PR DESCRIPTION
# Description

### **[Grocy](https://grocy.info/)**
Grocy is a web-based self-hosted groceries & household management solution for your home.
Inventory and track your household consumables, from your pantry, to your fridge, to your cleaning supplies.
Also allows assigning and tracking of Household Chores.
(can also be connected with Home Assistant)

Recipes can also be added to Grocy and, in theory, this can simplify Meal Planning and creating Shopping Lists.


### **[Barcode Buddy](https://github.com/Forceu/barcodebuddy)**
Companion tool for Grocy that makes adding/managing items easier.
Pass barcodes to Barcode Buddy.
If already in the Grocys system, it will consume/add/open the product there.
If an unknown barcode is passed, the product name will be looked up and a corresponding product can be chosen in the Web UI.
Tags can be saved — if a new product contains the tag in the name, the product will be already preselected in the drop-down list.



To Do:

[ ] Create Documentation


# How Has This Been Tested?

- [X] Created both Grocy and Barcode Buddy containers on my server
- [X] Connected Barcode Buddy to Grocy API
- [X] Set up companion apps for Grocy (Android & iOS) and Barcode Buddy (Android), and bought a bluetooth barcode scanner (though you can also use device's camera, but this was more satisfying)
- [X] Performed inventory of my Pantry using Barcode Buddy to search barcodes and create products in Grocy