### PR TITLE
feat(paperless_ngx): bump postgres to 18-alpine

### DIFF
--- a/roles/paperless_ngx/defaults/main.yml
+++ b/roles/paperless_ngx/defaults/main.yml
@@ -24,7 +24,7 @@ paperless_ngx_role_postgres_user: ""
 # If empty it will fallback to postgres role default
 paperless_ngx_role_postgres_password: ""
 paperless_ngx_role_postgres_docker_env_db: "{{ paperless_ngx_name }}"
-paperless_ngx_role_postgres_docker_image_tag: "14-alpine"
+paperless_ngx_role_postgres_docker_image_tag: "18-alpine"
 paperless_ngx_role_postgres_docker_image_repo: "postgres"
 paperless_ngx_role_postgres_docker_healthcheck:
   test: ["CMD-SHELL", "pg_isready -d {{ lookup('role_var', '_postgres_docker_env_db', role='paperless_ngx') }} -U {{ lookup('role_var', '_postgres_user', role='paperless_ngx') if (lookup('role_var', '_postgres_user', role='paperless_ngx') | length > 0) else lookup('role_var', '_docker_env_user', role='postgres') }}"]


### PR DESCRIPTION
# Description

Bumps the embedded PostgreSQL image tag from `14-alpine` to `18-alpine` for the paperless_ngx role.

PostgreSQL 14 reaches end-of-life in November 2026. PostgreSQL 18 is supported until November 2030. This matches the version used in paperless-ngx's own official [`docker-compose.postgres-tika.yml`](https://github.com/paperless-ngx/paperless-ngx/blob/dev/docker/compose/docker-compose.postgres-tika.yml), so we stay on what upstream actually tests against rather than an arbitrary intermediate version.

## Why no manual migration steps are required

The Saltbox `postgres` role (`roles/postgres/tasks/main2.yml`) handles major version upgrades automatically, including multi-major-version jumps in a single run (the logical `pg_dumpall`/`psql` dump-and-restore approach isn't tied to how many majors are skipped). When the role runs and detects that the major version in `PG_VERSION` on disk does not match the configured image tag, it:

1. Backs up the existing data directory (e.g. `.../postgres` → `.../postgres_backup`)
2. Starts a temporary container on the **old** version pointed at the backup
3. Starts a temporary container on the **new** version pointed at fresh storage
4. Streams a full logical dump across: `pg_dumpall` (old) piped directly into `psql` (new)
5. Tears down both temp containers and starts the real container on the new version

The backup is left in place until manually removed, so rollback is possible by stopping the container, removing the new data directory, and renaming `postgres_backup` back to `postgres`.

Note: [saltyorg/Saltbox@a2c71bc](https://github.com/saltyorg/Saltbox/commit/a2c71bc9b26e25528c0420609296578631e0a1e2) hardened this migration path (proper `pg_isready` polling instead of fixed sleeps, semver-aware version comparison, interrupted-migration recovery, and post-migration verification that all databases/roles carried over) and is already on Saltbox `master`, so this bump is covered by that fix.

Users re-running `sb install paperless_ngx` is all that is needed.

# How Has This Been Tested?

Verified by reviewing the Saltbox postgres role migration logic in `roles/postgres/tasks/main2.yml`, including the hardening in the commit linked above.

- [x] Change is a one-line image tag bump with no logic changes
- [x] Migration is handled entirely by the existing Saltbox postgres role
- [x] Rollback is possible via the backup directory left in place after migration