### PR TITLE
slskd: add role

### DIFF
--- a/roles/slskd/defaults/main.yml
+++ b/roles/slskd/defaults/main.yml
@@ -1,0 +1,159 @@
+##########################################################################
+# Title:            Sandbox: slskd   | Default Variables                 #
+# Author(s):        PokePango                                            #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+slskd_name: slskd
+
+################################
+# Paths
+################################
+
+slskd_paths_folder: "{{ slskd_name }}"
+slskd_paths_location: "{{ server_appdata_path }}/{{ slskd_paths_folder }}"
+slskd_paths_downloads_location: "{{ downloads_root_path }}/{{ slskd_paths_folder }}"
+slskd_paths_folders_list:
+  - "{{ slskd_paths_location }}"
+  - "{{ slskd_paths_downloads_location }}"
+  - "{{ slskd_paths_downloads_location }}/completed"
+  - "{{ slskd_paths_downloads_location }}/incomplete"
+slskd_paths_recursive: true
+
+################################
+# Web
+################################
+
+slskd_web_subdomain: "{{ slskd_name }}"
+slskd_web_domain: "{{ user.domain }}"
+slskd_web_port: "5030"
+slskd_web_url: "{{ 'https://' + (slskd_web_subdomain + '.' + slskd_web_domain
+                         if (slskd_web_subdomain | length > 0)
+                         else slskd_web_domain) }}"
+
+################################
+# DNS
+################################
+
+slskd_dns_record: "{{ lookup('vars', slskd_name + '_web_subdomain', default=slskd_web_subdomain) }}"
+slskd_dns_zone: "{{ lookup('vars', slskd_name + '_web_domain', default=slskd_web_domain) }}"
+slskd_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+slskd_traefik_sso_middleware: ""
+slskd_traefik_middleware_default: "{{ traefik_default_middleware }}"
+slskd_traefik_middleware_custom: ""
+slskd_traefik_certresolver: "{{ traefik_default_certresolver }}"
+slskd_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+slskd_docker_container: "{{ slskd_name }}"
+
+# Image
+slskd_docker_image_pull: true
+slskd_docker_image_repo: "ghcr.io/slskd/slskd"
+slskd_docker_image_tag: "latest"
+slskd_docker_image: "{{ lookup('vars', slskd_name + '_docker_image_repo', default=slskd_docker_image_repo)
+                                 + ':' + lookup('vars', slskd_name + '_docker_image_tag', default=slskd_docker_image_tag) }}"
+
+# Ports
+slskd_docker_ports_defaults:
+  - "5030:5030"
+  - "50300:50300"
+slskd_docker_ports_custom: []
+slskd_docker_ports: "{{ lookup('vars', slskd_name + '_docker_ports_defaults', default=slskd_docker_ports_defaults)
+                                 + lookup('vars', slskd_name + '_docker_ports_custom', default=slskd_docker_ports_custom) }}"
+
+# Envs
+slskd_docker_envs_default:
+  SLSKD_REMOTE_CONFIGURATION: "true"
+  SLSKD_DOWNLOADS_DIR: "{{ slskd_paths_downloads_location }}/completed"
+  SLSKD_INCOMPLETE_DIR: "{{ slskd_paths_downloads_location }}/incomplete"
+  SLSKD_SHARED_DIR: "/mnt/unionfs/Media/Music"
+  SLSKD_USERNAME: "{{ user.name }}"
+  SLSKD_PASSWORD: "{{ user.pass }}"
+  TZ: "{{ tz }}"
+slskd_docker_envs_custom: {}
+slskd_docker_envs: "{{ lookup('vars', slskd_name + '_docker_envs_default', default=slskd_docker_envs_default)
+                                | combine(lookup('vars', slskd_name + '_docker_envs_custom', default=slskd_docker_envs_custom)) }}"
+
+# Commands
+slskd_docker_commands_default: []
+slskd_docker_commands_custom: []
+slskd_docker_commands: "{{ lookup('vars', slskd_name + '_docker_commands_default', default=slskd_docker_commands_default)
+                                    + lookup('vars', slskd_name + '_docker_commands_custom', default=slskd_docker_commands_custom) }}"
+
+# Volumes
+slskd_docker_volumes_default:
+  - "{{ slskd_paths_location }}:/app"
+  - "{{ slskd_paths_downloads_location }}/completed:/app/downloads"
+  - "{{ slskd_paths_downloads_location }}/incomplete:/app/incomplete"
+slskd_docker_volumes_custom: []
+slskd_docker_volumes: "{{ lookup('vars', slskd_name + '_docker_volumes_default', default=slskd_docker_volumes_default)
+                                   + lookup('vars', slskd_name + '_docker_volumes_custom', default=slskd_docker_volumes_custom) }}"
+
+# Devices
+slskd_docker_devices_default: []
+slskd_docker_devices_custom: []
+slskd_docker_devices: "{{ lookup('vars', slskd_name + '_docker_devices_default', default=slskd_docker_devices_default)
+                                   + lookup('vars', slskd_name + '_docker_devices_custom', default=slskd_docker_devices_custom) }}"
+
+# Hosts
+slskd_docker_hosts_default: {}
+slskd_docker_hosts_custom: {}
+slskd_docker_hosts: "{{ docker_hosts_common
+                                 | combine(lookup('vars', slskd_name + '_docker_hosts_default', default=slskd_docker_hosts_default))
+                                 | combine(lookup('vars', slskd_name + '_docker_hosts_custom', default=slskd_docker_hosts_custom)) }}"
+
+# Labels
+slskd_docker_labels_default: {}
+slskd_docker_labels_custom: {}
+slskd_docker_labels: "{{ docker_labels_common
+                                  | combine(lookup('vars', slskd_name + '_docker_labels_default', default=slskd_docker_labels_default))
+                                  | combine(lookup('vars', slskd_name + '_docker_labels_custom', default=slskd_docker_labels_custom)) }}"
+
+# Hostname
+slskd_docker_hostname: "{{ slskd_name }}"
+
+# Networks
+slskd_docker_networks_alias: "{{ slskd_name }}"
+slskd_docker_networks_default: []
+slskd_docker_networks_custom: []
+slskd_docker_networks: "{{ docker_networks_common
+                                    + lookup('vars', slskd_name + '_docker_networks_default', default=slskd_docker_networks_default)
+                                    + lookup('vars', slskd_name + '_docker_networks_custom', default=slskd_docker_networks_custom) }}"
+
+# Capabilities
+slskd_docker_capabilities_default: []
+slskd_docker_capabilities_custom: []
+slskd_docker_capabilities: "{{ lookup('vars', slskd_name + '_docker_capabilities_default', default=slskd_docker_capabilities_default)
+                                        + lookup('vars', slskd_name + '_docker_capabilities_custom', default=slskd_docker_capabilities_custom) }}"
+
+# Security Opts
+slskd_docker_security_opts_default: []
+slskd_docker_security_opts_custom: []
+slskd_docker_security_opts: "{{ lookup('vars', slskd_name + '_docker_security_opts_default', default=slskd_docker_security_opts_default)
+                                         + lookup('vars', slskd_name + '_docker_security_opts_custom', default=slskd_docker_security_opts_custom) }}"
+
+# Restart Policy
+slskd_docker_restart_policy: unless-stopped
+
+# State
+slskd_docker_state: started
+
+# User
+slskd_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/slskd/tasks/main.yml
+++ b/roles/slskd/tasks/main.yml
@@ -1,0 +1,24 @@
+##########################################################################
+# Title:            Sandbox: slskd                                       #
+# Author(s):        PokePango                                            #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -158,6 +158,7 @@
     - { role: rocketchat, tags: ['rocketchat'] }
     - { role: sabthrottle, tags: ['sabthrottle'] }
     - { role: semaphoreui, tags: ['semaphoreui'] }
