### PR TITLE
feat(n8n): bump postgres to 16-alpine

### DIFF
--- a/roles/n8n/defaults/main.yml
+++ b/roles/n8n/defaults/main.yml
@@ -24,7 +24,7 @@ n8n_role_postgres_user: ""
 # If empty it will fallback to postgres role default
 n8n_role_postgres_password: ""
 n8n_role_postgres_docker_env_db: "{{ n8n_name }}"
-n8n_role_postgres_docker_image_tag: "14-alpine"
+n8n_role_postgres_docker_image_tag: "16-alpine"
 n8n_role_postgres_docker_image_repo: "postgres"
 n8n_role_postgres_docker_healthcheck:
   test: ["CMD-SHELL", "pg_isready -d {{ lookup('role_var', '_postgres_docker_env_db', role='n8n') }} -U {{ lookup('role_var', '_postgres_user', role='n8n') if (lookup('role_var', '_postgres_user', role='n8n') | length > 0) else lookup('role_var', '_docker_env_user', role='postgres') }}"]


### PR DESCRIPTION
# Description

Bumps the embedded PostgreSQL image tag from `14-alpine` to `16-alpine` for the n8n role.

PostgreSQL 14 reaches end-of-life in November 2026. PostgreSQL 16 is supported until November 2028. Aligning on 16 (rather than a newer major) matches the version used in [n8n's own docker-compose reference](https://github.com/n8n-io/n8n-hosting/blob/main/docker-compose/withPostgres/docker-compose.yml), so we stay on what n8n actually tests against.

## Why no manual migration steps are required

The Saltbox `postgres` role (`roles/postgres/tasks/main2.yml`) handles major version upgrades automatically. When the role runs and detects that the major version in `PG_VERSION` on disk does not match the configured image tag, it:

1. Backs up the existing data directory (e.g. `.../postgres` → `.../postgres_backup`)
2. Starts a temporary container on the **old** version pointed at the backup
3. Starts a temporary container on the **new** version pointed at fresh storage
4. Streams a full logical dump across: `pg_dumpall` (old) piped directly into `psql` (new)
5. Tears down both temp containers and starts the real container on the new version

The backup is left in place until manually removed, so rollback is possible by stopping the container, removing the new data directory, and renaming `postgres_backup` back to `postgres`.

Users re-running `sb install n8n` is all that is needed.

# How Has This Been Tested?

Verified by reviewing the Saltbox postgres role migration logic in `roles/postgres/tasks/main2.yml`. The automatic upgrade path has been in place for existing roles in the repo that have already been bumped across major versions (e.g. teslamate at `18`, tandoor at `17-alpine`).

- [x] Change is a one-line image tag bump with no logic changes
- [x] Migration is handled entirely by the existing Saltbox postgres role
- [x] Rollback is possible via the backup directory left in place after migration