### PR TITLE
ESPHome role

### DIFF
--- a/roles/esphome/defaults/main.yml
+++ b/roles/esphome/defaults/main.yml
@@ -1,0 +1,151 @@
+##########################################################################
+# Title:         Sandbox: esphome                                        #
+# Author(s):     Zuke97                                                  #
+# URL:           https://github.com/saltyorg/Sandbox                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+esphome_name: esphome
+
+################################
+# Paths
+################################
+
+esphome_paths_folder: "{{ esphome_name }}"
+esphome_paths_location: "{{ server_appdata_path }}/{{ esphome_paths_folder }}"
+esphome_paths_conf: "{{ esphome_paths_location }}/configuration.yaml"
+esphome_paths_folders_list:
+  - "{{ esphome_paths_location }}"
+
+################################
+# Web
+################################
+
+esphome_web_subdomain: "{{ esphome_name }}"
+esphome_web_domain: "{{ user.domain }}"
+esphome_web_port: "6052"
+esphome_web_url: "{{ 'https://' + (esphome_web_subdomain + '.' + esphome_web_domain
+                        if (esphome_web_subdomain | length > 0)
+                        else esphome_web_domain) }}"
+
+################################
+# DNS
+################################
+
+esphome_dns_record: "{{ esphome_web_subdomain }}"
+esphome_dns_zone: "{{ esphome_web_domain }}"
+esphome_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+esphome_traefik_sso_middleware: ""
+esphome_traefik_middleware_default: "{{ traefik_default_middleware }}"
+esphome_traefik_middleware_custom: ""
+esphome_traefik_certresolver: "{{ traefik_default_certresolver }}"
+esphome_traefik_enabled: true
+esphome_traefik_api_enabled: false
+esphome_traefik_api_endpoint: ""
+
+################################
+# Docker
+################################
+
+# Container
+esphome_docker_container: "{{ esphome_name }}"
+
+# Image
+esphome_docker_image_pull: true
+esphome_docker_image_tag: "latest"
+esphome_docker_image: "ghcr.io/esphome/esphome:{{ esphome_docker_image_tag }}"
+
+# Ports
+esphome_docker_ports_defaults: []
+esphome_docker_ports_custom: []
+esphome_docker_ports: "{{ esphome_docker_ports_defaults
+                                + esphome_docker_ports_custom }}"
+
+# Envs
+esphome_docker_envs_default:
+  TZ: "{{ tz }}"
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+esphome_docker_envs_custom: {}
+esphome_docker_envs: "{{ esphome_docker_envs_default
+                               | combine(esphome_docker_envs_custom) }}"
+
+# Commands
+esphome_docker_commands_default: []
+esphome_docker_commands_custom: []
+esphome_docker_commands: "{{ esphome_docker_commands_default
+                                   + esphome_docker_commands_custom }}"
+
+# Volumes
+esphome_docker_volumes_default:
+  - "{{ esphome_paths_location }}:/config"
+  - /etc/localtime:/etc/localtime:ro
+esphome_docker_volumes_custom: []
+esphome_docker_volumes: "{{ esphome_docker_volumes_default
+                                  + esphome_docker_volumes_custom }}"
+
+# Extended Privileges
+esphome_docker_privileged: "yes"
+
+# Devices
+esphome_docker_devices_default: []
+esphome_docker_devices_custom: []
+esphome_docker_devices: "{{ esphome_docker_devices_default
+                                  + esphome_docker_devices_custom }}"
+
+# Hosts
+esphome_docker_hosts_default: {}
+esphome_docker_hosts_custom: {}
+esphome_docker_hosts: "{{ docker_hosts_common
+                                | combine(esphome_docker_hosts_default)
+                                | combine(esphome_docker_hosts_custom) }}"
+
+# Labels
+esphome_docker_labels_default: {}
+esphome_docker_labels_custom: {}
+esphome_docker_labels: "{{ docker_labels_common
+                                 | combine(esphome_docker_labels_default)
+                                 | combine(esphome_docker_labels_custom) }}"
+
+# Hostname
+esphome_docker_hostname: "{{ esphome_name }}"
+
+# Networks
+esphome_docker_networks_alias: "{{ esphome_name }}"
+esphome_docker_networks_default: []
+esphome_docker_networks_custom: []
+esphome_docker_networks: "{{ docker_networks_common
+                                   + esphome_docker_networks_default
+                                   + esphome_docker_networks_custom }}"
+
+# Capabilities
+esphome_docker_capabilities_default: []
+esphome_docker_capabilities_custom: []
+esphome_docker_capabilities: "{{ esphome_docker_capabilities_default
+                                       + esphome_docker_capabilities_custom }}"
+
+# Network Mode
+esphome_docker_network_mode: "host"
+
+# Security Opts
+esphome_docker_security_opts_default: []
+esphome_docker_security_opts_custom: []
+esphome_docker_security_opts: "{{ esphome_docker_security_opts_default
+                                        + esphome_docker_security_opts_custom }}"
+
+# Restart Policy
+esphome_docker_restart_policy: unless-stopped
+
+# State
+esphome_docker_state: started

--- a/roles/esphome/defaults/main.yml
+++ b/roles/esphome/defaults/main.yml
@@ -46,7 +46,7 @@ esphome_dns_proxy: "{{ dns.proxied }}"
 # Traefik
 ################################
 
-esphome_traefik_sso_middleware: ""
+esphome_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
 esphome_traefik_middleware_default: "{{ traefik_default_middleware }}"
 esphome_traefik_middleware_custom: ""
 esphome_traefik_certresolver: "{{ traefik_default_certresolver }}"

--- a/roles/esphome/tasks/main.yml
+++ b/roles/esphome/tasks/main.yml
@@ -1,0 +1,24 @@
+##########################################################################
+# Title:         Sandbox: esphome                                        #
+# Author(s):     Zuke97                                                  #
+# URL:           https://github.com/saltyorg/Sandbox                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -55,6 +55,7 @@
     - { role: elasticsearch, tags: ['elasticsearch'] }
     - { role: embystat, tags: ['embystat'] }
     - { role: epms, tags: ['epms'] }
+    - { role: esphome, tags: ['esphome'] }
     - { role: factorio, tags: ['factorio'] }
     - { role: filebot, tags: ['filebot'] }
     - { role: filebrowser, tags: ['filebrowser'] }


### PR DESCRIPTION
# Description

ESPHome is a framework for creating custom firmware for wifi enabled microcontrollers. Generally (or in my case at least) they're used for full local hosted smart home devices tied into Homeassistant; where Homeassistant provides the nice user interface and automations and ESPHome devices handle the relays, switches, and lights to actually do the thing.

Docker container: https://ghcr.io/esphome/esphome
Homepage: https://esphome.io/
Docs: https://esphome.io/components/#

Saltbox Docs PR:

# How Has This Been Tested?
- [x] Installed on local machine
- [x] Configured esp device using webserial to local saltbox server
- [x] Verified configs stay when docker container is destroyed/rebuilt
