### PR TITLE
feat(silo): add Jellyfin/Audiobookshelf-compatible Traefik endpoints

### DIFF
--- a/roles/silo/defaults/main.yml
+++ b/roles/silo/defaults/main.yml
@@ -107,11 +107,11 @@ silo_role_dns_proxy: "{{ dns_proxied }}"
 
 silo_role_jf_dns_record: "{{ lookup('role_var', '_jf_web_subdomain', role='silo') }}"
 silo_role_jf_dns_zone: "{{ lookup('role_var', '_jf_web_domain', role='silo') }}"
-silo_role_jf_dns_proxy: "{{ dns_proxied }}"
+silo_role_jf_dns_proxy: "{{ lookup('role_var', '_dns_proxy', role='silo') }}"
 
 silo_role_abs_dns_record: "{{ lookup('role_var', '_abs_web_subdomain', role='silo') }}"
 silo_role_abs_dns_zone: "{{ lookup('role_var', '_abs_web_domain', role='silo') }}"
-silo_role_abs_dns_proxy: "{{ dns_proxied }}"
+silo_role_abs_dns_proxy: "{{ lookup('role_var', '_dns_proxy', role='silo') }}"
 
 ################################
 # Traefik
@@ -143,8 +143,8 @@ silo_role_jf_docker_labels_template:
   - '{ "traefik.http.services.{{ silo_name }}-jf.loadbalancer.server.port": "{{ lookup("role_var", "_jf_web_port", role="silo") }}" }'
 
 silo_role_jf_docker_labels: "{{ (silo_role_jf_docker_labels_template | map('from_json') | combine)
-                              if (lookup('role_var', '_jf_enabled', role='silo') | bool)
-                              else {} }}"
+                                if (lookup('role_var', '_jf_enabled', role='silo') | bool)
+                                else {} }}"
 
 # Audiobookshelf-compatible endpoint router/service labels (only rendered when silo_role_abs_enabled is true)
 silo_role_abs_docker_labels_template:
@@ -163,12 +163,12 @@ silo_role_abs_docker_labels_template:
   - '{ "traefik.http.services.{{ silo_name }}-abs.loadbalancer.server.port": "{{ lookup("role_var", "_abs_web_port", role="silo") }}" }'
 
 silo_role_abs_docker_labels: "{{ (silo_role_abs_docker_labels_template | map('from_json') | combine)
-                               if (lookup('role_var', '_abs_enabled', role='silo') | bool)
-                               else {} }}"
+                                  if (lookup('role_var', '_abs_enabled', role='silo') | bool)
+                                  else {} }}"
 
 silo_role_docker_labels_custom: {}
-silo_role_docker_labels: "{{ silo_role_jf_docker_labels
-                             | combine(silo_role_abs_docker_labels)
+silo_role_docker_labels: "{{ lookup('role_var', '_jf_docker_labels', role='silo')
+                             | combine(lookup('role_var', '_abs_docker_labels', role='silo'))
                              | combine(lookup('role_var', '_docker_labels_custom', role='silo')) }}"
 
 ################################

--- a/roles/silo/defaults/main.yml
+++ b/roles/silo/defaults/main.yml
@@ -72,12 +72,46 @@ silo_role_web_url: "{{ 'https://' + (lookup('role_var', '_web_subdomain', role='
                     else lookup('role_var', '_web_domain', role='silo')) }}"
 
 ################################
