### PR TITLE
Suwayomi-Role-Refactor: Fixed issue with default download directory

### DIFF
--- a/roles/suwayomi/templates/server.conf.j2
+++ b/roles/suwayomi/templates/server.conf.j2
@@ -5,7 +5,7 @@
 server.autoDownloadNewChapters = true
 
 # Download new chapters for titles that Suwayomi marks as unread chapters
-server.excludeEntryWithUnreadChapters = true
+server.excludeEntryWithUnreadChapters = false
 
 # Download Format
 server.downloadAsCbz = true


### PR DESCRIPTION
This download directory preconfiguration causes issues for the default Saltbox setup. I didn't catch it earlier due to my custom inventories file, apologies!