### PR TITLE
 feat(role): add dispatcharr

### DIFF
--- a/roles/dispatcharr/defaults/main.yml
+++ b/roles/dispatcharr/defaults/main.yml
@@ -1,0 +1,112 @@
+##########################################################################
+# Title:         Sandbox: Dispatcharr | Default Variables                #
+# Author(s):     Jamyn Shanley                                           #
+# URL:           https://github.com/saltyorg/Sandbox                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+dispatcharr_name: dispatcharr
+
+################################
+# Settings
+################################
+
+dispatcharr_role_log_level: "info"
+dispatcharr_role_use_legacy_numpy: false
+
+################################
+# Paths
+################################
+
+dispatcharr_role_paths_folder: "{{ dispatcharr_name }}"
+dispatcharr_role_paths_location: "{{ server_appdata_path }}/{{ dispatcharr_role_paths_folder }}"
+dispatcharr_role_paths_folders_list:
+  - "{{ dispatcharr_role_paths_location }}"
+
+################################
+# Web
+################################
+
+dispatcharr_role_web_subdomain: "{{ dispatcharr_name }}"
+dispatcharr_role_web_domain: "{{ user.domain }}"
+dispatcharr_role_web_port: "9191"
+dispatcharr_role_web_url: "{{ 'https://' + (lookup('role_var', '_web_subdomain', role='dispatcharr') + '.' + lookup('role_var', '_web_domain', role='dispatcharr')
+                           if (lookup('role_var', '_web_subdomain', role='dispatcharr') | length > 0)
+                           else lookup('role_var', '_web_domain', role='dispatcharr')) }}"
+
+################################
+# DNS
+################################
+
+dispatcharr_role_dns_record: "{{ lookup('role_var', '_web_subdomain', role='dispatcharr') }}"
+dispatcharr_role_dns_zone: "{{ lookup('role_var', '_web_domain', role='dispatcharr') }}"
+dispatcharr_role_dns_proxy: "{{ dns_proxied }}"
+
+################################
+# Traefik
+################################
+
+dispatcharr_role_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+dispatcharr_role_traefik_middleware_default: "{{ traefik_default_middleware }}"
+dispatcharr_role_traefik_middleware_custom: ""
+dispatcharr_role_traefik_certresolver: "{{ traefik_default_certresolver }}"
+dispatcharr_role_traefik_enabled: true
+dispatcharr_role_traefik_api_enabled: false
+dispatcharr_role_traefik_api_endpoint: ""
+
+################################
+# Docker
+################################
+
+# Container
+dispatcharr_role_docker_container: "{{ dispatcharr_name }}"
+
+# Image
+dispatcharr_role_docker_image_pull: true
+dispatcharr_role_docker_image_repo: "ghcr.io/dispatcharr/dispatcharr"
+dispatcharr_role_docker_image_tag: "latest"
+dispatcharr_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='dispatcharr') }}:{{ lookup('role_var', '_docker_image_tag', role='dispatcharr') }}"
+
+# Envs
+dispatcharr_role_docker_envs_default:
+  TZ: "{{ tz }}"
+  DISPATCHARR_ENV: "aio"
+  REDIS_HOST: "localhost"
+  CELERY_BROKER_URL: "redis://localhost:6379/0"
+  DISPATCHARR_LOG_LEVEL: "{{ lookup('role_var', '_log_level', role='dispatcharr') }}"
+  USE_LEGACY_NUMPY: "{{ 'true'
+                     if (lookup('role_var', '_use_legacy_numpy', role='dispatcharr') | bool)
+                     else omit }}"
+dispatcharr_role_docker_envs_custom: {}
+dispatcharr_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='dispatcharr')
+                                  | combine(lookup('role_var', '_docker_envs_custom', role='dispatcharr')) }}"
+
+# Volumes
+dispatcharr_role_docker_volumes_default:
+  - "{{ lookup('role_var', '_paths_location', role='dispatcharr') }}:/data"
+dispatcharr_role_docker_volumes_custom: []
+dispatcharr_role_docker_volumes: "{{ lookup('role_var', '_docker_volumes_default', role='dispatcharr')
+                                     + lookup('role_var', '_docker_volumes_custom', role='dispatcharr') }}"
+
+# Hostname
+dispatcharr_role_docker_hostname: "{{ dispatcharr_name }}"
+
+# Networks
+dispatcharr_role_docker_networks_alias: "{{ dispatcharr_name }}"
+dispatcharr_role_docker_networks_default: []
+dispatcharr_role_docker_networks_custom: []
+dispatcharr_role_docker_networks: "{{ docker_networks_common
+                                      + lookup('role_var', '_docker_networks_default', role='dispatcharr')
+                                      + lookup('role_var', '_docker_networks_custom', role='dispatcharr') }}"
+
+# Restart Policy
+dispatcharr_role_docker_restart_policy: unless-stopped
+
+# State
+dispatcharr_role_docker_state: started

