### PR TITLE
Cloudflared role

### DIFF
--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -1,6 +1,8 @@
 ---
 a_train:
   remotes: [""]
+cloudflared:
+  token:
 delugevpn:
   vpn_endpoint: netherlands.ovpn
   vpn_pass: your_vpn_password

--- a/roles/cloudflared/defaults/main.yml
+++ b/roles/cloudflared/defaults/main.yml
@@ -1,0 +1,120 @@
+##########################################################################
+# Title:            Sandbox: cloudflared | Default Variables             #
+# Author(s):        shaboigan                                            #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+cloudflared_name: cloudflared
+
+################################
+# Paths
+################################
+
+cloudflared_paths_folder: "{{ cloudflared_name }}"
+cloudflared_paths_location: "{{ server_appdata_path }}/{{ cloudflared_paths_folder }}"
+cloudflared_paths_config_location: "{{ cloudflared_paths_location }}/config"
+cloudflared_paths_folders_list:
+  - "{{ cloudflared_paths_location }}/config"
+
+################################
+# Docker
+################################
+
+# Container
+cloudflared_docker_container: "{{ cloudflared_name }}"
+
+# Image
+cloudflared_docker_image_pull: true
+cloudflared_docker_image_tag: "latest"
+cloudflared_docker_image: "cloudflare/cloudflared:{{ cloudflared_docker_image_tag }}"
+
+# Ports
+cloudflared_docker_ports_defaults: []
+cloudflared_docker_ports_custom: []
+cloudflared_docker_ports: "{{ cloudflared_docker_ports_defaults
+                       + cloudflared_docker_ports_custom }}"
+
+# Envs
+cloudflared_docker_envs_default:
+  TZ: "{{ tz }}"
+cloudflared_docker_envs_custom: {}
+cloudflared_docker_envs: "{{ cloudflared_docker_envs_default
+                      | combine(cloudflared_docker_envs_custom) }}"
+
+# Commands
+cloudflared_docker_commands_default:
+  - "tunnel"
+  - "--no-autoupdate"
+  - "run"
+  - "--token"
+  - "{{ cloudflared.token }}"
+cloudflared_docker_commands_custom: []
+cloudflared_docker_commands: "{{ cloudflared_docker_commands_default
+                          + cloudflared_docker_commands_custom }}"
+
+# Volumes
+cloudflared_docker_volumes_default:
+  - "{{ cloudflared_paths_location }}/config:/cloudflared/config"
+  - "/etc/localtime:/etc/localtime:ro"
+cloudflared_docker_volumes_custom: []
+cloudflared_docker_volumes: "{{ cloudflared_docker_volumes_default
+                         + cloudflared_docker_volumes_custom }}"
+
+# Devices
+cloudflared_docker_devices_default: []
+cloudflared_docker_devices_custom: []
+cloudflared_docker_devices: "{{ cloudflared_docker_devices_default
+                         + cloudflared_docker_devices_custom }}"
+
+# Hosts
+cloudflared_docker_hosts_default: {}
+cloudflared_docker_hosts_custom: {}
+cloudflared_docker_hosts: "{{ docker_hosts_common
+                       | combine(cloudflared_docker_hosts_default)
+                       | combine(cloudflared_docker_hosts_custom) }}"
+
+# Labels
+cloudflared_docker_labels_default: {}
+cloudflared_docker_labels_custom: {}
+cloudflared_docker_labels: "{{ docker_labels_common
+                        | combine(cloudflared_docker_labels_default)
+                        | combine(cloudflared_docker_labels_custom) }}"
+
+# Hostname
+cloudflared_docker_hostname: "{{ cloudflared_name }}"
+
+# Networks
+cloudflared_docker_networks_alias: "{{ cloudflared_name }}"
+cloudflared_docker_networks_default: []
+cloudflared_docker_networks_custom: []
+cloudflared_docker_networks: "{{ docker_networks_common
+                          + cloudflared_docker_networks_default
+                          + cloudflared_docker_networks_custom }}"
+
+# Capabilities
+cloudflared_docker_capabilities_default: []
+cloudflared_docker_capabilities_custom: []
+cloudflared_docker_capabilities: "{{ cloudflared_docker_capabilities_default
+                              + cloudflared_docker_capabilities_custom }}"
+
+# Security Opts
+cloudflared_docker_security_opts_default: []
+cloudflared_docker_security_opts_custom: []
+cloudflared_docker_security_opts: "{{ cloudflared_docker_security_opts_default
+                               + cloudflared_docker_security_opts_custom }}"
+
+# Restart Policy
+cloudflared_docker_restart_policy: unless-stopped
+
+# State
+cloudflared_docker_state: started
+
+# User
+cloudflared_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/cloudflared/tasks/main.yml
+++ b/roles/cloudflared/tasks/main.yml
@@ -1,0 +1,17 @@
+#########################################################################
+# Title:            Sandbox: cloudflared                                #
+# Author(s):        shaboigan                                           #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -37,6 +37,7 @@
     - { role: changedetection, tags: ['changedetection'] }
     - { role: cherry, tags: ['cherry'] }
     - { role: chrome, tags: ['chrome'] }
+    - { role: cloudflared, tags: ['cloudflared'] }
     - { role: cockpit, tags: ['cockpit'] }
     - { role: codex, tags: ['codex'] }
     - { role: code_server, tags: ['code-server'] }


### PR DESCRIPTION
# Description

Cloudflared is a lightweight daemon and command-line tool developed by Cloudflare that plays a crucial role in connecting your infrastructure to Cloudflare's global network, enabling services like Cloudflare Tunnel. It allows for secure, outbound-only connections from your origin server to Cloudflare's edge network, facilitating remote access to services or private applications without exposing them directly to the internet.

Docker container: https://hub.docker.com/r/cloudflare/cloudflared
Docs: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/

It would be greatly appreciated if you create a sandbox documentation page yourself and do a PR into the [docs repo](https://github.com/saltyorg/docs).  You, as the person creating the role, have presumably used the thing and are presumably familiar with any setup steps required.  Anyone else here would need to research that.

# How Has This Been Tested?

- [x] Installed on local machine
- [x] Tested creating tunnel from running the container, verified working when container is destroyed/rebuilt
- [x] Confirmed on the Cloudflare tunnel page that the tunnel is stable and healthy, and external traffic can be passed to internal containers

Saltbox Docs PR: 