+# Jellyfin-compatible endpoint
+################################
+
+silo_role_jf_enabled: false
+silo_role_jf_web_subdomain: "{{ silo_name }}jf"
+silo_role_jf_web_domain: "{{ user.domain }}"
+silo_role_jf_web_port: "8096"
+silo_role_jf_host: "{{ (lookup('role_var', '_jf_web_subdomain', role='silo') + '.' + lookup('role_var', '_jf_web_domain', role='silo'))
+                    if (lookup('role_var', '_jf_web_subdomain', role='silo') | length > 0)
+                    else lookup('role_var', '_jf_web_domain', role='silo') }}"
+silo_role_jf_url: "https://{{ lookup('role_var', '_jf_host', role='silo') }}"
+
+################################
+# Audiobookshelf-compatible endpoint
+################################
+
+silo_role_abs_enabled: false
+silo_role_abs_web_subdomain: "{{ silo_name }}abs"
+silo_role_abs_web_domain: "{{ user.domain }}"
+silo_role_abs_web_port: "13378"
+silo_role_abs_host: "{{ (lookup('role_var', '_abs_web_subdomain', role='silo') + '.' + lookup('role_var', '_abs_web_domain', role='silo'))
+                     if (lookup('role_var', '_abs_web_subdomain', role='silo') | length > 0)
+                     else lookup('role_var', '_abs_web_domain', role='silo') }}"
+silo_role_abs_url: "https://{{ lookup('role_var', '_abs_host', role='silo') }}"
+
+################################
 # DNS
 ################################
 
 silo_role_dns_record: "{{ lookup('role_var', '_web_subdomain', role='silo') }}"
 silo_role_dns_zone: "{{ lookup('role_var', '_web_domain', role='silo') }}"
 silo_role_dns_proxy: "{{ dns_proxied }}"
+
+silo_role_jf_dns_record: "{{ lookup('role_var', '_jf_web_subdomain', role='silo') }}"
+silo_role_jf_dns_zone: "{{ lookup('role_var', '_jf_web_domain', role='silo') }}"
+silo_role_jf_dns_proxy: "{{ dns_proxied }}"
+
+silo_role_abs_dns_record: "{{ lookup('role_var', '_abs_web_subdomain', role='silo') }}"
+silo_role_abs_dns_zone: "{{ lookup('role_var', '_abs_web_domain', role='silo') }}"
+silo_role_abs_dns_proxy: "{{ dns_proxied }}"
 
 ################################
 # Traefik
@@ -91,6 +125,51 @@ silo_role_traefik_enabled: true
 silo_role_traefik_api_enabled: false
 silo_role_traefik_api_endpoint: ""
 silo_role_traefik_gzip_enabled: false
+
+# Jellyfin-compatible endpoint router/service labels (only rendered when silo_role_jf_enabled is true)
+silo_role_jf_docker_labels_template:
+  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.entrypoints": "{{ traefik_entrypoint_web }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.service": "{{ silo_name }}-jf" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.rule": "Host(`{{ lookup("role_var", "_jf_host", role="silo") }}`)" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.middlewares": "{{ traefik_default_middleware_http }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.priority": "20" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.entrypoints": "{{ traefik_entrypoint_websecure }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.service": "{{ silo_name }}-jf" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.rule": "Host(`{{ lookup("role_var", "_jf_host", role="silo") }}`)" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.tls.options": "securetls@file" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.tls.certresolver": "{{ lookup("role_var", "_traefik_certresolver", role="silo") }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.middlewares": "{{ lookup("role_var", "_traefik_middleware_default", role="silo") }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.priority": "20" }'
+  - '{ "traefik.http.services.{{ silo_name }}-jf.loadbalancer.server.port": "{{ lookup("role_var", "_jf_web_port", role="silo") }}" }'
+
+silo_role_jf_docker_labels: "{{ (silo_role_jf_docker_labels_template | map('from_json') | combine)
+                              if (lookup('role_var', '_jf_enabled', role='silo') | bool)
+                              else {} }}"
+
+# Audiobookshelf-compatible endpoint router/service labels (only rendered when silo_role_abs_enabled is true)
+silo_role_abs_docker_labels_template:
+  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.entrypoints": "{{ traefik_entrypoint_web }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.service": "{{ silo_name }}-abs" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.rule": "Host(`{{ lookup("role_var", "_abs_host", role="silo") }}`)" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.middlewares": "{{ traefik_default_middleware_http }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.priority": "20" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.entrypoints": "{{ traefik_entrypoint_websecure }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.service": "{{ silo_name }}-abs" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.rule": "Host(`{{ lookup("role_var", "_abs_host", role="silo") }}`)" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.tls.options": "securetls@file" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.tls.certresolver": "{{ lookup("role_var", "_traefik_certresolver", role="silo") }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.middlewares": "{{ lookup("role_var", "_traefik_middleware_default", role="silo") }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.priority": "20" }'
+  - '{ "traefik.http.services.{{ silo_name }}-abs.loadbalancer.server.port": "{{ lookup("role_var", "_abs_web_port", role="silo") }}" }'
+
+silo_role_abs_docker_labels: "{{ (silo_role_abs_docker_labels_template | map('from_json') | combine)
+                               if (lookup('role_var', '_abs_enabled', role='silo') | bool)
+                               else {} }}"
+
+silo_role_docker_labels_custom: {}
+silo_role_docker_labels: "{{ silo_role_jf_docker_labels
+                             | combine(silo_role_abs_docker_labels)
+                             | combine(lookup('role_var', '_docker_labels_custom', role='silo')) }}"
 
 ################################
 # Docker

--- a/roles/silo/defaults/main.yml
+++ b/roles/silo/defaults/main.yml
@@ -143,8 +143,8 @@ silo_role_jf_docker_labels_template:
   - '{ "traefik.http.services.{{ silo_name }}-jf.loadbalancer.server.port": "{{ lookup("role_var", "_jf_web_port", role="silo") }}" }'
 
 silo_role_jf_docker_labels: "{{ (silo_role_jf_docker_labels_template | map('from_json') | combine)
-                                if (lookup('role_var', '_jf_enabled', role='silo') | bool)
-                                else {} }}"
+                             if (lookup('role_var', '_jf_enabled', role='silo') | bool)
+                             else {} }}"
 
 # Audiobookshelf-compatible endpoint router/service labels (only rendered when silo_role_abs_enabled is true)
 silo_role_abs_docker_labels_template:
