### PR TITLE
feat(linkwarden): bump postgres to 17-alpine

### DIFF
--- a/roles/linkwarden/defaults/main.yml
+++ b/roles/linkwarden/defaults/main.yml
@@ -22,7 +22,7 @@ linkwarden_role_postgres_name: "{{ linkwarden_name }}-postgres"
 linkwarden_role_postgres_user: "{{ linkwarden_name }}"
 linkwarden_role_postgres_password: "{{ linkwarden_name }}"
 linkwarden_role_postgres_docker_env_db: "{{ linkwarden_name }}"
-linkwarden_role_postgres_docker_image_tag: "16-alpine"
+linkwarden_role_postgres_docker_image_tag: "17-alpine"
 linkwarden_role_postgres_docker_image_repo: "postgres"
 linkwarden_role_postgres_docker_healthcheck:
   test: ["CMD-SHELL", "pg_isready -d {{ lookup('role_var', '_postgres_docker_env_db', role='linkwarden') }} -U {{ lookup('role_var', '_postgres_user', role='linkwarden') }}"]


### PR DESCRIPTION
# Description

Bumps the embedded PostgreSQL image tag from `16-alpine` to `17-alpine` for the linkwarden role.

PostgreSQL 16 reaches end-of-life in November 2028. PostgreSQL 17 is supported until November 2029.

## Why no manual migration steps are required

The Saltbox `postgres` role (`roles/postgres/tasks/main2.yml`) handles major version upgrades automatically. When the role runs and detects that the major version in `PG_VERSION` on disk does not match the configured image tag, it:

1. Backs up the existing data directory (e.g. `.../postgres` → `.../postgres_backup`)
2. Starts a temporary container on the **old** version pointed at the backup
3. Starts a temporary container on the **new** version pointed at fresh storage
4. Streams a full logical dump across: `pg_dumpall` (old) piped directly into `psql` (new)
5. Tears down both temp containers and starts the real container on the new version

The backup is left in place until manually removed, so rollback is possible by stopping the container, removing the new data directory, and renaming `postgres_backup` back to `postgres`.

Users re-running `sb install linkwarden` is all that is needed.

# How Has This Been Tested?

Verified by reviewing the Saltbox postgres role migration logic in `roles/postgres/tasks/main2.yml`. The automatic upgrade path has been in place for existing roles in the repo that have already been bumped across major versions (e.g. teslamate at `18`, tandoor at `17-alpine`).

- [x] Change is a one-line image tag bump with no logic changes
- [x] Migration is handled entirely by the existing Saltbox postgres role
- [x] Rollback is possible via the backup directory left in place after migration
