### PR TITLE
feat(joplin): bump postgres to 16

### DIFF
--- a/roles/joplin/defaults/main.yml
+++ b/roles/joplin/defaults/main.yml
@@ -22,7 +22,7 @@ joplin_role_postgres_name: "{{ joplin_name }}-postgres"
 joplin_role_postgres_user: "joplin"
 joplin_role_postgres_password: "joplin"
 joplin_role_postgres_docker_env_db: "joplin"
-joplin_role_postgres_docker_image_tag: "13"
+joplin_role_postgres_docker_image_tag: "16"
 joplin_role_postgres_docker_image_repo: "postgres"
 joplin_role_postgres_docker_healthcheck:
   test: ["CMD-SHELL", "pg_isready -d {{ lookup('role_var', '_postgres_docker_env_db', role='joplin') }} -U {{ lookup('role_var', '_postgres_user', role='joplin') }}"]


### PR DESCRIPTION
# Description

Bumps the embedded PostgreSQL image tag from `13` to `16` for the joplin role.

PostgreSQL 13 has reached end-of-life (November 2025). PostgreSQL 16 is supported until November 2028. This matches the version used in [Joplin's own official `docker-compose.server.yml`](https://github.com/laurent22/joplin/blob/dev/docker-compose.server.yml) (`image: postgres:16`), so we stay on what upstream actually tests against rather than jumping further ahead.

**Note:** this upgrade still crosses the PostgreSQL 14 authentication boundary. PostgreSQL 14 changed the default password hashing algorithm from `md5` to `scram-sha-256`. The Saltbox postgres role detects this automatically and runs `ALTER USER ... WITH PASSWORD '...'` inside the new container immediately after the dump/restore, so the Joplin application can authenticate without any manual credential changes.

## Why no manual migration steps are required

The Saltbox `postgres` role (`roles/postgres/tasks/main2.yml`) handles major version upgrades automatically. When the role runs and detects that the major version in `PG_VERSION` on disk does not match the configured image tag, it:

1. Backs up the existing data directory (e.g. `.../postgres` → `.../postgres_backup`)
2. Starts a temporary container on the **old** version pointed at the backup
3. Starts a temporary container on the **new** version pointed at fresh storage
4. Streams a full logical dump across: `pg_dumpall` (old) piped directly into `psql` (new)
5. Tears down both temp containers and starts the real container on the new version

The backup is left in place until manually removed, so rollback is possible by stopping the container, removing the new data directory, and renaming `postgres_backup` back to `postgres`.

Users re-running `sb install joplin` is all that is needed.

# How Has This Been Tested?

Verified by reviewing the Saltbox postgres role migration logic in `roles/postgres/tasks/main2.yml`. The automatic upgrade path has been in place for existing roles in the repo that have already been bumped across major versions (e.g. teslamate at `18`, tandoor at `17-alpine`).

- [x] Change is a one-line image tag bump with no logic changes
- [x] Migration is handled entirely by the existing Saltbox postgres role
- [x] Rollback is possible via the backup directory left in place after migration