+    - { role: slskd, tags: ['slskd'] }
     - { role: solr, tags: ['solr'] }
     - { role: speedtest, tags: ['speedtest'] }
     - { role: sqlitebrowser, tags: ['sqlitebrowser'] }


### PR DESCRIPTION
# Description

Just a quick warning, I discovered Soulseek network 2 days ago and looked for a clean way to add it to Saltbox.

[Slskd](https://github.com/slskd/slskd) is a service that acts as a client and server to share files through the [Soulseek](https://www.slsknet.org/news/) P2P network. 

Soulseek can be accessed using a unique **and non-registered** username associated with a password (optional).

Slskd can be connected to *arr services as an indexer and a download client to fetch and download media from the network. For example plugins such as [Tubifarry](https://github.com/TypNull/Tubifarry) are able to communicate with the service to automate music download through Lidarr.

- [Docker documentation](https://github.com/slskd/slskd/blob/master/docs/docker.md)
- [Environment configuration](https://github.com/slskd/slskd/blob/master/docs/config.md)

Resolves issue #499 

(I will update Saltbox documentation)

# How Has This Been Tested?

1. ` sb install sandbox-slskd`
2. Check the service state by connecting into slskd.your.domain using your Saltbox main username and password.
3. Set the following configuration in /opt/slskd/slskd.yml or from the web UI in `System > Options`:

```
web:
  authentication:
    api_keys:
      my_api_key:
        key: [GENERATE YOUR API KEY AND PASTE IT HERE]
soulseek:
  username: [USE A UNIQUE USERNAME TO CONNECT TO SOULSEEK)
  password: [SET A PASSWORD]
```
4. Restart slskd (through WebUi or through docker)
5. Connect slskd through Lidarr:
    1. I have changed the default lidarr branch from `latest` to `plugin`
    2. It allows me to install Tubifarry using their simple documentation for slskd and lidarr.

Note: API keys can be generated using: `openssl rand -hex 16`

# Comments on this PR

- I used user.pass and user.name to manage default ID to slskd WebUI
- By default the slskd container uses `/app/downloads` for completed downloads and `/app/incomplete` for incomplete downloads. I created a new directory under `/mnt/unionfs/downloads/slskd` to replicate existing folder structure from other download services (`/completed` and `/incomplete`). Slskd's configuration allows to move those directories using environment variables (yay!).
- I didn't use inventory for api key, soulseek username and password. I'll follow your recommendations as I'm not sure what's the consensus on this. It's interesting to note that the Soulseek's ID could be randomized on every `sb install` run. API key should not.
- I'd like to add VPN support but I'm not sure how to proceed.
