### PR TITLE
Hoarder/Chrome/Meilisearch roles

### DIFF
--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -85,7 +85,3 @@ transmissionvpn:
 your_spotify:
   public_key:
   secret_key:
-hoarder:
-  nextauth_secret:
-meilisearch:
-  meili_master_key:

--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -85,3 +85,6 @@ transmissionvpn:
 your_spotify:
   public_key:
   secret_key:
+hoarder:
+  nextauth_secret:
+  meili_master_key:

--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -87,4 +87,5 @@ your_spotify:
   secret_key:
 hoarder:
   nextauth_secret:
+meilisearch:
   meili_master_key:

--- a/roles/chrome/defaults/main.yml
+++ b/roles/chrome/defaults/main.yml
@@ -52,12 +52,12 @@ chrome_docker_envs: "{{ chrome_docker_envs_default
 
 # Commands
 chrome_docker_commands_default:
-  - --no-sandbox
-  - --disable-gpu
-  - --disable-dev-shm-usage
-  - --remote-debugging-address=0.0.0.0
-  - --remote-debugging-port=9222
-  - --hide-scrollbars
+  - "--no-sandbox"
+  - "--disable-gpu"
+  - "--disable-dev-shm-usage"
+  - "--remote-debugging-address=0.0.0.0"
+  - "--remote-debugging-port=9222"
+  - "--hide-scrollbars"
 chrome_docker_commands_custom: []
 chrome_docker_commands: "{{ chrome_docker_commands_default
                              + chrome_docker_commands_custom }}"

--- a/roles/chrome/defaults/main.yml
+++ b/roles/chrome/defaults/main.yml
@@ -1,0 +1,118 @@
+##########################################################################
+# Title:            Sandbox: Chrome  | Default Variables                 #
+# Author(s):        Zuke97                                               #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+chrome_name: chrome
+
+################################
+# Paths
+################################
+
+chrome_paths_folder: "{{ chrome_name }}"
+chrome_paths_location: "{{ server_appdata_path }}/{{ chrome_paths_folder }}"
+chrome_paths_folders_list:
+  - "{{ chrome_paths_location }}"
+
+################################
+# Docker
+################################
+
+# Container
+chrome_docker_container: "{{ chrome_name }}"
+
+# Image
+chrome_docker_image_pull: true
+chrome_docker_image: "gcr.io/zenika-hub/alpine-chrome"
+chrome_docker_image_tag: "123"
+
+# Ports
+chrome_docker_ports_defaults:
+  - "9222:9222"
+chrome_docker_ports_custom: []
+chrome_docker_ports: "{{ chrome_docker_ports_defaults
+                          + chrome_docker_ports_custom }}"
+
+# Envs
+chrome_docker_envs_default:
+  TZ: "{{ tz }}"
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+chrome_docker_envs_custom: {}
+chrome_docker_envs: "{{ chrome_docker_envs_default
+                         | combine(chrome_docker_envs_custom) }}"
+
+# Commands
+chrome_docker_commands_default:
+  - --no-sandbox
+  - --disable-gpu
+  - --disable-dev-shm-usage
+  - --remote-debugging-address=0.0.0.0
+  - --remote-debugging-port=9222
+  - --hide-scrollbars
+chrome_docker_commands_custom: []
+chrome_docker_commands: "{{ chrome_docker_commands_default
+                             + chrome_docker_commands_custom }}"
+
+# Volumes
+chrome_docker_volumes_default: []
+chrome_docker_volumes_custom: []
+chrome_docker_volumes: "{{ chrome_docker_volumes_default
+                            + chrome_docker_volumes_custom }}"
+
+# Devices
+chrome_docker_devices_default: []
+chrome_docker_devices_custom: []
+chrome_docker_devices: "{{ chrome_docker_devices_default
+                            + chrome_docker_devices_custom }}"
+
+# Hosts
+chrome_docker_hosts_default: {}
+chrome_docker_hosts_custom: {}
+chrome_docker_hosts: "{{ docker_hosts_common
+                          | combine(chrome_docker_hosts_default)
+                          | combine(chrome_docker_hosts_custom) }}"
+
+# Labels
+chrome_docker_labels_default: {}
+chrome_docker_labels_custom: {}
+chrome_docker_labels: "{{ docker_labels_common
+                           | combine(chrome_docker_labels_default)
+                           | combine(chrome_docker_labels_custom) }}"
+
+# Hostname
+chrome_docker_hostname: "{{ chrome_name }}"
+
+# Networks
+chrome_docker_networks_alias: "{{ chrome_name }}"
+chrome_docker_networks_default: []
+chrome_docker_networks_custom: []
+chrome_docker_networks: "{{ docker_networks_common
+                             + chrome_docker_networks_default
+                             + chrome_docker_networks_custom }}"
+
+# Capabilities
+chrome_docker_capabilities_default: []
+chrome_docker_capabilities_custom: []
+chrome_docker_capabilities: "{{ chrome_docker_capabilities_default
+                                 + chrome_docker_capabilities_custom }}"
+
+# Security Opts
+chrome_docker_security_opts_default: []
+chrome_docker_security_opts_custom: []
+chrome_docker_security_opts: "{{ chrome_docker_security_opts_default
+                                  + chrome_docker_security_opts_custom }}"
+
+# Restart Policy
+chrome_docker_restart_policy: unless-stopped
+
+# State
+chrome_docker_state: started

