### PR TITLE
Additional Telegraf Features

### DIFF
--- a/roles/telegraf/defaults/main.yml
+++ b/roles/telegraf/defaults/main.yml
@@ -1,0 +1,155 @@
+#########################################################################
+# Title:            Saltbox: telegraf                                   #
+# Author(s):        Zuke97, salty                                       #
+# URL:              https://github.com/saltyorg/Saltbox                 #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+
+telegraf_instances: ["telegraf"]
+
+################################
+# Paths
+################################
+
+telegraf_paths_folder: "telegraf"
+telegraf_paths_location: "{{ server_appdata_path }}/{{ telegraf_paths_folder }}"
+telegraf_paths_folders_list:
+  - "{{ telegraf_paths_location }}/"
+  - "{{ telegraf_paths_location }}/{{ telegraf_name }}"
+telegraf_paths_recursive: true
+
+################################
+# Web
+################################
+
+telegraf_web_subdomain: "{{ telegraf_name }}"
+telegraf_web_domain: "{{ user.domain }}"
+
+################################
+# DNS
+################################
+
+telegraf_dns_record: "{{ lookup('vars', telegraf_name + '_web_subdomain', default=telegraf_web_subdomain) }}"
+telegraf_dns_zone: "{{ lookup('vars', telegraf_name + '_web_domain', default=telegraf_web_domain) }}"
+telegraf_dns_proxy: false
+
+################################
+# Traefik
+################################
+
+telegraf_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+telegraf_traefik_middleware_default: "{{ traefik_default_middleware }}"
+telegraf_traefik_middleware_custom: ""
+telegraf_traefik_certresolver: "{{ traefik_default_certresolver }}"
+telegraf_traefik_enabled: true
+telegraf_traefik_api_enabled: false
+telegraf_traefik_api_endpoint: ""
+
+################################
+# Docker
+################################
+
+# Container
+telegraf_docker_container: "{{ telegraf_name }}"
+
+# Image
+telegraf_docker_image_pull: true
+telegraf_docker_image_repo: "telegraf"
+telegraf_docker_image_tag: "latest"
+telegraf_docker_image: "{{ lookup('vars', telegraf_name + '_docker_image_repo', default=telegraf_docker_image_repo)
+                            + ':' + lookup('vars', telegraf_name + '_docker_image_tag', default=telegraf_docker_image_tag) }}"
+
+# Ports
+telegraf_docker_ports_defaults: []
+telegraf_docker_ports_custom: []
+telegraf_docker_ports: "{{ lookup('vars', telegraf_name + '_docker_ports_defaults', default=telegraf_docker_ports_defaults)
+                            + lookup('vars', telegraf_name + '_docker_ports_custom', default=telegraf_docker_ports_custom) }}"
+
+# Envs
+telegraf_docker_envs_default:
+  TZ: "{{ tz }}"
+  EULA: "TRUE"
+  UID: "{{ uid }}"
+  GID: "{{ gid }}"
+telegraf_docker_envs_custom: {}
+telegraf_docker_envs: "{{ lookup('vars', telegraf_name + '_docker_envs_default', default=telegraf_docker_envs_default)
+                           | combine(lookup('vars', telegraf_name + '_docker_envs_custom', default=telegraf_docker_envs_custom)) }}"
+
+# Commands
+telegraf_docker_commands_default: []
+telegraf_docker_commands_custom: []
+telegraf_docker_commands: "{{ lookup('vars', telegraf_name + '_docker_commands_default', default=telegraf_docker_commands_default)
+                               + lookup('vars', telegraf_name + '_docker_commands_custom', default=telegraf_docker_commands_custom) }}"
+
+# Volumes
+telegraf_docker_volumes_default:
+  - "/opt/telegraf/{{ telegraf_name }}:/etc/telegraf:ro"
+  - "/var/run/docker.sock:/var/run/docker.sock:ro"
+  - "/var/run/utmp:/var/run/utmp"
+  - "/:/host:ro"
+  - "/sys:/host/sys:ro"
+  - "/proc:/host/proc:ro"
+  - "/etc:/host/etc:ro"
+telegraf_docker_volumes_custom: []
+telegraf_docker_volumes: "{{ lookup('vars', telegraf_name + '_docker_volumes_default', default=telegraf_docker_volumes_default)
+                              + lookup('vars', telegraf_name + '_docker_volumes_custom', default=telegraf_docker_volumes_custom) }}"
+
+# Devices
+telegraf_docker_devices_default: []
+telegraf_docker_devices_custom: []
+telegraf_docker_devices: "{{ lookup('vars', telegraf_name + '_docker_devices_default', default=telegraf_docker_devices_default)
+                              + lookup('vars', telegraf_name + '_docker_devices_custom', default=telegraf_docker_devices_custom) }}"
+
+# Hosts
+telegraf_docker_hosts_default: {}
+telegraf_docker_hosts_custom: {}
+telegraf_docker_hosts: "{{ docker_hosts_common
+                            | combine(lookup('vars', telegraf_name + '_docker_hosts_default', default=telegraf_docker_hosts_default))
+                            | combine(lookup('vars', telegraf_name + '_docker_hosts_custom', default=telegraf_docker_hosts_custom)) }}"
+
+# Labels
+telegraf_docker_labels_default: {
+  "com.github.saltbox.saltbox_managed": "true"
+}
+telegraf_docker_labels_custom: {}
+telegraf_docker_labels: "{{ docker_labels_common
+                             | combine(lookup('vars', telegraf_name + '_docker_labels_default', default=telegraf_docker_labels_default))
+                             | combine(lookup('vars', telegraf_name + '_docker_labels_custom', default=telegraf_docker_labels_custom)) }}"
+
+# Hostname
+telegraf_docker_hostname: "{{ telegraf_name }}"
+
+# Network Mode
+telegraf_docker_network_mode_default: "{{ docker_networks_name_common }}"
+telegraf_docker_network_mode: "{{ lookup('vars', telegraf_name + '_docker_network_mode_default', default=telegraf_docker_network_mode_default) }}"
+
+# Networks
+telegraf_docker_networks_alias: "{{ telegraf_name }}"
+telegraf_docker_networks_default: []
+telegraf_docker_networks_custom: []
+telegraf_docker_networks: "{{ docker_networks_common
+                               + lookup('vars', telegraf_name + '_docker_networks_default', default=telegraf_docker_networks_default)
+                               + lookup('vars', telegraf_name + '_docker_networks_custom', default=telegraf_docker_networks_custom) }}"
+
+# Capabilities
+telegraf_docker_capabilities_default: []
+telegraf_docker_capabilities_custom: []
+telegraf_docker_capabilities: "{{ lookup('vars', telegraf_name + '_docker_capabilities_default', default=telegraf_docker_capabilities_default)
+                                   + lookup('vars', telegraf_name + '_docker_capabilities_custom', default=telegraf_docker_capabilities_custom) }}"
+
+# Security Opts
+telegraf_docker_security_opts_default: []
+telegraf_docker_security_opts_custom: []
+telegraf_docker_security_opts: "{{ lookup('vars', telegraf_name + '_docker_security_opts_default', default=telegraf_docker_security_opts_default)
+                                    + lookup('vars', telegraf_name + '_docker_security_opts_custom', default=telegraf_docker_security_opts_custom) }}"
+
+# Restart Policy
+telegraf_docker_restart_policy: unless-stopped
+
+# State
+telegraf_docker_state: started

