### PR TITLE
Update Wrapperr docker volume

### DIFF
--- a/roles/wrapperr/defaults/main.yml
+++ b/roles/wrapperr/defaults/main.yml
@@ -85,7 +85,7 @@ wrapperr_docker_commands: "{{ wrapperr_docker_commands_default
 
 # Volumes
 wrapperr_docker_volumes_default:
-  - "{{ wrapperr_paths_location }}:/var/www/html/config"
+  - "{{ wrapperr_paths_location }}:/app/config"
 wrapperr_docker_volumes_custom: []
 wrapperr_docker_volumes: "{{ wrapperr_docker_volumes_default
                              + wrapperr_docker_volumes_custom }}"


### PR DESCRIPTION
# Description

It looks like at some point there was an upstream change to the Wrapperr volume mapping with regards to the internal container path. A new install of the app would lose any configuration changes if the tag was run again.

The Wrapperr docker compose example from their [GitHub](https://github.com/aunefyren/wrapperr/wiki/Docker) has the volume mapping as `'./my-folder:/app/config'`, but the Sandbox role uses `"{{ wrapperr_paths_location }}:/var/www/html/config"`. This PR updates the mapping to what is currently expected by Wrapperr.

# How Has This Been Tested?

- [X] I added the following entry to my inventory and ran the wrapperr tag. I then configured the app and ran the wrapperr tag again. After running the tag a second time the configuration changes persist.
```
wrapperr_docker_volumes_default:
  - "{{ wrapperr_paths_location }}:/app/config"
```

I'd appreciate it if a reviewer did a sanity check and considered if this would break any other users existing Wrapper setups, I think that's a little over my head. Thanks!