--- a/roles/chrome/tasks/main.yml
+++ b/roles/chrome/tasks/main.yml
@@ -1,29 +1,13 @@
 #########################################################################
-# Title:            Sandbox: Hoarder                                    #
+# Title:            Sandbox: Chrome                                     #
 # Author(s):        Zuke97                                              #
 # URL:              https://github.com/saltyorg/Sandbox                 #
 # --                                                                    #
 #########################################################################
 #                   GNU General Public License v3.0                     #
 #########################################################################
-# Repository: https://github.com/hoarder-app/hoarder
+# Repository: https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980;tab=install
 ---
-
-- name: Chrome role
-  ansible.builtin.include_role:
-    name: chrome
-
-- name: Meilisearch role
-  ansible.builtin.include_role:
-    name: meilisearch
-
-- name: Add DNS record
-  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
-  vars:
-    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
-    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
-    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
-
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 

--- a/roles/chrome/tasks/main.yml
+++ b/roles/chrome/tasks/main.yml
@@ -16,4 +16,3 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
-

--- a/roles/hoarder/defaults/main.yml
+++ b/roles/hoarder/defaults/main.yml
@@ -79,8 +79,8 @@ hoarder_docker_envs_default:
   HOARDER_VERSION: "release"
   MEILI_ADDR: "http://meilisearch:7700"
   BROWSER_WEB_URL: "http://chrome:9222"
-  NEXTAUTH_SECRET: "{{ hoarder.nextauth_secret | default('', true) }}"
-  MEILI_MASTER_KEY: "{{ meilisearch.meili_master_key | default('', true) }}"
+  NEXTAUTH_SECRET: "{{ hoarder_saltbox_facts.facts.secret_key }}"
+  MEILI_MASTER_KEY: "{{ meilisearch_saltbox_facts.facts.secret_key }}"
   NEXTAUTH_URL: "{{ hoarder_web_url }}"
   DATA_DIR: "/data"
 hoarder_docker_envs_custom: {}

--- a/roles/hoarder/defaults/main.yml
+++ b/roles/hoarder/defaults/main.yml
@@ -60,6 +60,12 @@ hoarder_traefik_api_endpoint: ""
 # Container
 hoarder_docker_container: "{{ hoarder_name }}"
 
+# Dependant Container Settings
+hoarder_meili_name: "meilisearch"
+hoarder_meili_port: "7700"
+hoarder_chrome_name: "chrome"
+hoarder_chrome_port: "9222"
+
 # Image
 hoarder_docker_image_pull: true
 hoarder_docker_image: "ghcr.io/hoarder-app/hoarder"
