### PR TITLE
feat: add panelarr role

### DIFF
--- a/roles/panelarr/defaults/main.yml
+++ b/roles/panelarr/defaults/main.yml
@@ -1,0 +1,128 @@
+##########################################################################
+# Title:            Sandbox: Panelarr | Default Variables                #
+# Author(s):        thug-drama                                           #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+panelarr_name: panelarr
+
+################################
+# Paths
+################################
+
+panelarr_role_paths_folder: "{{ panelarr_name }}"
+panelarr_role_paths_location: "{{ server_appdata_path }}/{{ lookup('role_var', '_paths_folder', role='panelarr') }}"
+panelarr_role_paths_folders_list:
+  - "{{ lookup('role_var', '_paths_location', role='panelarr') }}"
+
+################################
+# Docker Socket Proxy
+################################
+
+panelarr_role_docker_socket_proxy_envs:
+  ALLOW_START: "1"
+  ALLOW_STOP: "1"
+  ALLOW_RESTARTS: "1"
+  CONTAINERS: "1"
+  IMAGES: "1"
+  POST: "1"
+  NETWORKS: "1"
+
+################################
+# Web
+################################
+
+panelarr_role_web_subdomain: "{{ panelarr_name }}"
+panelarr_role_web_domain: "{{ user.domain }}"
+panelarr_role_web_port: "8000"
+panelarr_role_web_url: "{{ 'https://' + (lookup('role_var', '_web_subdomain', role='panelarr') + '.' + lookup('role_var', '_web_domain', role='panelarr')
+                        if (lookup('role_var', '_web_subdomain', role='panelarr') | length > 0)
+                        else lookup('role_var', '_web_domain', role='panelarr')) }}"
+
+################################
+# DNS
+################################
+
+panelarr_role_dns_record: "{{ lookup('role_var', '_web_subdomain', role='panelarr') }}"
+panelarr_role_dns_zone: "{{ lookup('role_var', '_web_domain', role='panelarr') }}"
+panelarr_role_dns_proxy: "{{ dns_proxied }}"
+
+################################
+# Traefik
+################################
+
+panelarr_role_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+panelarr_role_traefik_middleware_default: "{{ traefik_default_middleware }}"
+panelarr_role_traefik_middleware_custom: ""
+panelarr_role_traefik_certresolver: "{{ traefik_default_certresolver }}"
+panelarr_role_traefik_enabled: true
+panelarr_role_traefik_api_enabled: true
+panelarr_role_traefik_api_endpoint: "PathPrefix(`/api`) || PathPrefix(`/ws`)"
+
+################################
+# Docker
+################################
+
+# Container
+panelarr_role_docker_container: "{{ panelarr_name }}"
+
+# Image
+panelarr_role_docker_image_pull: true
+panelarr_role_docker_image_repo: "ghcr.io/thug-drama/panelarr"
+panelarr_role_docker_image_tag: "latest"
+panelarr_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='panelarr') }}:{{ lookup('role_var', '_docker_image_tag', role='panelarr') }}"
+
+# Envs
+panelarr_role_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+  DOCKER_SOCKET: "tcp://{{ panelarr_name }}-docker-socket-proxy:2375"
+panelarr_role_docker_envs_custom: {}
+panelarr_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='panelarr')
+                               | combine(lookup('role_var', '_docker_envs_custom', role='panelarr')) }}"
+
+# Volumes
+panelarr_role_docker_volumes_default:
+  - "{{ lookup('role_var', '_paths_location', role='panelarr') }}:/config"
+panelarr_role_docker_volumes_custom: []
+panelarr_role_docker_volumes: "{{ lookup('role_var', '_docker_volumes_default', role='panelarr')
+                                  + lookup('role_var', '_docker_volumes_custom', role='panelarr') }}"
+
+# Hostname
+panelarr_role_docker_hostname: "{{ panelarr_name }}"
+
+# Networks
+panelarr_role_docker_networks_alias: "{{ panelarr_name }}"
+panelarr_role_docker_networks_default: []
+panelarr_role_docker_networks_custom: []
+panelarr_role_docker_networks: "{{ docker_networks_common
+                                   + lookup('role_var', '_docker_networks_default', role='panelarr')
+                                   + lookup('role_var', '_docker_networks_custom', role='panelarr') }}"
+
+# Capabilities
+panelarr_role_docker_capabilities_default:
+  - CHOWN
+  - SETUID
+  - SETGID
+panelarr_role_docker_capabilities_custom: []
+panelarr_role_docker_capabilities: "{{ lookup('role_var', '_docker_capabilities_default', role='panelarr')
+                                       + lookup('role_var', '_docker_capabilities_custom', role='panelarr') }}"
+
+# Restart Policy
+panelarr_role_docker_restart_policy: unless-stopped
+
+# State
+panelarr_role_docker_state: started
+
+# Dependencies
+panelarr_role_depends_on: "{{ panelarr_name }}-docker-socket-proxy"
+panelarr_role_depends_on_delay: "0"
+panelarr_role_depends_on_healthchecks: "false"

--- a/roles/panelarr/tasks/main.yml
+++ b/roles/panelarr/tasks/main.yml
@@ -1,0 +1,31 @@
+##########################################################################
+# Title:            Sandbox: Panelarr                                    #
+# Author(s):        thug-drama                                           #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Docker Socket Proxy Role
+  ansible.builtin.include_role:
+    name: docker_socket_proxy
+  vars:
+    docker_socket_proxy_name: "{{ panelarr_name }}-docker-socket-proxy"
+    docker_socket_proxy_role_docker_envs_custom: "{{ lookup('role_var', '_docker_socket_proxy_envs', role='panelarr') }}"
+
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('role_var', '_dns_record') }}"
+    dns_zone: "{{ lookup('role_var', '_dns_zone') }}"
+    dns_proxy: "{{ lookup('role_var', '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -128,6 +128,7 @@
     - { role: openobserve, tags: ['openobserve'] }
     - { role: paperless_ai, tags: ['paperless-ai'] }
     - { role: paperless_ngx, tags: ['paperless-ngx'] }
+    - { role: panelarr, tags: ['panelarr'] }
     - { role: pgadmin, tags: ['pgadmin'] }
     - { role: photoprism, tags: ['photoprism'] }
     - { role: phpmyadmin, tags: ['phpmyadmin'] }


### PR DESCRIPTION
## Summary

Adds a Sandbox role for [Panelarr](https://github.com/thug-drama/panelarr), a self-hosted control center for Docker-based media stacks.

- Single container that manages Sonarr, Radarr, qBittorrent, SABnzbd, Plex, Jellyfin, and Docker containers from one dashboard
- GHCR image at `ghcr.io/thug-drama/panelarr:latest` (amd64 + arm64)
- Uses Docker socket proxy with permissions for containers, images, networks, and POST operations
- Config persisted to the standard appdata path at `/config`
- Traefik with SSO middleware and API/WebSocket path routing
- Setup wizard auto-discovers services on the same Docker network and pre-fills URLs

After install, open `https://panelarr.yourdomain.com` and complete the setup wizard. No manual config file editing needed.

**Project:** https://github.com/thug-drama/panelarr
**Site:** https://panelarr.dev
**License:** MIT

## Test plan

- [ ] `sb install sandbox` with `panelarr` tag
- [ ] Verify Docker socket proxy creates alongside panelarr container
- [ ] Verify Traefik routes to port 8000 with SSO middleware
- [ ] Verify setup wizard detects Sonarr/Radarr/etc. on the saltbox network
- [ ] Verify config persists across container recreates