### PR TITLE
Update Docker image repository for maintainerr role

### DIFF
--- a/roles/maintainerr/defaults/main.yml
+++ b/roles/maintainerr/defaults/main.yml
@@ -62,7 +62,7 @@ maintainerr_role_docker_container: "{{ maintainerr_name }}"
 
 # Image
 maintainerr_role_docker_image_pull: true
-maintainerr_role_docker_image_repo: "jorenn92/maintainerr"
+maintainerr_role_docker_image_repo: "maintainerr/maintainerr"
 maintainerr_role_docker_image_tag: "latest"
 maintainerr_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='maintainerr') }}:{{ lookup('role_var', '_docker_image_tag', role='maintainerr') }}"
 


### PR DESCRIPTION
# Description
For existing roles, please include a summary of the change and which issue is fixed if any. Please also include relevant motivation and context. List any dependencies that are required for this change.

The project has moved its repository to an organization:
https://github.com/Maintainerr/Maintainerr/releases/tag/v2.22.0

# How Has This Been Tested?

I have tested on my server (Ubuntu 22.04, latest saltbox update)