@@ -163,8 +163,8 @@ silo_role_abs_docker_labels_template:
   - '{ "traefik.http.services.{{ silo_name }}-abs.loadbalancer.server.port": "{{ lookup("role_var", "_abs_web_port", role="silo") }}" }'
 
 silo_role_abs_docker_labels: "{{ (silo_role_abs_docker_labels_template | map('from_json') | combine)
-                                  if (lookup('role_var', '_abs_enabled', role='silo') | bool)
-                                  else {} }}"
+                              if (lookup('role_var', '_abs_enabled', role='silo') | bool)
+                              else {} }}"
 
 silo_role_docker_labels_custom: {}
 silo_role_docker_labels: "{{ lookup('role_var', '_jf_docker_labels', role='silo')

--- a/roles/silo/defaults/main.yml
+++ b/roles/silo/defaults/main.yml
@@ -1,5 +1,5 @@
 ##########################################################################
-# Title:            Sandbox: Silo | Default Variables                   #
+# Title:            Sandbox: Silo | Default Variables                    #
 # Author(s):        After-Shock                                          #
 # URL:              https://github.com/saltyorg/Sandbox                  #
 # --                                                                     #
@@ -12,6 +12,15 @@
 ################################
 
 silo_name: silo
+
+################################
+# Settings
+################################
+
+# Toggle Jellyfin-compatible endpoint
+silo_role_jf_enabled: false
+# Toggle Audiobookshelf-compatible endpoint
+silo_role_abs_enabled: false
 
 ################################
 # Postgres
@@ -71,31 +80,21 @@ silo_role_web_url: "{{ 'https://' + (lookup('role_var', '_web_subdomain', role='
                     if (lookup('role_var', '_web_subdomain', role='silo') | length > 0)
                     else lookup('role_var', '_web_domain', role='silo')) }}"
 
-################################
-# Jellyfin-compatible endpoint
-################################
+silo_role_web_jf_subdomain: "{{ silo_name }}jf"
+silo_role_web_jf_domain: "{{ user.domain }}"
+silo_role_web_jf_port: "8096"
+silo_role_web_jf_host: "{{ (lookup('role_var', '_web_jf_subdomain', role='silo') + '.' + lookup('role_var', '_web_jf_domain', role='silo'))
+                        if (lookup('role_var', '_web_jf_subdomain', role='silo') | length > 0)
+                        else lookup('role_var', '_web_jf_domain', role='silo') }}"
+silo_role_web_jf_url: "https://{{ lookup('role_var', '_web_jf_host', role='silo') }}"
 
