### PR TITLE
FireflyIII Importer: Change domain name to fireflyiii-importer

### DIFF
--- a/roles/fireflyiii_importer/defaults/main.yml
+++ b/roles/fireflyiii_importer/defaults/main.yml
@@ -11,7 +11,7 @@
 # Basics
 ################################
 
-fireflyiii_importer_name: fireflyiii_importer
+fireflyiii_importer_name: fireflyiii-importer
 
 ################################
 # Paths

--- a/roles/fireflyiii_importer/tasks/main.yml
+++ b/roles/fireflyiii_importer/tasks/main.yml
@@ -14,6 +14,11 @@
     dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
     dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
 
+- name: Remove legacy Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+  vars:
+    var_prefix: "fireflyiii_importer"
+
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 


### PR DESCRIPTION
# Description

This pull request fixes an issue with client ID authentication between fireflyiii and fireflyiii_importer. Currently the importer only relies on Token Access, which requires to add a value to localhost.yml inventory. I personnaly haven't been able to successfully use the importer relying on the Token Access method.

Currently when creating a Client ID in Firefly III (Profile > Oauth) using an URL including a `_` doesn't work and doesn't display any error message. Replacing it with `-` fixes this issue and allows you to use Client ID instead of an Access Token.

# How Has This Been Tested?

- [x] Ran `sb install sandbox-fireflyiii_importer and sandbox-fireflyiii`
- [x] Created a Client ID referencing the correct domain name in Firefly III
- [x] Successfully imported data using Client ID instead of Token Access

For firefly users please don't forget to remove old containers since the name changed.