### PR TITLE
feat(role): add silo

### DIFF
--- a/roles/silo/defaults/main.yml
+++ b/roles/silo/defaults/main.yml
@@ -132,7 +132,6 @@ silo_role_docker_volumes_default:
   - "{{ silo_role_paths_location }}/audiobook-covers:/var/lib/silo/audiobook-covers"
   - "{{ silo_role_paths_location }}/catalog-seeds:/catalog-seeds:ro"
   - "/proc/meminfo:/host/proc/meminfo:ro"
-  - "/dev/shm:/dev/shm"
 silo_role_docker_volumes_custom: []
 silo_role_docker_volumes: "{{ lookup('role_var', '_docker_volumes_default', role='silo')
                               + lookup('role_var', '_docker_volumes_custom', role='silo') }}"

--- a/roles/silo/defaults/main.yml
+++ b/roles/silo/defaults/main.yml
@@ -1,0 +1,165 @@
+##########################################################################
+# Title:            Sandbox: Silo | Default Variables                   #
+# Author(s):        After-Shock                                          #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+silo_name: silo
+
+################################
+# Postgres
+################################
+
+silo_role_postgres_deploy: true
+silo_role_postgres_name: "{{ silo_name }}-postgres"
+# If empty it will fall back to the postgres role default.
+silo_role_postgres_user: ""
+# If empty it will fall back to the postgres role default.
+silo_role_postgres_password: ""
+silo_role_postgres_docker_env_db: "silo"
+silo_role_postgres_docker_image_repo: "pgvector/pgvector"
+silo_role_postgres_docker_image_tag: "pg18"
+silo_role_postgres_docker_shm_size: "8G"
+silo_role_postgres_docker_healthcheck:
+  test: ["CMD-SHELL", "pg_isready -d {{ lookup('role_var', '_postgres_docker_env_db', role='silo') }} -U {{ lookup('role_var', '_postgres_user', role='silo') if (lookup('role_var', '_postgres_user', role='silo') | length > 0) else lookup('role_var', '_docker_env_user', role='postgres') }}"]
+  start_period: 20s
+  interval: 30s
+  retries: 5
+  timeout: 5s
+silo_role_postgres_paths_folder: "{{ silo_name }}"
+silo_role_postgres_paths_location: "{{ server_appdata_path }}/{{ silo_role_postgres_paths_folder }}/postgres"
+
+################################
+# Redis
+################################
+
+silo_role_redis_name: "{{ silo_name }}-redis"
+silo_role_redis_docker_image_tag: "alpine"
+silo_role_redis_paths_folder: "{{ silo_name }}"
+silo_role_redis_paths_location: "{{ server_appdata_path }}/{{ silo_role_redis_paths_folder }}/redis"
+
+################################
+# Paths
+################################
+
+silo_role_paths_folder: "{{ silo_name }}"
+silo_role_paths_location: "{{ server_appdata_path }}/{{ silo_role_paths_folder }}"
+silo_role_paths_transcodes_location: "{{ transcodes_path }}/{{ silo_role_paths_folder }}"
+silo_role_paths_folders_list:
+  - "{{ silo_role_paths_location }}"
+  - "{{ silo_role_paths_location }}/plugins"
+  - "{{ silo_role_paths_location }}/compat"
+  - "{{ silo_role_paths_transcodes_location }}"
+  - "{{ silo_role_paths_location }}/audiobook-covers"
+  - "{{ silo_role_paths_location }}/catalog-seeds"
+
+################################
+# Web
+################################
+
+silo_role_web_subdomain: "{{ silo_name }}"
+silo_role_web_domain: "{{ user.domain }}"
+silo_role_web_port: "8080"
+silo_role_web_url: "{{ 'https://' + (lookup('role_var', '_web_subdomain', role='silo') + '.' + lookup('role_var', '_web_domain', role='silo')
+                    if (lookup('role_var', '_web_subdomain', role='silo') | length > 0)
+                    else lookup('role_var', '_web_domain', role='silo')) }}"
+
+################################
+# DNS
+################################
+
+silo_role_dns_record: "{{ lookup('role_var', '_web_subdomain', role='silo') }}"
+silo_role_dns_zone: "{{ lookup('role_var', '_web_domain', role='silo') }}"
+silo_role_dns_proxy: "{{ dns_proxied }}"
+
+################################
+# Traefik
+################################
+
+silo_role_traefik_sso_middleware: ""
+silo_role_traefik_middleware_default: "{{ traefik_default_middleware }}"
+silo_role_traefik_middleware_custom: ""
+silo_role_traefik_certresolver: "{{ traefik_default_certresolver }}"
+silo_role_traefik_enabled: true
+silo_role_traefik_api_enabled: false
+silo_role_traefik_api_endpoint: ""
+silo_role_traefik_gzip_enabled: false
+
+################################
+# Docker
+################################
+
+# Container
+silo_role_docker_container: "{{ silo_name }}"
+
+# Image
+silo_role_docker_image_pull: true
+silo_role_docker_image_repo: "ghcr.io/silo-server/silo-server"
+silo_role_docker_image_tag: "latest"
+silo_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='silo') }}:{{ lookup('role_var', '_docker_image_tag', role='silo') }}"
+
+# Envs
+silo_role_docker_envs_default:
+  HOME: "/tmp"
+  SILO_PUBLIC_URL: "{{ lookup('role_var', '_web_url', role='silo') }}"
+  MODE: "integrated"
+  SECRET_KEY: "{{ silo_saltbox_facts.facts.secret_key }}"
+  DATABASE_URL: "postgres://{{ lookup('role_var', '_postgres_user', role='silo')
+                        if (lookup('role_var', '_postgres_user', role='silo') | length > 0)
+                        else lookup('role_var', '_docker_env_user', role='postgres') }}:{{ lookup('role_var', '_postgres_password', role='silo')
+                        if (lookup('role_var', '_postgres_password', role='silo') | length > 0)
+                        else lookup('role_var', '_docker_env_password', role='postgres') }}@{{ lookup('role_var', '_postgres_name', role='silo') }}:5432/{{ lookup('role_var', '_postgres_docker_env_db', role='silo') }}?sslmode=disable"
+  REDIS_URL: "redis://{{ lookup('role_var', '_redis_name', role='silo') }}:6379"
+  SILO_PLUGIN_CACHE_DIR: "/var/lib/silo/plugins"
+  POSTGRES_TUNE: "auto"
+  TZ: "{{ tz }}"
+silo_role_docker_envs_custom: {}
+silo_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='silo')
+                           | combine(lookup('role_var', '_docker_envs_custom', role='silo')) }}"
+
+# Volumes
+silo_role_docker_volumes_default:
+  - "{{ silo_role_paths_location }}/plugins:/var/lib/silo/plugins"
+  - "{{ silo_role_paths_location }}/compat:/var/lib/silo/compat"
+  - "{{ silo_role_paths_transcodes_location }}:/tmp/silo-transcode"
+  - "{{ silo_role_paths_location }}/audiobook-covers:/var/lib/silo/audiobook-covers"
+  - "{{ silo_role_paths_location }}/catalog-seeds:/catalog-seeds:ro"
+  - "/proc/meminfo:/host/proc/meminfo:ro"
+  - "/dev/shm:/dev/shm"
+silo_role_docker_volumes_custom: []
+silo_role_docker_volumes: "{{ lookup('role_var', '_docker_volumes_default', role='silo')
+                              + lookup('role_var', '_docker_volumes_custom', role='silo') }}"
+
+# Hostname
+silo_role_docker_hostname: "{{ silo_name }}"
+
+# Networks
+silo_role_docker_networks_alias: "{{ silo_name }}"
+silo_role_docker_networks_default: []
+silo_role_docker_networks_custom: []
+silo_role_docker_networks: "{{ docker_networks_common
+                               + lookup('role_var', '_docker_networks_default', role='silo')
+                               + lookup('role_var', '_docker_networks_custom', role='silo') }}"
+
+# Restart Policy
+silo_role_docker_restart_policy: unless-stopped
+
+# Groups
+silo_role_docker_groups:
+  - "{{ vgid }}"
+  - "{{ rgid }}"
+
+# User
+silo_role_docker_user: "{{ uid }}:{{ gid }}"
+
+# Dependencies
+silo_role_depends_on: "{{ lookup('role_var', '_postgres_name', role='silo') }},{{ lookup('role_var', '_redis_name', role='silo') }}"
+silo_role_depends_on_delay: "0"
+silo_role_depends_on_healthchecks: "false"

