### PR TITLE
Update actualbudget_paths_folders_list format

### DIFF
--- a/roles/actualbudget/defaults/main.yml
+++ b/roles/actualbudget/defaults/main.yml
@@ -21,8 +21,8 @@ actualbudget_paths_folder: "{{ actualbudget_name }}"
 actualbudget_paths_location: "{{ server_appdata_path }}/{{ actualbudget_paths_folder }}"
 actualbudget_paths_folders_list:
   - "{{ actualbudget_paths_location }}"
-  - "{{ actualbudget_paths_location }}:/server-files"
-  - "{{ actualbudget_paths_location }}:/user-files"
+  - "{{ actualbudget_paths_location }}/server-files"
+  - "{{ actualbudget_paths_location }}/user-files"
 
 ################################
 # Web


### PR DESCRIPTION
# Description

Removed the colons that were causing duplicate directories being created at time of role install. When sb install sandbox-actualbudget is installed it creates: /opt/actualbudget
/opt/actualbudget:
because of the colons

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.  You can use the checkboxes below or delete them as you wish.

- [X] I modified the main.yml locally in /opt/sandbox/roles/actualbudget and reinstalled the role and it did not create the directory with the colon at the end

