### PR TITLE
feat(wikijs): bump postgres to 17-alpine

### DIFF
--- a/roles/wikijs/defaults/main.yml
+++ b/roles/wikijs/defaults/main.yml
@@ -24,7 +24,7 @@ wikijs_role_postgres_user: ""
 # If empty it will fallback to postgres role default
 wikijs_role_postgres_password: ""
 wikijs_role_postgres_docker_env_db: "{{ wikijs_name }}"
-wikijs_role_postgres_docker_image_tag: "15-alpine"
+wikijs_role_postgres_docker_image_tag: "17-alpine"
 wikijs_role_postgres_docker_image_repo: "postgres"
 wikijs_role_postgres_docker_healthcheck:
   test: ["CMD-SHELL", "pg_isready -d {{ lookup('role_var', '_postgres_docker_env_db', role='wikijs') }} -U {{ lookup('role_var', '_postgres_user', role='wikijs') if (lookup('role_var', '_postgres_user', role='wikijs') | length > 0) else lookup('role_var', '_docker_env_user', role='postgres') }}"]


### PR DESCRIPTION
# Description

Bumps the embedded PostgreSQL image tag from `15-alpine` to `17-alpine` for the wikijs role.

PostgreSQL 15 reaches end-of-life in November 2027. PostgreSQL 17 is supported until November 2029.

## Why no manual migration steps are required

The Saltbox `postgres` role (`roles/postgres/tasks/main2.yml`) handles major version upgrades automatically. When the role runs and detects that the major version in `PG_VERSION` on disk does not match the configured image tag, it:

1. Backs up the existing data directory (e.g. `.../postgres` → `.../postgres_backup`)
2. Starts a temporary container on the **old** version pointed at the backup
3. Starts a temporary container on the **new** version pointed at fresh storage
4. Streams a full logical dump across: `pg_dumpall` (old) piped directly into `psql` (new)
5. Tears down both temp containers and starts the real container on the new version

The backup is left in place until manually removed, so rollback is possible by stopping the container, removing the new data directory, and renaming `postgres_backup` back to `postgres`.

Users re-running `sb install wikijs` is all that is needed.

# How Has This Been Tested?

Verified by reviewing the Saltbox postgres role migration logic in `roles/postgres/tasks/main2.yml`. The automatic upgrade path has been in place for existing roles in the repo that have already been bumped across major versions (e.g. teslamate at `18`, tandoor at `17-alpine`).

- [x] Change is a one-line image tag bump with no logic changes
- [x] Migration is handled entirely by the existing Saltbox postgres role
- [x] Rollback is possible via the backup directory left in place after migration