-silo_role_jf_enabled: false
-silo_role_jf_web_subdomain: "{{ silo_name }}jf"
-silo_role_jf_web_domain: "{{ user.domain }}"
-silo_role_jf_web_port: "8096"
-silo_role_jf_host: "{{ (lookup('role_var', '_jf_web_subdomain', role='silo') + '.' + lookup('role_var', '_jf_web_domain', role='silo'))
-                    if (lookup('role_var', '_jf_web_subdomain', role='silo') | length > 0)
-                    else lookup('role_var', '_jf_web_domain', role='silo') }}"
-silo_role_jf_url: "https://{{ lookup('role_var', '_jf_host', role='silo') }}"
-
-################################
-# Audiobookshelf-compatible endpoint
-################################
-
-silo_role_abs_enabled: false
-silo_role_abs_web_subdomain: "{{ silo_name }}abs"
-silo_role_abs_web_domain: "{{ user.domain }}"
-silo_role_abs_web_port: "13378"
-silo_role_abs_host: "{{ (lookup('role_var', '_abs_web_subdomain', role='silo') + '.' + lookup('role_var', '_abs_web_domain', role='silo'))
-                     if (lookup('role_var', '_abs_web_subdomain', role='silo') | length > 0)
-                     else lookup('role_var', '_abs_web_domain', role='silo') }}"
-silo_role_abs_url: "https://{{ lookup('role_var', '_abs_host', role='silo') }}"
+silo_role_web_abs_subdomain: "{{ silo_name }}abs"
+silo_role_web_abs_domain: "{{ user.domain }}"
+silo_role_web_abs_port: "13378"
+silo_role_web_abs_host: "{{ (lookup('role_var', '_web_abs_subdomain', role='silo') + '.' + lookup('role_var', '_web_abs_domain', role='silo'))
+                         if (lookup('role_var', '_web_abs_subdomain', role='silo') | length > 0)
+                         else lookup('role_var', '_web_abs_domain', role='silo') }}"
+silo_role_web_abs_url: "https://{{ lookup('role_var', '_web_abs_host', role='silo') }}"
 
 ################################
 # DNS
@@ -105,12 +104,12 @@ silo_role_dns_record: "{{ lookup('role_var', '_web_subdomain', role='silo') }}"
 silo_role_dns_zone: "{{ lookup('role_var', '_web_domain', role='silo') }}"
 silo_role_dns_proxy: "{{ dns_proxied }}"
 
-silo_role_jf_dns_record: "{{ lookup('role_var', '_jf_web_subdomain', role='silo') }}"
-silo_role_jf_dns_zone: "{{ lookup('role_var', '_jf_web_domain', role='silo') }}"
+silo_role_jf_dns_record: "{{ lookup('role_var', '_web_jf_subdomain', role='silo') }}"
+silo_role_jf_dns_zone: "{{ lookup('role_var', '_web_jf_domain', role='silo') }}"
 silo_role_jf_dns_proxy: "{{ lookup('role_var', '_dns_proxy', role='silo') }}"
 
-silo_role_abs_dns_record: "{{ lookup('role_var', '_abs_web_subdomain', role='silo') }}"
-silo_role_abs_dns_zone: "{{ lookup('role_var', '_abs_web_domain', role='silo') }}"
+silo_role_abs_dns_record: "{{ lookup('role_var', '_web_abs_subdomain', role='silo') }}"
+silo_role_abs_dns_zone: "{{ lookup('role_var', '_web_abs_domain', role='silo') }}"
 silo_role_abs_dns_proxy: "{{ lookup('role_var', '_dns_proxy', role='silo') }}"
 
 ################################
@@ -125,51 +124,6 @@ silo_role_traefik_enabled: true
 silo_role_traefik_api_enabled: false
 silo_role_traefik_api_endpoint: ""
 silo_role_traefik_gzip_enabled: false
