### PR TITLE
feat(role): add QuickLinks

### DIFF
--- a/roles/quicklinks/defaults/main.yml
+++ b/roles/quicklinks/defaults/main.yml
@@ -1,0 +1,103 @@
+#########################################################################
+# Title:            Sandbox: QuickLinks                                 #
+# Author(s):        Jordan Farmer                                       #
+# URL:              https://hub.docker.com/r/jordanmfarmer/quicklinks   #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+
+quicklinks_name: quicklinks
+
+################################
+# Paths
+################################
+
+quicklinks_role_paths_folder: "{{ quicklinks_name }}"
+quicklinks_role_paths_location: "{{ server_appdata_path }}/{{ quicklinks_role_paths_folder }}"
+quicklinks_role_paths_folders_list:
+  - "{{ quicklinks_role_paths_location }}"
+
+################################
+# Web
+################################
+
+quicklinks_role_web_subdomain: "{{ quicklinks_name }}"
+quicklinks_role_web_domain: "{{ user.domain }}"
+quicklinks_role_web_port: "6969"
+quicklinks_role_web_url: "https://{{ lookup('role_var', '_web_subdomain', role='quicklinks') + '.' + lookup('role_var', '_web_domain', role='quicklinks')
+                                  if (lookup('role_var', '_web_subdomain', role='quicklinks') | length > 0)
+                                  else lookup('role_var', '_web_domain', role='quicklinks') }}"
+
+################################
+# DNS
+################################
+
+quicklinks_role_dns_record: "{{ lookup('role_var', '_web_subdomain', role='quicklinks') }}"
+quicklinks_role_dns_zone: "{{ lookup('role_var', '_web_domain', role='quicklinks') }}"
+quicklinks_role_dns_proxy: "{{ dns_proxied }}"
+
+################################
+# Traefik
+################################
+
+quicklinks_role_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+quicklinks_role_traefik_middleware_default: "{{ traefik_default_middleware }}"
+quicklinks_role_traefik_middleware_custom: ""
+quicklinks_role_traefik_certresolver: "{{ traefik_default_certresolver }}"
+quicklinks_role_traefik_enabled: true
+quicklinks_role_traefik_api_enabled: false
+quicklinks_role_traefik_api_endpoint: ""
+
+################################
+# Docker
+################################
+
+# Container
+quicklinks_role_docker_container: "{{ quicklinks_name }}"
+
+# Image
+quicklinks_role_docker_image_pull: true
+quicklinks_role_docker_image_repo: "jordanmfarmer/quicklinks"
+quicklinks_role_docker_image_tag: "2026.08.09.002"
+quicklinks_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='quicklinks') }}:{{ lookup('role_var', '_docker_image_tag', role='quicklinks') }}"
+
+# Envs
+quicklinks_role_docker_envs_default:
+  TZ: "{{ tz }}"
+  DATA_DIR: "/app/data"
+  ADMIN_USERNAME: "{{ user.name }}"
+  ADMIN_PASSWORD: "{{ user.pass }}"
+  SESSION_SECRET: "{{ user.pass | hash('sha256') }}"
+quicklinks_role_docker_envs_custom: {}
+quicklinks_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='quicklinks')
+                                 | combine(lookup('role_var', '_docker_envs_custom', role='quicklinks')) }}"
+
+# Volumes
+quicklinks_role_docker_volumes_default:
+  - "{{ lookup('role_var', '_paths_location', role='quicklinks') }}:/app/data"
+  - "/etc/localtime:/etc/localtime:ro"
+quicklinks_role_docker_volumes_custom: []
+quicklinks_role_docker_volumes: "{{ lookup('role_var', '_docker_volumes_default', role='quicklinks')
+                                    + lookup('role_var', '_docker_volumes_custom', role='quicklinks') }}"
+
+# Hostname
+quicklinks_role_docker_hostname: "{{ quicklinks_name }}"
+
+# Networks
+quicklinks_role_docker_networks_alias: "{{ quicklinks_name }}"
+quicklinks_role_docker_networks_default: []
+quicklinks_role_docker_networks_custom: []
+quicklinks_role_docker_networks: "{{ docker_networks_common
+                                     + lookup('role_var', '_docker_networks_default', role='quicklinks')
+                                     + lookup('role_var', '_docker_networks_custom', role='quicklinks') }}"
+
+# Restart Policy
+quicklinks_role_docker_restart_policy: unless-stopped
+
+# User
+quicklinks_role_docker_user: "{{ uid }}:{{ gid }}"