@@ -77,8 +83,8 @@ hoarder_docker_envs_default:
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
   HOARDER_VERSION: "release"
-  MEILI_ADDR: "http://meilisearch:7700"
-  BROWSER_WEB_URL: "http://chrome:9222"
+  MEILI_ADDR: "{{ 'http://' + hoarder_meili_name + ':' + hoarder_meili_port }}"
+  BROWSER_WEB_URL: "{{ 'http://' + hoarder_chrome_name + ':' + hoarder_chrome_port }}"
   NEXTAUTH_SECRET: "{{ hoarder_saltbox_facts.facts.secret_key }}"
   MEILI_MASTER_KEY: "{{ meilisearch_saltbox_facts.facts.secret_key }}"
   NEXTAUTH_URL: "{{ hoarder_web_url }}"

--- a/roles/hoarder/defaults/main.yml
+++ b/roles/hoarder/defaults/main.yml
@@ -66,8 +66,7 @@ hoarder_docker_image: "ghcr.io/hoarder-app/hoarder"
 hoarder_docker_image_tag: "release"
 
 # Ports
-hoarder_docker_ports_defaults:
-  - "3000:3000"
+hoarder_docker_ports_defaults: []
 hoarder_docker_ports_custom: []
 hoarder_docker_ports: "{{ hoarder_docker_ports_defaults
                           + hoarder_docker_ports_custom }}"

--- a/roles/hoarder/defaults/main.yml
+++ b/roles/hoarder/defaults/main.yml
@@ -78,8 +78,10 @@ hoarder_docker_envs_default:
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
   HOARDER_VERSION: "release"
+  MEILI_ADDR: "http://meilisearch:7700"
+  BROWSER_WEB_URL: "http://chrome:9222"
   NEXTAUTH_SECRET: "{{ hoarder.nextauth_secret | default('', true) }}"
-  MEILI_MASTER_KEY: "{{ hoarder.meili_master_key | default('', true) }}"
+  MEILI_MASTER_KEY: "{{ meilisearch.meili_master_key | default('', true) }}"
   NEXTAUTH_URL: "{{ hoarder_web_url }}"
   DATA_DIR: "/data"
 hoarder_docker_envs_custom: {}
@@ -95,7 +97,6 @@ hoarder_docker_commands: "{{ hoarder_docker_commands_default
 # Volumes
 hoarder_docker_volumes_default:
   - "{{ hoarder_paths_location }}/data:/data"
-  - "{{ hoarder_paths_location }}/meili:/meili_data"
 hoarder_docker_volumes_custom: []
 hoarder_docker_volumes: "{{ hoarder_docker_volumes_default
                             + hoarder_docker_volumes_custom }}"

