### PR TITLE
Recyclarr - Docker image tag from 'latest' to '8'

### DIFF
--- a/roles/recyclarr/defaults/main.yml
+++ b/roles/recyclarr/defaults/main.yml
@@ -38,7 +38,7 @@ recyclarr_role_docker_container: "{{ recyclarr_name }}"
 # Image
 recyclarr_role_docker_image_pull: true
 recyclarr_role_docker_image_repo: "ghcr.io/recyclarr/recyclarr"
-recyclarr_role_docker_image_tag: "latest"
+recyclarr_role_docker_image_tag: "8"
 recyclarr_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='recyclarr') }}:{{ lookup('role_var', '_docker_image_tag', role='recyclarr') }}"
 
 # Envs


### PR DESCRIPTION
Fix for this bug: https://github.com/saltyorg/Sandbox/issues/552

# How Has This Been Tested?

Tested by using:

recyclarr_role_docker_image_repo: "ghcr.io/recyclarr/recyclarr"
recyclarr_role_docker_image_tag: "8"

Works fine.
