### PR TITLE
fix(yacht): add missing docker socket proxy permissions

### DIFF
--- a/roles/yacht/defaults/main.yml
+++ b/roles/yacht/defaults/main.yml
@@ -14,6 +14,9 @@
 yacht_docker_socket_proxy_envs:
   CONTAINERS: "1"
   POST: "0"
+  IMAGES: "1"
+  VOLUMES: "1"
+  NETWORKS: "1"
 
 ################################
 # Basics


### PR DESCRIPTION
Add IMAGES, VOLUMES, and NETWORKS permissions to Yacht's Docker socket proxy configuration to fix 403 Forbidden errors when accessing Docker resources.

This change allows Yacht to properly access and display Docker images, volumes, and networks through the socket proxy, resolving the 403 Forbidden errors that were preventing full functionality of the Yacht container management UI.