--- a/roles/dispatcharr/tasks/main.yml
+++ b/roles/dispatcharr/tasks/main.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:            Sandbox: Dispatcharr                                #
+# Author(s):        Jamyn Shanley                                       #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('role_var', '_dns_record') }}"
+    dns_zone: "{{ lookup('role_var', '_dns_zone') }}"
+    dns_proxy: "{{ lookup('role_var', '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -43,6 +43,7 @@
     - { role: deemix, tags: ['deemix'] }
     - { role: delugevpn, tags: ['delugevpn'] }
     - { role: discoflix, tags: ['discoflix'] }
+    - { role: dispatcharr, tags: ['dispatcharr'] }
     - { role: dockwatch, tags: ['dockwatch'] }
     - { role: doplarr, tags: ['doplarr'] }
     - { role: duplicati, tags: ['duplicati'] }


### PR DESCRIPTION
# Description

- [x] Official full name of the app: **Dispatcharr**
- [x] Summary of what the app is:
    > an open-source IPTV and stream management application with EPG handling, M3U/Xtream Codes import, HDHomeRun tuner emulation, and a stream proxy for Plex, Emby, and Jellyfin.
- [x] Link to [Docker Compose sample](https://github.com/Dispatcharr/Dispatcharr/blob/main/docker/docker-compose.aio.yml)
- [x] Link to [homepage](https://github.com/Dispatcharr/Dispatcharr)
- [x] Link to [releases page](https://github.com/Dispatcharr/Dispatcharr/releases)
- [x] Link to [documentation](https://dispatcharr.github.io/Dispatcharr-Docs/)
- [x] Link to primary [community discord](https://discord.gg/Sp45V5BcxU)
- [x] This role does not require Saltbox-specific configuration instructions (the upstream documentation is sufficient)
- [x] I will submit the documentation PR after the role is merged.

The role deploys the upstream all-in-one image (`ghcr.io/dispatcharr/dispatcharr:latest`, `DISPATCHARR_ENV: aio`), which bundles Dispatcharr, Celery, Redis, and Postgres into a single container. Port `9191` is exposed via Traefik on `dispatcharr.<domain>`. A docs PR will be opened against [saltyorg/docs](https://github.com/saltyorg/docs) to add `docs/sandbox/apps/dispatcharr.md` 

# How Has This Been Tested?
Deployed on a Saltbox install via `sb install sandbox-dispatcharr` on Ubuntu 22.04.

```
cd /opt/sandbox
git remote add fork https://github.com/jamyn/Sandbox.git
git checkout -B add-dispatcharr-role fork/add-dispatcharr-role
sb install sandbox-dispatcharr --no-cache
```

- [x] Cloudflare DNS record created automatically: `dispatcharr.<domain>`
- [x] Container starts and is healthy
- [x] Web UI reachable at `https://dispatcharr.<my-domain>` through Traefik
- [x] Basic configuration using web UI succeeds
- [x] Plugin installation succeeds, plugins appear functional
- [x] [Free IPTV m3u](https://github.com/iptv-org/iptv) feed added; channels viewable in dispatcharr browser
- [x] Dispatcharr appears as a tuner named `Dispatcharr HDHomeRun` in Plex
- [x] Plex Live TV can tune channels added to Dispatcharr
- [x] Persistent data survives container recreation (config and DB retained under `{{ server_appdata_path }}/dispatcharr`)