### PR TITLE
FireflyIII Importer: Adds support for server-side import

### DIFF
--- a/roles/fireflyiii_importer/defaults/main.yml
+++ b/roles/fireflyiii_importer/defaults/main.yml
@@ -21,6 +21,7 @@ fireflyiii_importer_paths_folder: "{{ fireflyiii_name }}"
 fireflyiii_importer_paths_location: "{{ server_appdata_path }}/{{ fireflyiii_importer_paths_folder }}"
 fireflyiii_importer_paths_folders_list:
   - "{{ fireflyiii_importer_paths_location }}"
+  - "{{ fireflyiii_importer_paths_location }}/import"
 
 ################################
 # Web
@@ -73,6 +74,7 @@ fireflyiii_importer_docker_ports: "{{ fireflyiii_importer_docker_ports_defaults
 
 # Envs
 fireflyiii_importer_docker_envs_default:
+  IMPORT_DIR_ALLOWLIST: /import
   FIREFLY_III_URL: "http://{{ fireflyiii_name }}:8080"
   VANITY_URL: "{{ fireflyiii_web_url }}"
   TRUSTED_PROXIES: "**"
@@ -89,6 +91,7 @@ fireflyiii_importer_docker_commands: "{{ fireflyiii_importer_docker_commands_def
 
 # Volumes
 fireflyiii_importer_docker_volumes_default:
+  - "{{ fireflyiii_paths_location }}/import:/import"
   - /etc/timezone:/etc/timezone:ro
   - /etc/localtime:/etc/localtime:ro
 fireflyiii_importer_docker_volumes_custom: []


### PR DESCRIPTION
# Description

This pull request allows user to import CSV files from the server.

By default, the importer allows users to import CSV using the web interface. This interface doesn't surface big CSV files because of a 600 seconds processing limitation. This limitation doesn't exists from the server side, procedure is explained in the following documentation: https://docs.firefly-iii.org/how-to/data-importer/import/automated/

Config and transactions files need to be copied in /opt/fireflyiii/import directory.

New functionalities:

- Added env variable IMPORT_DIR_ALLOWLIST=/import
- Added directory /opt/fireflyiii/import
- Added volume /opt/fireflyiii/import:/import.

# How Has This Been Tested?

- [x] Ran `sb install sandbox-fireflyiii_importer and sandbox-fireflyiii`
- [x] Copied a .CSV file containing a high number of transactions (over 5000) in /opt/filreflyiii/import
- [x] Copied a .JSON config file
- [x] Successfully executed the import (over 1 hour of duration): `docker exec -it fireflyiii-importer php artisan importer:import /import/xxx.json /import/xxx.csv`