### PR TITLE
Homebox fork

### DIFF
--- a/roles/homebox/defaults/main.yml
+++ b/roles/homebox/defaults/main.yml
@@ -63,7 +63,7 @@ homebox_docker_container: "{{ homebox_name }}"
 # Image
 homebox_docker_image_pull: true
 homebox_docker_image_tag: "latest"
-homebox_docker_image: "ghcr.io/hay-kot/homebox:{{ homebox_docker_image_tag }}"
+homebox_docker_image: "ghcr.io/sysadminsmedia/homebox:{{ homebox_docker_image_tag }}"
 
 # Ports
 homebox_docker_ports_defaults: []

--- a/roles/homebox/tasks/main.yml
+++ b/roles/homebox/tasks/main.yml
@@ -26,4 +26,4 @@
 
 - name: Print Tweaking Info
   ansible.builtin.debug:
-    msg: "For custom docker envs, please visit: https://hay-kot.github.io/homebox/quick-start/"
+    msg: "For custom docker envs, please visit: https://homebox.software/en/quick-start.html"


### PR DESCRIPTION
# Description

The [original Homebox project](https://github.com/hay-kot/homebox) appears to have been archived in June of 2024, but a [fork](https://github.com/sysadminsmedia/homebox) appears to be under active development. This PR is just a change of the image that the role uses.

# How Has This Been Tested?

- [X] I added `homebox_docker_image: "ghcr.io/sysadminsmedia/homebox:{{ homebox_docker_image_tag }}"` to my inventory and ran the homebox tag again. The existing data I had in Homebox appears to still be there.
- [X] I read through the [release notes](https://github.com/sysadminsmedia/homebox/releases) of the fork and there did not seem to be any breaking changes that would impact the Saltbox implementation (based on my limited understanding).

I am not a Homebox power user by any means, so if there is specific Homebox functionality that should be tested please let me know. Additionally if there are any test steps you would have expected to see when moving a Sandbox role to a fork I'm happy to go through those as well.