--- a/roles/silo/tasks/main.yml
+++ b/roles/silo/tasks/main.yml
@@ -57,18 +57,6 @@
 - name: Create directories
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
 
-- name: Ensure writable directories have correct ownership
-  ansible.builtin.file:
-    path: "{{ item }}"
-    owner: "{{ user.name }}"
-    group: "{{ user.name }}"
-    recurse: true
-  loop:
-    - "{{ silo_role_paths_location }}/plugins"
-    - "{{ silo_role_paths_location }}/compat"
-    - "{{ silo_role_paths_transcodes_location }}"
-    - "{{ silo_role_paths_location }}/audiobook-covers"
-
 - name: Docker Devices Task
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/set_docker_devices_variable.yml"
   when: use_intel or use_nvidia

--- a/roles/silo/tasks/main.yml
+++ b/roles/silo/tasks/main.yml
@@ -1,0 +1,77 @@
+##########################################################################
+# Title:            Sandbox: Silo                                        #
+# Author(s):        After-Shock                                          #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: "Save Silo Saltbox facts"
+  saltbox_facts:
+    role: "silo"
+    instance: "silo"
+    keys:
+      secret_key: "{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=50) }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    base_path: "{{ server_appdata_path }}"
+  no_log: true
+  register: silo_saltbox_facts
+
+- name: Redis Role
+  ansible.builtin.include_role:
+    name: redis
+  vars:
+    redis_instances: ["{{ lookup('role_var', '_redis_name', role='silo') }}"]
+    redis_role_docker_image_tag: "{{ lookup('role_var', '_redis_docker_image_tag', role='silo') }}"
+    redis_role_paths_folder: "{{ lookup('role_var', '_redis_paths_folder', role='silo') }}"
+    redis_role_paths_location: "{{ lookup('role_var', '_redis_paths_location', role='silo') }}"
+
+- name: "Import Postgres Role"
+  ansible.builtin.include_role:
+    name: postgres
+  vars:
+    postgres_instances: ["{{ lookup('role_var', '_postgres_name', role='silo') }}"]
+    postgres_role_docker_image_repo: "{{ lookup('role_var', '_postgres_docker_image_repo', role='silo') }}"
+    postgres_role_docker_image_tag: "{{ lookup('role_var', '_postgres_docker_image_tag', role='silo') }}"
+    postgres_role_docker_shm_size: "{{ lookup('role_var', '_postgres_docker_shm_size', role='silo') }}"
+    postgres_role_paths_folder: "{{ lookup('role_var', '_postgres_paths_folder', role='silo') }}"
+    postgres_role_paths_location: "{{ lookup('role_var', '_postgres_paths_location', role='silo') }}"
+    postgres_role_docker_env_db: "{{ lookup('role_var', '_postgres_docker_env_db', role='silo') }}"
+    postgres_role_docker_env_user_include: "{{ lookup('role_var', '_postgres_user', role='silo') }}"
+    postgres_role_docker_env_password_include: "{{ lookup('role_var', '_postgres_password', role='silo') }}"
+    postgres_role_docker_healthcheck: "{{ lookup('role_var', '_postgres_docker_healthcheck', role='silo') }}"
+  when: lookup('role_var', '_postgres_deploy', role='silo')
+
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('role_var', '_dns_record', role='silo') }}"
+    dns_zone: "{{ lookup('role_var', '_dns_zone', role='silo') }}"
+    dns_proxy: "{{ lookup('role_var', '_dns_proxy', role='silo') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Ensure writable directories have correct ownership
+  ansible.builtin.file:
+    path: "{{ item }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    recurse: true
+  loop:
+    - "{{ silo_role_paths_location }}/plugins"
+    - "{{ silo_role_paths_location }}/compat"
+    - "{{ silo_role_paths_transcodes_location }}"
+    - "{{ silo_role_paths_location }}/audiobook-covers"
+
+- name: Docker Devices Task
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/set_docker_devices_variable.yml"
+  when: use_intel or use_nvidia
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/silo/tasks/main.yml
+++ b/roles/silo/tasks/main.yml
@@ -16,7 +16,6 @@
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
     base_path: "{{ server_appdata_path }}"
