### PR TITLE
xbackbone: fix base URL being set to http during setup

### DIFF
--- a/roles/xbackbone/defaults/main.yml
+++ b/roles/xbackbone/defaults/main.yml
@@ -28,7 +28,9 @@ xbackbone_role_paths_folders_list:
 
 xbackbone_role_web_subdomain: "{{ xbackbone_name }}"
 xbackbone_role_web_domain: "{{ user.domain }}"
-xbackbone_role_web_port: "80"
+xbackbone_role_web_port: "443"
+xbackbone_role_web_scheme: "https"
+xbackbone_role_web_serverstransport: "skipverify@file"
 xbackbone_role_web_url: "{{ 'https://' + (lookup('role_var', '_web_subdomain', role='xbackbone') + '.' + lookup('role_var', '_web_domain', role='xbackbone')
                          if (lookup('role_var', '_web_subdomain', role='xbackbone') | length > 0)
                          else lookup('role_var', '_web_domain', role='xbackbone')) }}"


### PR DESCRIPTION
## Why

XBackbone's installer sets `base_url` from `$_SERVER['HTTPS']`, which is only populated on a TLS connection and ignores `X-Forwarded-Proto`. The role pointed Traefik at the container on port 80 over plain HTTP, so nginx saw a non-TLS connection and the installer wrote `http://` into `/config/www/xbackbone/config.php`, even when the admin loaded the site over https. The bug is on the Traefik-to-container hop, not the browser-to-Traefik hop.

The LSIO image serves the same UI over TLS on 443 (`-p 443:443`, "https gui" in the image docs). Pointing Traefik at 443 with backend TLS makes nginx report `$_SERVER['HTTPS']='on'`, so the installer writes `https://`.

## Change

`roles/xbackbone/defaults/main.yml`, Web section, matching the existing `crafty` and `unifi_network_application` roles that already speak HTTPS to a self-signed backend:

- `web_port` 80 -> 443
- add `web_scheme: "https"`
- add `web_serverstransport: "skipverify@file"` (the LSIO 443 listener uses a self-signed cert, so backend verification must be skipped or Traefik returns 502)

## Scope

This corrects new installs. An existing deployment that already ran the setup wizard has `http` persisted in `/config/www/xbackbone/config.php`; per the LSIO image docs that value has to be edited there once by hand, which Ansible cannot retroactively fix cleanly.

Closes #535