-
-# Jellyfin-compatible endpoint router/service labels (only rendered when silo_role_jf_enabled is true)
-silo_role_jf_docker_labels_template:
-  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.entrypoints": "{{ traefik_entrypoint_web }}" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.service": "{{ silo_name }}-jf" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.rule": "Host(`{{ lookup("role_var", "_jf_host", role="silo") }}`)" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.middlewares": "{{ traefik_default_middleware_http }}" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.priority": "20" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-jf.entrypoints": "{{ traefik_entrypoint_websecure }}" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-jf.service": "{{ silo_name }}-jf" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-jf.rule": "Host(`{{ lookup("role_var", "_jf_host", role="silo") }}`)" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-jf.tls.options": "securetls@file" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-jf.tls.certresolver": "{{ lookup("role_var", "_traefik_certresolver", role="silo") }}" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-jf.middlewares": "{{ lookup("role_var", "_traefik_middleware_default", role="silo") }}" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-jf.priority": "20" }'
-  - '{ "traefik.http.services.{{ silo_name }}-jf.loadbalancer.server.port": "{{ lookup("role_var", "_jf_web_port", role="silo") }}" }'
-
-silo_role_jf_docker_labels: "{{ (silo_role_jf_docker_labels_template | map('from_json') | combine)
-                             if (lookup('role_var', '_jf_enabled', role='silo') | bool)
-                             else {} }}"
-
-# Audiobookshelf-compatible endpoint router/service labels (only rendered when silo_role_abs_enabled is true)
-silo_role_abs_docker_labels_template:
-  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.entrypoints": "{{ traefik_entrypoint_web }}" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.service": "{{ silo_name }}-abs" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.rule": "Host(`{{ lookup("role_var", "_abs_host", role="silo") }}`)" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.middlewares": "{{ traefik_default_middleware_http }}" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.priority": "20" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-abs.entrypoints": "{{ traefik_entrypoint_websecure }}" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-abs.service": "{{ silo_name }}-abs" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-abs.rule": "Host(`{{ lookup("role_var", "_abs_host", role="silo") }}`)" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-abs.tls.options": "securetls@file" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-abs.tls.certresolver": "{{ lookup("role_var", "_traefik_certresolver", role="silo") }}" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-abs.middlewares": "{{ lookup("role_var", "_traefik_middleware_default", role="silo") }}" }'
-  - '{ "traefik.http.routers.{{ silo_name }}-abs.priority": "20" }'
-  - '{ "traefik.http.services.{{ silo_name }}-abs.loadbalancer.server.port": "{{ lookup("role_var", "_abs_web_port", role="silo") }}" }'
-
-silo_role_abs_docker_labels: "{{ (silo_role_abs_docker_labels_template | map('from_json') | combine)
-                              if (lookup('role_var', '_abs_enabled', role='silo') | bool)
-                              else {} }}"
-
-silo_role_docker_labels_custom: {}
-silo_role_docker_labels: "{{ lookup('role_var', '_jf_docker_labels', role='silo')
-                             | combine(lookup('role_var', '_abs_docker_labels', role='silo'))
-                             | combine(lookup('role_var', '_docker_labels_custom', role='silo')) }}"
 
 ################################
 # Docker
@@ -214,6 +168,50 @@ silo_role_docker_volumes_default:
 silo_role_docker_volumes_custom: []
 silo_role_docker_volumes: "{{ lookup('role_var', '_docker_volumes_default', role='silo')
                               + lookup('role_var', '_docker_volumes_custom', role='silo') }}"
