### PR TITLE
feat(forgejo): upgrade to v16, fix env var names and MariaDB password lookup

### DIFF
--- a/roles/forgejo/defaults/main.yml
+++ b/roles/forgejo/defaults/main.yml
@@ -76,7 +76,7 @@ forgejo_role_docker_envs_default:
   USER_GID: "{{ gid }}"
   FORGEJO__database__DB_TYPE: "mysql"
   FORGEJO__database__HOST: "mariadb:3306"
-  FORGEJO__database__USER: "root"
+  FORGEJO__database__USER: "{{ lookup('role_var', '_docker_env_user', role='mariadb') }}"
   FORGEJO__database__PASSWD: "{{ lookup('role_var', '_docker_env_password', role='mariadb') }}"
   FORGEJO__database__NAME: "forgejo"
   FORGEJO__server__DISABLE_SSH: "true"

--- a/roles/forgejo/defaults/main.yml
+++ b/roles/forgejo/defaults/main.yml
@@ -76,12 +76,12 @@ forgejo_role_docker_envs_default:
   USER_GID: "{{ gid }}"
   FORGEJO__database__DB_TYPE: "mysql"
   FORGEJO__database__HOST: "mariadb:3306"
-  FORGEJO__database__USER: "{{ lookup('role_var', '_docker_env_user', role='mariadb') }}"
+  FORGEJO__database__USER: "root"
   FORGEJO__database__PASSWD: "{{ lookup('role_var', '_docker_env_password', role='mariadb') }}"
   FORGEJO__database__NAME: "forgejo"
   FORGEJO__server__DISABLE_SSH: "true"
   FORGEJO__server__ROOT_URL: "{{ lookup('role_var', '_web_url', role='forgejo') }}/"
-  FORGEJO__security__REVERSE_PROXY_TRUSTED_PROXIES: "*"
+  FORGEJO__security__REVERSE_PROXY_TRUSTED_PROXIES: "172.19.0.0/16"
 forgejo_role_docker_envs_custom: {}
 forgejo_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='forgejo')
                               | combine(lookup('role_var', '_docker_envs_custom', role='forgejo')) }}"

--- a/roles/forgejo/defaults/main.yml
+++ b/roles/forgejo/defaults/main.yml
@@ -67,7 +67,7 @@ forgejo_role_docker_container: "{{ forgejo_name }}"
 # Image
 forgejo_role_docker_image_pull: true
 forgejo_role_docker_image_repo: "codeberg.org/forgejo/forgejo"
-forgejo_role_docker_image_tag: "13" # the Codeberg container registry does not provide a "latest" tag
+forgejo_role_docker_image_tag: "16" # the Codeberg container registry does not provide a "latest" tag
 forgejo_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='forgejo') }}:{{ lookup('role_var', '_docker_image_tag', role='forgejo') }}"
 
 # Envs
@@ -77,9 +77,10 @@ forgejo_role_docker_envs_default:
   DB_TYPE: "mysql"
   DB_HOST: "mariadb:3306"
   DB_USER: "root"
-  DB_PASS: "password321"
-  DB_DATABASE: "forgejo"
+  DB_PASSWD: "{{ lookup('role_var', '_docker_env_password', role='mariadb') }}"
+  DB_NAME: "forgejo"
   DISABLE_SSH: "true"
+  FORGEJO__security__REVERSE_PROXY_TRUSTED_PROXIES: "*"
   ROOT_URL: "{{ lookup('role_var', '_web_url', role='forgejo') }}/"
 forgejo_role_docker_envs_custom: {}
 forgejo_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='forgejo')

--- a/roles/forgejo/defaults/main.yml
+++ b/roles/forgejo/defaults/main.yml
@@ -74,14 +74,14 @@ forgejo_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='fo
 forgejo_role_docker_envs_default:
   USER_UID: "{{ uid }}"
   USER_GID: "{{ gid }}"
