### PR TITLE
Updating Homepage documentation URLs to correct location

### DIFF
--- a/roles/homepage/files/bookmarks.yaml
+++ b/roles/homepage/files/bookmarks.yaml
@@ -1,6 +1,6 @@
 ---
 # For configuration options and examples, please see:
-# https://gethomepage.dev/en/configs/bookmarks
+# https://gethomepage.dev/configs/bookmarks
 
 - Saltbox:
     - Core Repository:

--- a/roles/homepage/files/services.yaml
+++ b/roles/homepage/files/services.yaml
@@ -1,6 +1,6 @@
 ---
 # For configuration options and examples, please see:
-# https://gethomepage.dev/en/configs/services
+# https://gethomepage.dev/configs/services
 
 # - Movies and Series Management:
 #     - Radarr (4K):

--- a/roles/homepage/files/widgets.yaml
+++ b/roles/homepage/files/widgets.yaml
@@ -1,6 +1,6 @@
 ---
 # For configuration options and examples, please see:
-# https://gethomepage.dev/configs/widgets
+# https://gethomepage.dev/configs/info-widgets/
 
 - resources:
     cpu: true

--- a/roles/homepage/files/widgets.yaml
+++ b/roles/homepage/files/widgets.yaml
@@ -1,6 +1,6 @@
 ---
 # For configuration options and examples, please see:
-# https://gethomepage.dev/en/configs/widgets
+# https://gethomepage.dev/configs/widgets
 
 - resources:
     cpu: true

--- a/roles/homepage/templates/docker.yaml.j2
+++ b/roles/homepage/templates/docker.yaml.j2
@@ -1,6 +1,6 @@
 ---
 # For configuration options and examples, please see:
-# https://gethomepage.dev/en/configs/docker/
+# https://gethomepage.dev/configs/docker/
 
 # my-docker:
 #   socket: /var/run/docker.sock

--- a/roles/homepage/templates/settings.yaml.j2
+++ b/roles/homepage/templates/settings.yaml.j2
@@ -1,6 +1,6 @@
 ---
 # For configuration options and examples, please see:
-# https://gethomepage.dev/en/configs/settings
+# https://gethomepage.dev/configs/settings
 
 providers:
   openweathermap: openweathermapapikey


### PR DESCRIPTION
# Description

Updating an existing role, noticed that the config files have embedded documentation URLs that were 404ing because Homepage devs changed the path on their docs site.
Base URL used to be https://gethomepage.dev/en/configs/, is now https://gethomepage.dev/configs/
These are just oneliner changes to the commented out URLs in each affected file.

# How Has This Been Tested?

Updated the URLs to reflect the pattern change and confirmed they all load when navigated to on my machine.