--- a/roles/quicklinks/tasks/main.yml
+++ b/roles/quicklinks/tasks/main.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:            Sandbox: QuickLinks                                 #
+# Author(s):        Jordan Farmer                                       #
+# URL:              https://hub.docker.com/r/jordanmfarmer/quicklinks   #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('role_var', '_dns_record') }}"
+    dns_zone: "{{ lookup('role_var', '_dns_zone') }}"
+    dns_proxy: "{{ lookup('role_var', '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -133,6 +133,7 @@
     - { role: qbit_manage, tags: ['qbit-manage'] }
     - { role: qbittorrentvpn, tags: ['qbittorrentvpn'] }
     - { role: qui, tags: ['qui'] }
+    - { role: quicklinks, tags: ['quicklinks'] }
     - { role: recyclarr, tags: ['recyclarr'] }
     - { role: reposilite, tags: ['reposilite'] }
     - { role: requestrr, tags: ['requestrr'] }


### PR DESCRIPTION
# Description

For new roles please include:

- [x] Official full name of the app: QuickLinks
- [x] Summary of what the app is:

    > A self-hosted link portal with local administration, CSV import/export, customizable branding, and optional Active Directory authentication.

- [x] Link to Docker Compose sample: No separate public Compose sample is currently published; the container contract is represented by this role and the [Docker Hub image](https://hub.docker.com/r/jordanmfarmer/quicklinks).
- [x] Link to homepage: [QuickLinks on Docker Hub](https://hub.docker.com/r/jordanmfarmer/quicklinks)
- [x] Link to releases page: [QuickLinks image tags](https://hub.docker.com/r/jordanmfarmer/quicklinks/tags)
- [x] Link to documentation: [QuickLinks Docker Hub overview](https://hub.docker.com/r/jordanmfarmer/quicklinks)
- [x] Link to primary community space: No separate public community space is currently maintained; support is handled by the image publisher.
- [ ] This role does not require Saltbox-specific configuration instructions (the upstream documentation is sufficient)

It would be greatly appreciated if you create a sandbox documentation page yourself and do a PR into the [docs repo](https://github.com/saltyorg/docs). You, as the person creating the role, have presumably used the thing and are presumably familiar with any setup steps required. Anyone else here would need to research that.

- [x] I will create documentation after the role is merged.

## Role behavior

- installs with `sb install sandbox-quicklinks`
- deploys `jordanmfarmer/quicklinks:2026.08.09.002`
- exposes the application through Traefik at `https://quicklinks.<user.domain>`
- uses the standard Saltbox DNS and default SSO middleware configuration
- persists application data under `<server_appdata_path>/quicklinks`
- seeds the initial administrator from Saltbox `user.name` and `user.pass`

# How Has This Been Tested?

- [x] Ran `ansible-playbook /opt/sandbox/sandbox.yml --syntax-check` successfully.
- [x] Installed the role on Ubuntu Server 22.04 with `sb install sandbox-quicklinks` (`failed=0`).
- [x] Verified the QuickLinks container reports healthy on the Saltbox Docker network.
- [x] Verified an HTTP 200 response from the application on container port 6969.
- [x] Verified public HTTPS routing through Traefik and the configured Saltbox SSO middleware.
- [x] Verified persistent SQLite application data under `/opt/quicklinks`.
- [x] Verified initial authentication uses the Saltbox inventory username and password.
- [x] Verified the published image supports the Saltbox inventory password's seven-character minimum.

The pull-request CI will additionally run the repository's ansible-lint, defaults-lint, missing-entry, and role-installation checks.