-  DB_TYPE: "mysql"
-  DB_HOST: "mariadb:3306"
-  DB_USER: "root"
-  DB_PASSWD: "{{ lookup('role_var', '_docker_env_password', role='mariadb') }}"
-  DB_NAME: "forgejo"
-  DISABLE_SSH: "true"
+  FORGEJO__database__DB_TYPE: "mysql"
+  FORGEJO__database__HOST: "mariadb:3306"
+  FORGEJO__database__USER: "root"
+  FORGEJO__database__PASSWD: "{{ lookup('role_var', '_docker_env_password', role='mariadb') }}"
+  FORGEJO__database__NAME: "forgejo"
+  FORGEJO__server__DISABLE_SSH: "true"
+  FORGEJO__server__ROOT_URL: "{{ lookup('role_var', '_web_url', role='forgejo') }}/"
   FORGEJO__security__REVERSE_PROXY_TRUSTED_PROXIES: "*"
-  ROOT_URL: "{{ lookup('role_var', '_web_url', role='forgejo') }}/"
 forgejo_role_docker_envs_custom: {}
 forgejo_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='forgejo')
                               | combine(lookup('role_var', '_docker_envs_custom', role='forgejo')) }}"


### PR DESCRIPTION
# Description

Upgrades the Forgejo role from image tag \`13\` to \`16\` (current stable release), fixes two long-standing silent bugs in the Docker env var configuration, and migrates all config env vars to the \`FORGEJO__\` convention.

- **Image tag**: \`"13"\` → \`"16"\` (v15 is LTS, v16 is current stable; v13 is discontinued)
- **Full \`FORGEJO__\` env var convention**: All config env vars now use the \`FORGEJO__<section>__<key>\` format processed by \`environment-to-ini\` on every container start, rather than bare env vars (\`DISABLE_SSH\`, \`ROOT_URL\`, etc.) that the entrypoint only applies on first boot when \`app.ini\` doesn't yet exist. This means config is always authoritative regardless of whether it's a new or existing install.
- **\`DB_PASS\` → \`FORGEJO__database__PASSWD\`**: The old key was silently ignored on fresh installs, leaving the database password empty.
- **\`DB_DATABASE\` → \`FORGEJO__database__NAME\`**: The old key was silently ignored, causing the database name to default to \`gitea\` instead of \`forgejo\` on fresh installs.
- **MariaDB password lookup**: Replaced hardcoded \`"password321"\` with \`lookup('role_var', '_docker_env_password', role='mariadb')\` — the standard Saltbox/Sandbox pattern used by all other MariaDB-backed roles (gitea, bookstack, etc.). DB user remains \`root\`: the non-root MariaDB user (\`_docker_env_user\`) only has grants on the \`saltbox\` database, not on \`forgejo\`.
- **\`FORGEJO__security__REVERSE_PROXY_TRUSTED_PROXIES: "172.19.0.0/16"\`**: The v16 image template omits \`REVERSE_PROXY_TRUSTED_PROXIES = *\` from \`[security]\`, which v13/v15 included by default. Without this, new v16 installs behind Traefik would not trust \`X-Forwarded-For\` headers. Scoped to the saltbox Docker network subnet (\`172.19.0.0/16\`) rather than \`"*"\` so only co-located containers (Traefik) are trusted.

**File changed**: \`roles/forgejo/defaults/main.yml\` only. \`tasks/main.yml\` is unchanged — Forgejo auto-migrates its DB schema on startup, and direct v13→v16 skipping is supported per the official docs.

**Impact on existing installs**: \`app.ini\` is already on disk so the env var fixes only matter for new installs. The switch to \`FORGEJO__\` format means config keys are now enforced on every container restart rather than being set-once.

# How Has This Been Tested?

- [x] Pulled and inspected the actual Docker images for v13, v15, and v16 — confirmed the entrypoint script and \`app.ini\` template use \`$DB_PASSWD\` and \`$DB_NAME\` (not \`$DB_PASS\` / \`$DB_DATABASE\`) via \`envsubst\`, byte-for-byte identical across all three versions
- [x] Confirmed v16 template omits \`REVERSE_PROXY_TRUSTED_PROXIES = *\` from \`[security]\` (present in v13/v15)
- [x] Confirmed \`environment-to-ini\` processes \`FORGEJO__\` vars on every container start
- [x] Verified saltbox Docker network subnet is \`172.19.0.0/16\` (from \`roles/docker/tasks/subtasks/network.yml\` in saltyorg/saltbox)