--- a/roles/hoarder/defaults/main.yml
+++ b/roles/hoarder/defaults/main.yml
@@ -1,0 +1,150 @@
+##########################################################################
+# Title:            Sandbox: Hoarder | Default Variables                 #
+# Author(s):        Zuke97                                               #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+hoarder_name: hoarder
+
+################################
+# Paths
+################################
+
+hoarder_paths_folder: "{{ hoarder_name }}"
+hoarder_paths_location: "{{ server_appdata_path }}/{{ hoarder_paths_folder }}"
+hoarder_paths_folders_list:
+  - "{{ hoarder_paths_location }}"
+
+################################
+# Web
+################################
+
+hoarder_web_subdomain: "{{ hoarder_name }}"
+hoarder_web_domain: "{{ user.domain }}"
+hoarder_web_port: "3000"
+hoarder_web_url: "{{ 'https://' + (hoarder_web_subdomain + '.' + hoarder_web_domain
+                  if (hoarder_web_subdomain | length > 0)
+                  else hoarder_web_domain) }}"
+
+################################
+# DNS
+################################
+
+hoarder_dns_record: "{{ hoarder_web_subdomain }}"
+hoarder_dns_zone: "{{ hoarder_web_domain }}"
+hoarder_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+hoarder_traefik_sso_middleware: ""
+hoarder_traefik_middleware_default: "{{ traefik_default_middleware }}"
+hoarder_traefik_middleware_custom: ""
+hoarder_traefik_certresolver: "{{ traefik_default_certresolver }}"
+hoarder_traefik_enabled: true
+hoarder_traefik_api_enabled: false
+hoarder_traefik_api_endpoint: ""
+
+################################
+# Docker
+################################
+
+# Container
+hoarder_docker_container: "{{ hoarder_name }}"
+
+# Image
+hoarder_docker_image_pull: true
+hoarder_docker_image: "ghcr.io/hoarder-app/hoarder"
+hoarder_docker_image_tag: "release"
+
+# Ports
+hoarder_docker_ports_defaults:
+  - "3000:3000"
+hoarder_docker_ports_custom: []
+hoarder_docker_ports: "{{ hoarder_docker_ports_defaults
+                          + hoarder_docker_ports_custom }}"
+
+# Envs
+hoarder_docker_envs_default:
+  TZ: "{{ tz }}"
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  HOARDER_VERSION: "release"
+  NEXTAUTH_SECRET: "{{ hoarder.nextauth_secret | default('', true) }}"
+  MEILI_MASTER_KEY: "{{ hoarder.meili_master_key | default('', true) }}"
+  NEXTAUTH_URL: "{{ hoarder_web_url }}"
+  DATA_DIR: "/data"
+hoarder_docker_envs_custom: {}
+hoarder_docker_envs: "{{ hoarder_docker_envs_default
+                         | combine(hoarder_docker_envs_custom) }}"
+
+# Commands
+hoarder_docker_commands_default: []
+hoarder_docker_commands_custom: []
+hoarder_docker_commands: "{{ hoarder_docker_commands_default
+                             + hoarder_docker_commands_custom }}"
+
+# Volumes
+hoarder_docker_volumes_default:
+  - "{{ hoarder_paths_location }}/data:/data"
+  - "{{ hoarder_paths_location }}/meili:/meili_data"
+hoarder_docker_volumes_custom: []
+hoarder_docker_volumes: "{{ hoarder_docker_volumes_default
+                            + hoarder_docker_volumes_custom }}"
+
+# Devices
+hoarder_docker_devices_default: []
+hoarder_docker_devices_custom: []
+hoarder_docker_devices: "{{ hoarder_docker_devices_default
+                            + hoarder_docker_devices_custom }}"
+
+# Hosts
+hoarder_docker_hosts_default: {}
+hoarder_docker_hosts_custom: {}
+hoarder_docker_hosts: "{{ docker_hosts_common
+                          | combine(hoarder_docker_hosts_default)
+                          | combine(hoarder_docker_hosts_custom) }}"
+
+# Labels
+hoarder_docker_labels_default: {}
+hoarder_docker_labels_custom: {}
+hoarder_docker_labels: "{{ docker_labels_common
+                           | combine(hoarder_docker_labels_default)
+                           | combine(hoarder_docker_labels_custom) }}"
+
+# Hostname
+hoarder_docker_hostname: "{{ hoarder_name }}"
+
+# Networks
+hoarder_docker_networks_alias: "{{ hoarder_name }}"
+hoarder_docker_networks_default: []
+hoarder_docker_networks_custom: []
+hoarder_docker_networks: "{{ docker_networks_common
+                             + hoarder_docker_networks_default
+                             + hoarder_docker_networks_custom }}"
+
+# Capabilities
+hoarder_docker_capabilities_default: []
+hoarder_docker_capabilities_custom: []
+hoarder_docker_capabilities: "{{ hoarder_docker_capabilities_default
+                                 + hoarder_docker_capabilities_custom }}"
+
+# Security Opts
+hoarder_docker_security_opts_default: []
+hoarder_docker_security_opts_custom: []
+hoarder_docker_security_opts: "{{ hoarder_docker_security_opts_default
+                                  + hoarder_docker_security_opts_custom }}"
+
+# Restart Policy
+hoarder_docker_restart_policy: unless-stopped
+
+# State
+hoarder_docker_state: started

