### PR TITLE
Fix: Changed broken repo of Plex-Auto_languages to working and active fork

### DIFF
--- a/roles/plex_auto_languages/defaults/main.yml
+++ b/roles/plex_auto_languages/defaults/main.yml
@@ -33,7 +33,7 @@ plex_auto_languages_docker_container: "{{ plex_auto_languages_name }}"
 # Image
 plex_auto_languages_docker_image_pull: true
 plex_auto_languages_docker_image_tag: "latest"
-plex_auto_languages_docker_image: "remirigal/plex-auto-languages:{{ plex_auto_languages_docker_image_tag }}"
+plex_auto_languages_docker_image: "journeyover/plex-auto-languages:{{ plex_auto_languages_docker_image_tag }}"
 
 # Envs
 plex_auto_languages_docker_envs_default:


### PR DESCRIPTION
Thanks to @JourneyOver we have a working fork of Plex-Auto-Languages.
[https://github.com/JourneyDocker/Plex-Auto-Languages](https://github.com/JourneyDocker/Plex-Auto-Languages)

# Description
I simply changed image and default tag according to the new fork.

# How Has This Been Tested?

I  tested the changes on my saltbox server. Updated the defaults,  installed with `sb install sandbox-plex-auto-languages`. Works fine.

- [ x] Tested