+
+# Labels
+silo_role_docker_labels_jf_template:
+  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.entrypoints": "{{ traefik_entrypoint_web }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.service": "{{ silo_name }}-jf" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.rule": "Host(`{{ lookup("role_var", "_web_jf_host", role="silo") }}`)" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.middlewares": "{{ traefik_default_middleware_http }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf-http.priority": "20" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.entrypoints": "{{ traefik_entrypoint_websecure }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.service": "{{ silo_name }}-jf" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.rule": "Host(`{{ lookup("role_var", "_web_jf_host", role="silo") }}`)" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.tls.options": "securetls@file" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.tls.certresolver": "{{ lookup("role_var", "_traefik_certresolver", role="silo") }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.middlewares": "{{ lookup("role_var", "_traefik_middleware_default", role="silo") }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-jf.priority": "20" }'
+  - '{ "traefik.http.services.{{ silo_name }}-jf.loadbalancer.server.port": "{{ lookup("role_var", "_web_jf_port", role="silo") }}" }'
+
+silo_role_docker_labels_jf: "{{ (silo_role_docker_labels_jf_template | map('from_json') | combine)
+                             if (lookup('role_var', '_jf_enabled', role='silo') | bool)
+                             else {} }}"
+
+silo_role_docker_labels_abs_template:
+  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.entrypoints": "{{ traefik_entrypoint_web }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.service": "{{ silo_name }}-abs" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.rule": "Host(`{{ lookup("role_var", "_web_abs_host", role="silo") }}`)" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.middlewares": "{{ traefik_default_middleware_http }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs-http.priority": "20" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.entrypoints": "{{ traefik_entrypoint_websecure }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.service": "{{ silo_name }}-abs" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.rule": "Host(`{{ lookup("role_var", "_web_abs_host", role="silo") }}`)" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.tls.options": "securetls@file" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.tls.certresolver": "{{ lookup("role_var", "_traefik_certresolver", role="silo") }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.middlewares": "{{ lookup("role_var", "_traefik_middleware_default", role="silo") }}" }'
+  - '{ "traefik.http.routers.{{ silo_name }}-abs.priority": "20" }'
+  - '{ "traefik.http.services.{{ silo_name }}-abs.loadbalancer.server.port": "{{ lookup("role_var", "_web_abs_port", role="silo") }}" }'
+
+silo_role_docker_labels_abs: "{{ (silo_role_docker_labels_abs_template | map('from_json') | combine)
+                              if (lookup('role_var', '_abs_enabled', role='silo') | bool)
+                              else {} }}"
+
+silo_role_docker_labels_custom: {}
+silo_role_docker_labels: "{{ lookup('role_var', '_docker_labels_jf', role='silo')
+                             | combine(lookup('role_var', '_docker_labels_abs', role='silo'))
+                             | combine(lookup('role_var', '_docker_labels_custom', role='silo')) }}"
 
 # Hostname
 silo_role_docker_hostname: "{{ silo_name }}"

--- a/roles/silo/tasks/main.yml
+++ b/roles/silo/tasks/main.yml
@@ -50,6 +50,22 @@
     dns_zone: "{{ lookup('role_var', '_dns_zone', role='silo') }}"
     dns_proxy: "{{ lookup('role_var', '_dns_proxy', role='silo') }}"
 
+- name: Add DNS record (Jellyfin-compatible endpoint)
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('role_var', '_jf_dns_record', role='silo') }}"
+    dns_zone: "{{ lookup('role_var', '_jf_dns_zone', role='silo') }}"
+    dns_proxy: "{{ lookup('role_var', '_jf_dns_proxy', role='silo') }}"
+  when: lookup('role_var', '_jf_enabled', role='silo') | bool
+
+- name: Add DNS record (Audiobookshelf-compatible endpoint)
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('role_var', '_abs_dns_record', role='silo') }}"
+    dns_zone: "{{ lookup('role_var', '_abs_dns_zone', role='silo') }}"
+    dns_proxy: "{{ lookup('role_var', '_abs_dns_proxy', role='silo') }}"
+  when: lookup('role_var', '_abs_enabled', role='silo') | bool
+
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 

--- a/roles/silo/tasks/main.yml
+++ b/roles/silo/tasks/main.yml
@@ -78,3 +78,4 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+  

--- a/roles/silo/tasks/main.yml
+++ b/roles/silo/tasks/main.yml
@@ -78,4 +78,3 @@
 
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
-  


### PR DESCRIPTION
# Description

Add `jf_enabled` and `abs_enabled` toggles that expose Silo's Jellyfin-compatible and Audiobookshelf-compatible listeners through their own DNS records and Traefik routers, alongside the existing main web service.

Both endpoints are disabled by default. When enabled, each gets its own subdomain, DNS record, and http/https router pair with the standard Saltbox middleware and certresolver.

No dependencies beyond what the silo role already uses.

# How Has This Been Tested?

Enabled both `silo_role_jf_enabled: true` and `silo_role_abs_enabled: true` in host_vars and ran `sb sandbox install silo`.

- Both DNS records were created correctly via Cloudflare.
- Container came up with the jf/abs Traefik routers and labels applied, alongside the existing main router.
- Confirmed both toggles default to `false` and produce no DNS records or extra labels when left unset, so existing installs are unaffected.