--- a/roles/hoarder/tasks/main.yml
+++ b/roles/hoarder/tasks/main.yml
@@ -8,7 +8,6 @@
 #########################################################################
 # Repository: https://github.com/hoarder-app/hoarder
 ---
-
 - name: Chrome role
   ansible.builtin.include_role:
     name: chrome
@@ -32,4 +31,3 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
-

--- a/roles/hoarder/tasks/main.yml
+++ b/roles/hoarder/tasks/main.yml
@@ -8,6 +8,18 @@
 #########################################################################
 # Repository: https://github.com/hoarder-app/hoarder
 ---
+- name: "Save Hoarder Saltbox Facts"
+  saltbox_facts:
+    role: "hoarder"
+    instance: "hoarder"
+    keys:
+      secret_key: "{{ hoarder.secret_key
+                   if hoarder is defined and hoarder.secret_key is defined and hoarder.secret_key | length > 0
+                   else lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=36) }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+  register: hoarder_saltbox_facts
+
 - name: Chrome role
   ansible.builtin.include_role:
     name: chrome

--- a/roles/hoarder/tasks/main.yml
+++ b/roles/hoarder/tasks/main.yml
@@ -13,9 +13,7 @@
     role: "hoarder"
     instance: "hoarder"
     keys:
-      secret_key: "{{ hoarder.secret_key
-                   if hoarder is defined and hoarder.secret_key is defined and hoarder.secret_key | length > 0
-                   else lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=36) }}"
+      secret_key: "{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=36) }}"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
   register: hoarder_saltbox_facts

--- a/roles/hoarder/tasks/main.yml
+++ b/roles/hoarder/tasks/main.yml
@@ -1,0 +1,26 @@
+#########################################################################
+# Title:            Sandbox: Hoarder                                    #
+# Author(s):        Zuke97                                              #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+# Repository: https://github.com/hoarder-app/hoarder
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+