--- a/roles/telegraf/tasks/main.yml
+++ b/roles/telegraf/tasks/main.yml
@@ -1,68 +1,28 @@
 #########################################################################
-# Title:            Sandbox: Telegraf Role                              #
-# Author(s):        desimaniac, salty                                   #
-# URL:              https://github.com/saltyorg/Sandbox                 #
+# Title:         Saltbox: Telegraf | Multi-instance Tasks               #
+# Author(s):     Zuke97, salty                                          #
+# URL:           https://github.com/saltyorg/Saltbox                    #
 # --                                                                    #
 #########################################################################
 #                   GNU General Public License v3.0                     #
 #########################################################################
 ---
-- name: Stop and remove any existing containers
-  community.docker.docker_container:
-    name: telegraf
-    container_default_behavior: compatibility
-    tls_hostname: localhost
-    state: absent
+- name: Ensure we have instances for telegraf to install
+  ansible.builtin.assert:
+    that:
+      - telegraf_instances is not string
+      - telegraf_instances is not mapping
+      - telegraf_instances is iterable
+      - telegraf_instances | length > 0
+    fail_msg: >-
+      Telegraf was designed to use multi-instance configuration to install properly. Check out https://docs.saltbox.dev/reference/multiple-instances/
+    success_msg: >-
+      Detected multi-instance configuration.
 