-  no_log: true
   register: silo_saltbox_facts
 
 - name: Redis Role

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -144,6 +144,7 @@
     - { role: sabthrottle, tags: ['sabthrottle'] }
     - { role: semaphoreui, tags: ['semaphoreui'] }
     - { role: shelfmark, tags: ['shelfmark'] }
+    - { role: silo, tags: ['silo'] }
     - { role: slskd, tags: ['slskd'] }
     - { role: speedtest, tags: ['speedtest'] }
     - { role: sqlitebrowser, tags: ['sqlitebrowser'] }


### PR DESCRIPTION
## Summary

Adds a Sandbox role for [Silo](https://github.com/Silo-Server/silo-server), a self-hosted media server for movies, shows, music, and books.

The role deploys Silo with PostgreSQL and Redis through Saltbox's shared service roles. PostgreSQL uses `pgvector/pgvector:pg18`, which provides Silo's required vector extension.

## Role details

- Runs Silo as the Saltbox `uid:gid` instead of the image's default root user.
- Sets `HOME=/tmp` so Node and npm have a writable cache and temporary location.
- Adds the video and render groups so the non-root process can access `/dev/dri` for hardware transcoding.
- Uses the standard Saltbox transcodes path, mounted at `/tmp/silo-transcode`.
- Uses Saltbox's standard Docker device detection, networking, DNS, Traefik, and `/mnt` media mount behavior.
- Sets `SILO_PUBLIC_URL` from the role's public URL and disables Traefik gzip like the other media-server roles.
- Gives the bundled PostgreSQL container 8 GB of shared memory, matching Silo's upstream Compose default.
- Generates and persists Silo's credential-encryption key with `saltbox_facts` while suppressing sensitive task output.
- Mounts the plugin, compatibility, audiobook-cover, catalog-seed, and host memory-info paths used by the upstream deployment.

Silo's optional Jellyfin-compatible listener is disabled by default upstream and uses a separate port when enabled. This role currently exposes only Silo's main web service through Traefik.

## Testing

Validated with the current upstream Silo, pgvector PostgreSQL 18, and Redis Alpine images:

- Silo ran healthy as the configured Saltbox UID:GID with the supplementary video and render groups.
- Plugin, compatibility, transcode, audiobook-cover, and temporary paths remained writable after startup.
- `HOME=/tmp` was present and `SILO_PUBLIC_URL` matched the configured public role URL.
- The Silo process could read and write the available `/dev/dri` devices without root access.
- PostgreSQL became healthy with the Saltbox numeric user, an 8 GB shared-memory limit, and the vector extension available.
- Redis returned `PONG`.
- The public health and readiness endpoints returned HTTP 200.
- Current-start logs contained no permission errors.
- `ansible-lint`, the Sandbox defaults linter, role-entry checks, and `git diff --check` passed.

## Documentation

Companion documentation: saltyorg/docs#411