--- a/roles/meilisearch/defaults/main.yml
+++ b/roles/meilisearch/defaults/main.yml
@@ -1,0 +1,115 @@
+##########################################################################
+# Title:            Sandbox: Meilisearch | Default Variables             #
+# Author(s):        Zuke97                                               #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+meilisearch_name: meilisearch
+
+################################
+# Paths
+################################
+
+meilisearch_paths_folder: "{{ meilisearch_name }}"
+meilisearch_paths_location: "{{ server_appdata_path }}/{{ meilisearch_paths_folder }}"
+meilisearch_paths_folders_list:
+  - "{{ meilisearch_paths_location }}"
+
+################################
+# Docker
+################################
+
+# Container
+meilisearch_docker_container: "{{ meilisearch_name }}"
+
+# Image
+meilisearch_docker_image_pull: true
+meilisearch_docker_image: "getmeili/meilisearch"
+meilisearch_docker_image_tag: "v1.11.1"
+
+# Ports
+meilisearch_docker_ports_defaults:
+  - "7700:7700"
+meilisearch_docker_ports_custom: []
+meilisearch_docker_ports: "{{ meilisearch_docker_ports_defaults
+                          + meilisearch_docker_ports_custom }}"
+
+# Envs
+meilisearch_docker_envs_default:
+  TZ: "{{ tz }}"
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  MEILI_NO_ANALYTICS: "true"
+  MEILI_MASTER_KEY: "{{ meilisearch.meili_master_key }}"
+meilisearch_docker_envs_custom: {}
+meilisearch_docker_envs: "{{ meilisearch_docker_envs_default
+                         | combine(meilisearch_docker_envs_custom) }}"
+
+# Commands
+meilisearch_docker_commands_default: []
+meilisearch_docker_commands_custom: []
+meilisearch_docker_commands: "{{ meilisearch_docker_commands_default
+                             + meilisearch_docker_commands_custom }}"
+
+# Volumes
+meilisearch_docker_volumes_default:
+  - "{{ meilisearch_paths_location }}/data:/meili_data"
+meilisearch_docker_volumes_custom: []
+meilisearch_docker_volumes: "{{ meilisearch_docker_volumes_default
+                            + meilisearch_docker_volumes_custom }}"
+
+# Devices
+meilisearch_docker_devices_default: []
+meilisearch_docker_devices_custom: []
+meilisearch_docker_devices: "{{ meilisearch_docker_devices_default
+                            + meilisearch_docker_devices_custom }}"
+
+# Hosts
+meilisearch_docker_hosts_default: {}
+meilisearch_docker_hosts_custom: {}
+meilisearch_docker_hosts: "{{ docker_hosts_common
+                          | combine(meilisearch_docker_hosts_default)
+                          | combine(meilisearch_docker_hosts_custom) }}"
+
+# Labels
+meilisearch_docker_labels_default: {}
+meilisearch_docker_labels_custom: {}
+meilisearch_docker_labels: "{{ docker_labels_common
+                           | combine(meilisearch_docker_labels_default)
+                           | combine(meilisearch_docker_labels_custom) }}"
+
+# Hostname
+meilisearch_docker_hostname: "{{ meilisearch_name }}"
+
+# Networks
+meilisearch_docker_networks_alias: "{{ meilisearch_name }}"
+meilisearch_docker_networks_default: []
+meilisearch_docker_networks_custom: []
+meilisearch_docker_networks: "{{ docker_networks_common
+                             + meilisearch_docker_networks_default
+                             + meilisearch_docker_networks_custom }}"
+
+# Capabilities
+meilisearch_docker_capabilities_default: []
+meilisearch_docker_capabilities_custom: []
+meilisearch_docker_capabilities: "{{ meilisearch_docker_capabilities_default
+                                 + meilisearch_docker_capabilities_custom }}"
+
+# Security Opts
+meilisearch_docker_security_opts_default: []
+meilisearch_docker_security_opts_custom: []
+meilisearch_docker_security_opts: "{{ meilisearch_docker_security_opts_default
+                                  + meilisearch_docker_security_opts_custom }}"
+
+# Restart Policy
+meilisearch_docker_restart_policy: unless-stopped
+
+# State
+meilisearch_docker_state: started

--- a/roles/meilisearch/defaults/main.yml
+++ b/roles/meilisearch/defaults/main.yml
@@ -47,7 +47,7 @@ meilisearch_docker_envs_default:
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
   MEILI_NO_ANALYTICS: "true"
-  MEILI_MASTER_KEY: "{{ meilisearch.meili_master_key }}"
+  MEILI_MASTER_KEY: "{{ meilisearch_saltbox_facts.facts.secret_key }}"
 meilisearch_docker_envs_custom: {}
 meilisearch_docker_envs: "{{ meilisearch_docker_envs_default
                          | combine(meilisearch_docker_envs_custom) }}"

--- a/roles/meilisearch/defaults/main.yml
+++ b/roles/meilisearch/defaults/main.yml
@@ -35,8 +35,7 @@ meilisearch_docker_image: "getmeili/meilisearch"
 meilisearch_docker_image_tag: "v1.11.1"
 
 # Ports
-meilisearch_docker_ports_defaults:
-  - "7700:7700"
+meilisearch_docker_ports_defaults: []
 meilisearch_docker_ports_custom: []
 meilisearch_docker_ports: "{{ meilisearch_docker_ports_defaults
                           + meilisearch_docker_ports_custom }}"

--- a/roles/meilisearch/tasks/main.yml
+++ b/roles/meilisearch/tasks/main.yml
@@ -1,29 +1,13 @@
 #########################################################################
-# Title:            Sandbox: Hoarder                                    #
+# Title:            Sandbox: Meilisearch                                #
 # Author(s):        Zuke97                                              #
 # URL:              https://github.com/saltyorg/Sandbox                 #
 # --                                                                    #
 #########################################################################
 #                   GNU General Public License v3.0                     #
 #########################################################################
-# Repository: https://github.com/hoarder-app/hoarder
+# Repository: https://www.meilisearch.com/
 ---