-- name: Create required directories
-  ansible.builtin.file:
-    path: "/opt/telegraf"
-    state: "directory"
-    mode: "0775"
-    owner: "{{ user.name }}"
-    group: "{{ user.name }}"
-
-- name: Check if telegraf config exists
-  ansible.builtin.stat:
-    path: "/opt/telegraf/telegraf.conf"
-  register: telegraf_conf
-
-- name: Import telegraf config if needed
-  ansible.builtin.copy:
-    src: "telegraf.conf"
-    dest: "/opt/telegraf/telegraf.conf"
-    owner: "{{ uid }}"
-    group: "{{ gid }}"
-    mode: "0664"
-  when: not telegraf_conf.stat.exists
-
-- name: Create and start telegraf container
-  community.docker.docker_container:
-    name: telegraf
-    image: "telegraf"
-    pull: true
-    command_handling: compatibility
-    container_default_behavior: compatibility
-    default_host_ip: ""
-    volumes:
-      - "/opt/telegraf:/etc/telegraf:ro"
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      - "/var/run/utmp:/var/run/utmp"
-      - "/:/host:ro"
-      - "/sys:/host/sys:ro"
-      - "/proc:/host/proc:ro"
-      - "/etc:/host/etc:ro"
-    labels:
-      "com.github.saltbox.saltbox_managed": "true"
-    networks:
-      - name: saltbox
-        aliases:
-          - telegraf
-    network_mode: "saltbox"
-    networks_cli_compatible: true
-    comparisons:
-      '*': ignore
-    user: "telegraf:{{ dockergid }}"
-    tls_hostname: localhost
-    restart_policy: unless-stopped
-    state: started
+- name: "Execute telegraf roles"
+  ansible.builtin.include_tasks: main2.yml
+  vars:
+    telegraf_name: "{{ instance }}"
+  with_items: "{{ telegraf_instances }}"
+  loop_control:
+    loop_var: instance

--- a/roles/telegraf/tasks/main2.yml
+++ b/roles/telegraf/tasks/main2.yml
@@ -1,0 +1,38 @@
+#########################################################################
+# Title:            Sandbox: Telegraf | Deployment Tasks                #
+# Author(s):        desimaniac, Zuke97, salty                           #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create required directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Check if config exists
+  ansible.builtin.stat:
+    path: "{{ telegraf_paths_location }}/{{ telegraf_name }}/telegraf.conf"
+  register: telegraf_conf
+
+- name: Import telegraf config if needed
+  ansible.builtin.copy:
+    src: "telegraf.conf"
+    dest: "{{ telegraf_paths_location }}/{{ telegraf_name }}/telegraf.conf"
+    owner: "{{ uid }}"
+    group: "{{ gid }}"
+    mode: "0664"
+  when: not telegraf_conf.stat.exists
+
+- name: Create and start telegraf container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"


### PR DESCRIPTION
# Description

Added support for multiple instances, external access, and inventory customization that most other roles have. 

I've been trying to get IoT devices to talk to influxDB via webhooks through telegraf and discovered that telegraf was only available locally.

I'll try to remember to get around to updating the docs page


Telegraf doesn't really like the default config that was here before, but since each implementation requires a custom config I see no real reason to tweak it.

# How Has This Been Tested?
- [X] Single instance install with no inventory modifications
- [X] Single instance install w/new instance name and traefik/docker customization in inventory
- [X] Dual instance install (same as above, with another standard one)
