### PR TITLE
Teslamate secrets fix

### DIFF
--- a/roles/teslamate/defaults/main.yml
+++ b/roles/teslamate/defaults/main.yml
@@ -19,7 +19,7 @@ teslamate_secret_key: "{{ teslamate_saltbox_facts.facts.secret_key }}"
 
 teslamate_postgres_name: "{{ teslamate_name }}-postgres"
 teslamate_postgres_docker_env_db: "{{ teslamate_name }}"
-teslamate_postgres_docker_env_password: "{{ teslamate_db_saltbox_facts.facts.secret_key }}"
+teslamate_postgres_docker_env_password: "{{ teslamate_saltbox_facts.facts.postgres_password }}"
 teslamate_postgres_docker_image_tag: "16"
 teslamate_postgres_docker_image_repo: "postgres"
 teslamate_postgres_paths_folder: "{{ teslamate_name }}"

--- a/roles/teslamate/tasks/main.yml
+++ b/roles/teslamate/tasks/main.yml
@@ -17,6 +17,42 @@
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 
+- name: Check if '/opt/saltbox/teslamate_db.ini' folder exists
+  ansible.builtin.stat:
+    path: "/opt/saltbox/teslamate_db.ini"
+  register: teslamate_db_stat
+
+- name: Migration Block
+  when: teslamate_db_stat.stat.exists
+  block:
+    - name: "Load legacy Teslamate Postgres Saltbox facts"
+      saltbox_facts:
+        role: "teslamate_db"
+        instance: "teslamate"
+        keys:
+          secret_key: ""
+        method: load
+        owner: "{{ user.name }}"
+        group: "{{ user.name }}"
+      register: teslamate_db_saltbox_facts
+
+    - name: "Save Teslamate Saltbox facts"
+      saltbox_facts:
+        role: "teslamate"
+        instance: "teslamate"
+        keys:
+          secret_key: "{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=50) }}"
+          postgres_password: "{{ teslamate_db_saltbox_facts.facts.secret_key }}"
+        owner: "{{ user.name }}"
+        group: "{{ user.name }}"
+
+    - name: "Delete legacy Teslamate Postgres Saltbox facts"
+      saltbox_facts:
+        role: "teslamate_db"
+        instance: "teslamate"
+        delete_type: "role"
+        method: "delete"
+
 - name: "Save Teslamate Saltbox facts"
   saltbox_facts:
     role: "teslamate"
@@ -29,7 +65,7 @@
   register: teslamate_saltbox_facts
   tags:
     - teslamate
-    - teslamate-grafana
+    - teslamate-postgres-password
 
 - name: Postgres Role
   ansible.builtin.include_role:
@@ -43,11 +79,11 @@
     postgres_docker_env_db: "{{ teslamate_postgres_docker_env_db }}"
     postgres_docker_env_password: "{{ teslamate_postgres_docker_env_password }}"
 
-- name: Show Teslamate DB Password
+- name: Print Teslamate DB Password
   ansible.builtin.debug:
     msg: "{{ teslamate_postgres_docker_env_password }}"
   tags:
-    - teslamate-grafana
+    - teslamate-postgres-password
 
 - name: Mosquitto Role
   ansible.builtin.include_role:

--- a/roles/teslamate/tasks/main.yml
+++ b/roles/teslamate/tasks/main.yml
@@ -27,6 +27,9 @@
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
   register: teslamate_saltbox_facts
+  tags:
+    - teslamate
+    - teslamate-grafana
 
 - name: Postgres Role
   ansible.builtin.include_role:
@@ -39,6 +42,12 @@
     postgres_docker_image_tag: "{{ teslamate_postgres_docker_image_tag }}"
     postgres_docker_env_db: "{{ teslamate_postgres_docker_env_db }}"
     postgres_docker_env_password: "{{ teslamate_postgres_docker_env_password }}"
+
+- name: Show Teslamate DB Password
+  ansible.builtin.debug:
+    msg: "{{ teslamate_postgres_docker_env_password }}"
+  tags:
+    - teslamate-grafana
 
 - name: Mosquitto Role
   ansible.builtin.include_role:

--- a/roles/teslamate/tasks/main.yml
+++ b/roles/teslamate/tasks/main.yml
@@ -17,22 +17,13 @@
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 
-- name: "Save Teslamate Postgres Saltbox facts"
-  saltbox_facts:
-    role: "teslamate_db"
-    instance: "teslamate"
-    keys:
-      secret_key: "{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=50) }}"
-    owner: "{{ user.name }}"
-    group: "{{ user.name }}"
-  register: teslamate_db_saltbox_facts
-
 - name: "Save Teslamate Saltbox facts"
   saltbox_facts:
     role: "teslamate"
     instance: "teslamate"
     keys:
       secret_key: "{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=50) }}"
+      postgres_password: "{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=50) }}"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
   register: teslamate_saltbox_facts


### PR DESCRIPTION
# Description

For existing roles;

The issue we were having was that two .ini's were generated and two fact sheets were made. I merged both facts into a singular sheet and created a single .ini to store it. I then added a tag in tasks that allows the user to run sb install sandbox-teslamate-grafana to grab the DB password the user needs when setting up the data source in grafana.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.  You can use the checkboxes below or delete them as you wish.

- [ ] I deployed this in my dev box and did not lose any functionality
- [ ] I deployed this to prod once dev validation was done and did not lose any functionality.
- [ ] Validated that teslamate is using new db password that was generated by deleting the DB fact sheet for teslamate_db and only relying on teslamate.ini