-
-- name: Chrome role
-  ansible.builtin.include_role:
-    name: chrome
-
-- name: Meilisearch role
-  ansible.builtin.include_role:
-    name: meilisearch
-
-- name: Add DNS record
-  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
-  vars:
-    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
-    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
-    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
-
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 

--- a/roles/meilisearch/tasks/main.yml
+++ b/roles/meilisearch/tasks/main.yml
@@ -8,6 +8,18 @@
 #########################################################################
 # Repository: https://www.meilisearch.com/
 ---
+- name: "Save Meilisearch Saltbox Facts"
+  saltbox_facts:
+    role: "meilisearch"
+    instance: "meilisearch"
+    keys:
+      secret_key: "{{ meilisearch.secret_key
+                   if meilisearch is defined and meilisearch.secret_key is defined and meilisearch.secret_key | length > 0
+                   else lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=36) }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+  register: meilisearch_saltbox_facts
+
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 

--- a/roles/meilisearch/tasks/main.yml
+++ b/roles/meilisearch/tasks/main.yml
@@ -16,4 +16,3 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
-

--- a/roles/meilisearch/tasks/main.yml
+++ b/roles/meilisearch/tasks/main.yml
@@ -13,9 +13,7 @@
     role: "meilisearch"
     instance: "meilisearch"
     keys:
-      secret_key: "{{ meilisearch.secret_key
-                   if meilisearch is defined and meilisearch.secret_key is defined and meilisearch.secret_key | length > 0
-                   else lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=36) }}"
+      secret_key: "{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=36) }}"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
   register: meilisearch_saltbox_facts

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -78,6 +78,7 @@
     - { role: handbrake, tags: ['handbrake'] }
     - { role: healthchecks, tags: ['healthchecks'] }
     - { role: heimdall, tags: ['heimdall'] }
+    - { role: hoarder, tags: ['hoarder'] }
     - { role: homarr, tags: ['homarr'] }
     - { role: homeassistant, tags: ['homeassistant'] }
     - { role: homebox, tags: ['homebox'] }

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -36,6 +36,7 @@
     - { role: calibre_web, tags: ['calibre-web'] }
     - { role: changedetection, tags: ['changedetection'] }
     - { role: cherry, tags: ['cherry'] }
+    - { role: chrome, tags: ['chrome'] }
     - { role: cockpit, tags: ['cockpit'] }
     - { role: codex, tags: ['codex'] }
     - { role: code_server, tags: ['code-server'] }
@@ -107,6 +108,7 @@
     - { role: lunasea, tags: ['lunasea'] }
     - { role: makemkv, tags: ['makemkv'] }
     - { role: medusa, tags: ['medusa'] }
+    - { role: meilisearch, tags: ['meilisearch'] }
     - { role: minecraft, tags: ['minecraft'] }
     - { role: minecraft_bedrock, tags: ['minecraft-bedrock'] }
     - { role: miniflux, tags: ['miniflux'] }


### PR DESCRIPTION
"Hoarder is an open source "Bookmark Everything" app that uses AI for automatically tagging the content you throw at it. The app is built with self-hosting as a first class citizen."

Hoarder is a tool for bookmarking and archiving links/videos/images/documents that can also optionally use an AI model to create tags for the data.

[Homepage](https://hoarder.app/)
[Github](https://github.com/hoarder-app/hoarder)
[Project Docs](https://docs.hoarder.app/)

Also added Chrome and Meilisearch roles due to them being required for Hoarder
[Chrome repo](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980)
[Meilisearch - AI search tool](https://www.meilisearch.com/)

**Two secrets must be generated and stored in the user settings as hoarder.nextauth_secret & meilisearch.meili_master_key**
The docs recommend running `openssl rand -base64 36` to generate this
- nextauth: The built in auth server won't work and it will be inaccessible
- meili_master_key: search function doesn't work

# How Has This Been Tested?

- [X] Installed multiple times locally - running 22.04
- [X] Verified data is not erased when rebuilding the container
