### PR TITLE
Bump Paperless-NGX Gotenberg Version to 8.22

### DIFF
--- a/roles/paperless_ngx/tasks/main.yml
+++ b/roles/paperless_ngx/tasks/main.yml
@@ -48,7 +48,7 @@
     name: gotenberg
   vars:
     gotenberg_name: "{{ paperless_ngx_name }}-gotenberg"
-    gotenberg_docker_image_tag: "7.8"
+    gotenberg_docker_image_tag: "8.22"
     gotenberg_docker_commands_default:
       - "gotenberg"
       - "--chromium-disable-javascript=true"


### PR DESCRIPTION
# Description

Bump Paperless-NGX Gotenberg to 8.22 per paperless project's recommended/default compose
- https://github.com/paperless-ngx/paperless-ngx/blob/main/docker/compose/docker-compose.postgres-tika.yml
- https://docs.paperless-ngx.com/changelog/#dependencies_1
Current sandbox compose file is pinned to 7.8, which is almost 2 years old.

# How Has This Been Tested?

- Overrode tasks/main.yml with 8.22 tag locally, and re-ran sb install sandbox-paperless-ngx
- Confirmed Gotenberg is running 8.22
- Confirmed web client starts and accepts new files

