### PR TITLE
fix(main_tag): add check for 'roles' to enable the tag

### DIFF
--- a/roles/main_tag/tasks/main.yml
+++ b/roles/main_tag/tasks/main.yml
@@ -13,4 +13,4 @@
   with_items: "{{ sandbox_roles }}"
   loop_control:
     loop_var: sandbox_role
-  when: ('sandbox-roles' in ansible_run_tags)
+  when: ('sandbox-roles' in ansible_run_tags) or ('roles' in ansible_run_tags)


### PR DESCRIPTION
Ran into this after trying out the `roles` tag for the first time:
```sh
TASK [Execute Sandbox roles] ***************************************************************************************************************
task path: /opt/sandbox/roles/main_tag/tasks/main.yml:10
Thursday 30 October 2025  20:56:15 +0100 (0:00:01.311)       0:00:55.474 ******
skipping: [localhost] => (item=firefox)  => {
    "ansible_loop_var": "sandbox_role",
    "changed": false,
    "false_condition": "('sandbox-roles' in ansible_run_tags)",
    "sandbox_role": "firefox",
    "skip_reason": "Conditional result was False"
}
skipping: [localhost] => (item=notifiarr)  => {
    "ansible_loop_var": "sandbox_role",
    "changed": false,
    "false_condition": "('sandbox-roles' in ansible_run_tags)",
    "sandbox_role": "notifiarr",
    "skip_reason": "Conditional result was False"
}
skipping: [localhost] => (item=plextraktsync)  => {
    "ansible_loop_var": "sandbox_role",
    "changed": false,
    "false_condition": "('sandbox-roles' in ansible_run_tags)",
    "sandbox_role": "plextraktsync",
    "skip_reason": "Conditional result was False"
}
skipping: [localhost] => {
    "changed": false,
    "msg": "All items skipped"
}
```