### PR TITLE
feat(calibre_web_nextgen): add Calibre-Web-NextGen role

### DIFF
--- a/roles/calibre_web_nextgen/defaults/main.yml
+++ b/roles/calibre_web_nextgen/defaults/main.yml
@@ -25,28 +25,22 @@ calibre_web_nextgen_role_media_subfolder: "Books"
 # Will be placed in the downloads root: usually /mnt/unionfs/downloads/
 calibre_web_nextgen_role_ingest_subfolder: "ingest"
 
-# Hardcover.app API token, used for the Hardcover metadata provider.
-# Get one at https://docs.hardcover.app/api/getting-started/
+# Hardcover.app API token for the Hardcover metadata provider
 calibre_web_nextgen_role_hardcover_token: ""
 
-# Disables WAL mode and switches file watching to polling, for library
-# locations on a network share (NFS/SMB) or another mount with weak file
-# locking. Accepts: true/false
-calibre_web_nextgen_role_network_share_mode: false
-
-# Number of reverse proxies in front of this app, for correct client IP
-# detection (rate limiting, session protection). Accepts: an integer
-calibre_web_nextgen_role_trusted_proxy_count: 1
-
-# ComicVine API key, used for the ComicVine metadata provider. Optional -
-# ComicVine works without one on a shared key, which can hit the rate limit.
-# Get one at https://comicvine.gamespot.com/api/
+# ComicVine API key for the ComicVine metadata provider
 calibre_web_nextgen_role_comicvine_api_key: ""
 
-# Loads user-supplied Calibre plugins (e.g. DeDRM, ACSM Input) from the
-# config volume at startup. Off by default because it runs third-party
-# plugin code inside the container. Accepts: true/false
+# Toggle network share mode, for libraries on NFS/SMB mounts
+# Accepts: true/false
+calibre_web_nextgen_role_network_share_mode: false
+
+# Toggle loading of user-supplied Calibre plugins from the config volume
+# Accepts: true/false
 calibre_web_nextgen_role_calibre_user_plugins: false
+
+# Number of reverse proxies in front of the app
+calibre_web_nextgen_role_trusted_proxy_count: 1
 
 ################################
 # Paths
@@ -90,10 +84,6 @@ calibre_web_nextgen_role_traefik_middleware_custom: ""
 calibre_web_nextgen_role_traefik_certresolver: "{{ traefik_default_certresolver }}"
 calibre_web_nextgen_role_traefik_enabled: true
 calibre_web_nextgen_role_traefik_api_enabled: true
-# Device/API sync endpoints, exempted from SSO: OPDS readers, Kobo e-readers
-# and KOReader can't complete an interactive Authelia login. They authenticate
-# to the app itself (basic auth / per-user sync token), so the UI stays behind
-# SSO while these keep working.
 calibre_web_nextgen_role_traefik_api_endpoint: "PathPrefix(`/opds`) || PathPrefix(`/kobo`) || PathPrefix(`/kobo_auth`)
                                                 || PathPrefix(`/api/v3`) || PathPrefix(`/api/UserStorage`) || PathPrefix(`/kosync`)"
 calibre_web_nextgen_role_traefik_api_middleware: "{{ traefik_default_middleware_api }},calibre-web-nextgen-kobo-sync-headers"
@@ -116,11 +106,15 @@ calibre_web_nextgen_role_docker_envs_default:
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
   TZ: "{{ tz }}"
-  HARDCOVER_TOKEN: "{{ lookup('role_var', '_hardcover_token', role='calibre_web_nextgen') }}"
   NETWORK_SHARE_MODE: "{{ lookup('role_var', '_network_share_mode', role='calibre_web_nextgen') | string | lower }}"
   TRUSTED_PROXY_COUNT: "{{ lookup('role_var', '_trusted_proxy_count', role='calibre_web_nextgen') }}"
-  COMICVINE_API_KEY: "{{ lookup('role_var', '_comicvine_api_key', role='calibre_web_nextgen') }}"
   CWA_CALIBRE_USER_PLUGINS: "{{ lookup('role_var', '_calibre_user_plugins', role='calibre_web_nextgen') | string | lower }}"
+  HARDCOVER_TOKEN: "{{ lookup('role_var', '_hardcover_token', role='calibre_web_nextgen')
+                    if (lookup('role_var', '_hardcover_token', role='calibre_web_nextgen') | length > 0)
+                    else omit }}"
+  COMICVINE_API_KEY: "{{ lookup('role_var', '_comicvine_api_key', role='calibre_web_nextgen')
+                      if (lookup('role_var', '_comicvine_api_key', role='calibre_web_nextgen') | length > 0)
+                      else omit }}"
 calibre_web_nextgen_role_docker_envs_custom: {}
 calibre_web_nextgen_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='calibre_web_nextgen')
                                           | combine(lookup('role_var', '_docker_envs_custom', role='calibre_web_nextgen')) }}"

--- a/roles/calibre_web_nextgen/defaults/main.yml
+++ b/roles/calibre_web_nextgen/defaults/main.yml
@@ -1,5 +1,5 @@
 #########################################################################
-# Title:            Sandbox: Calibre-Web-NextGen | Default Variables   #
+# Title:            Sandbox: Calibre-Web-NextGen | Default Variables    #
 # Author(s):        balogan                                             #
 # URL:              https://github.com/saltyorg/Sandbox                 #
 # --                                                                    #

--- a/roles/calibre_web_nextgen/defaults/main.yml
+++ b/roles/calibre_web_nextgen/defaults/main.yml
@@ -1,0 +1,151 @@
+#########################################################################
+# Title:            Sandbox: Calibre-Web-NextGen | Default Variables   #
+# Author(s):        balogan                                             #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+################################
+# Basics
+################################
+
+calibre_web_nextgen_name: calibre-web-nextgen
+
+################################
+# Settings
+################################
+
+# Name of a subdirectory to be created in /mnt/unionfs/Media/
+# Opt out with a falsy value (e.g. "")
+calibre_web_nextgen_role_media_subfolder: "Books"
+
+# Name of the ingest ("drop zone") subdirectory - files placed here are
+# auto-converted, repaired, metadata-matched, and imported, then deleted.
+# Lives under the role's own appdata folder (not the downloads root) since
+# it's meant to be fed directly by this app and by companion apps such as
+# Shelfmark, not by a download client.
+calibre_web_nextgen_role_ingest_subfolder: "ingest"
+
+################################
+# A note on metadata.db and cloudplow
+################################
+#
+# calibre-web-nextgen keeps its library database, metadata.db, inside the
+# library folder itself, alongside the books - and writes to it in place,
+# which makes SQLite create metadata.db-wal / metadata.db-shm sidecar files
+# next to it the first time it's opened read/write. If your media library
+# sits on a cloud-tiered mount managed by cloudplow, its default excludes
+# only ever cover "*.db" itself, never these sidecars - so cloudplow's
+# periodic upload sweep can strand them on the cloud remote and every
+# subsequent write to the library will fail with "disk I/O error". If that
+# applies to you, add "*.db-wal", "*.db-shm", and "*.db-journal" to the
+# relevant remote's rclone_excludes in cloudplow's config. Note this edit
+# doesn't survive a cloudplow reinstall - Saltbox core generates cloudplow's
+# config from a template with the exclude list hardcoded, with no
+# settings-file variable exposed to extend it.
+#
+# (A local-only bind mount for metadata.db was investigated as a way to make
+# this role immune to the above regardless of cloudplow's config - it isn't
+# used here. calibre-web-nextgen's own locking model, and the fact that book
+# ingest shells out to the actual `calibredb` binary rather than writing
+# through this app's own code, both assume metadata.db lives at one single,
+# directly-accessible path. Splitting that path across a bind-mount shadow
+# fought those assumptions in ways that showed up as real, hard-to-predict
+# failures in testing, so it isn't worth it here - the cloudplow-level fix
+# above is the actual answer.)
+
+################################
+# Paths
+################################
+
+calibre_web_nextgen_role_paths_folder: "{{ calibre_web_nextgen_name }}"
+calibre_web_nextgen_role_paths_location: "{{ server_appdata_path }}/{{ calibre_web_nextgen_role_paths_folder }}"
+calibre_web_nextgen_role_paths_media_location: "/mnt/unionfs/Media/{{ calibre_web_nextgen_role_media_subfolder }}"
+calibre_web_nextgen_role_paths_ingest_location: "{{ calibre_web_nextgen_role_paths_location }}/{{ calibre_web_nextgen_role_ingest_subfolder }}"
+calibre_web_nextgen_role_paths_folders_list:
+  - "{{ calibre_web_nextgen_role_paths_location }}/config"
+  - "{{ calibre_web_nextgen_role_paths_ingest_location }}"
+
+################################
+# Web
+################################
+
+calibre_web_nextgen_role_web_subdomain: "{{ calibre_web_nextgen_name }}"
+calibre_web_nextgen_role_web_domain: "{{ user.domain }}"
+calibre_web_nextgen_role_web_port: "8083"
+calibre_web_nextgen_role_web_url: "https://{{ lookup('role_var', '_web_subdomain', role='calibre_web_nextgen') + '.' + lookup('role_var', '_web_domain', role='calibre_web_nextgen')
+                                           if (lookup('role_var', '_web_subdomain', role='calibre_web_nextgen') | length > 0)
+                                           else lookup('role_var', '_web_domain', role='calibre_web_nextgen') }}"
+
+################################
+# DNS
+################################
+
+calibre_web_nextgen_role_dns_record: "{{ lookup('role_var', '_web_subdomain', role='calibre_web_nextgen') }}"
+calibre_web_nextgen_role_dns_zone: "{{ lookup('role_var', '_web_domain', role='calibre_web_nextgen') }}"
+calibre_web_nextgen_role_dns_proxy: "{{ dns_proxied }}"
+
+################################
+# Traefik
+################################
+
+calibre_web_nextgen_role_traefik_sso_middleware: ""
+calibre_web_nextgen_role_traefik_middleware_default: "{{ traefik_default_middleware }},calibre-web-nextgen-kobo-sync-headers"
+calibre_web_nextgen_role_traefik_middleware_custom: ""
+calibre_web_nextgen_role_traefik_certresolver: "{{ traefik_default_certresolver }}"
+calibre_web_nextgen_role_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+calibre_web_nextgen_role_docker_container: "{{ calibre_web_nextgen_name }}"
+
+# Image
+calibre_web_nextgen_role_docker_image_pull: true
+calibre_web_nextgen_role_docker_image_repo: "ghcr.io/new-usemame/calibre-web-nextgen"
+calibre_web_nextgen_role_docker_image_tag: "latest"
+calibre_web_nextgen_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='calibre_web_nextgen') }}:{{ lookup('role_var', '_docker_image_tag', role='calibre_web_nextgen') }}"
+
+# Envs
+calibre_web_nextgen_role_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+  NETWORK_SHARE_MODE: "false"
+calibre_web_nextgen_role_docker_envs_custom: {}
+calibre_web_nextgen_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='calibre_web_nextgen')
+                                          | combine(lookup('role_var', '_docker_envs_custom', role='calibre_web_nextgen')) }}"
+
+# Volumes
+calibre_web_nextgen_role_docker_volumes_default:
+  - "{{ lookup('role_var', '_paths_location', role='calibre_web_nextgen') }}/config:/config"
+  - "{{ lookup('role_var', '_paths_media_location', role='calibre_web_nextgen') }}:/calibre-library"
+  - "{{ lookup('role_var', '_paths_ingest_location', role='calibre_web_nextgen') }}:/cwa-book-ingest"
+calibre_web_nextgen_role_docker_volumes_custom: []
+calibre_web_nextgen_role_docker_volumes: "{{ lookup('role_var', '_docker_volumes_default', role='calibre_web_nextgen')
+                                             + lookup('role_var', '_docker_volumes_custom', role='calibre_web_nextgen') }}"
+
+# Labels
+calibre_web_nextgen_role_docker_labels_default:
+  traefik.http.middlewares.calibre-web-nextgen-kobo-sync-headers.headers.customrequestheaders.X-Scheme: "https"
+calibre_web_nextgen_role_docker_labels_custom: {}
+calibre_web_nextgen_role_docker_labels: "{{ lookup('role_var', '_docker_labels_default', role='calibre_web_nextgen')
+                                            | combine(lookup('role_var', '_docker_labels_custom', role='calibre_web_nextgen')) }}"
+
+# Hostname
+calibre_web_nextgen_role_docker_hostname: "{{ calibre_web_nextgen_name }}"
+
+# Networks
+calibre_web_nextgen_role_docker_networks_alias: "{{ calibre_web_nextgen_name }}"
+calibre_web_nextgen_role_docker_networks_default: []
+calibre_web_nextgen_role_docker_networks_custom: []
+calibre_web_nextgen_role_docker_networks: "{{ docker_networks_common
+                                              + lookup('role_var', '_docker_networks_default', role='calibre_web_nextgen')
+                                              + lookup('role_var', '_docker_networks_custom', role='calibre_web_nextgen') }}"
+
+# Restart Policy
+calibre_web_nextgen_role_docker_restart_policy: unless-stopped

--- a/roles/calibre_web_nextgen/defaults/main.yml
+++ b/roles/calibre_web_nextgen/defaults/main.yml
@@ -21,40 +21,32 @@ calibre_web_nextgen_name: calibre-web-nextgen
 # Opt out with a falsy value (e.g. "")
 calibre_web_nextgen_role_media_subfolder: "Books"
 
-# Name of the ingest ("drop zone") subdirectory - files placed here are
-# auto-converted, repaired, metadata-matched, and imported, then deleted.
-# Lives under the role's own appdata folder (not the downloads root) since
-# it's meant to be fed directly by this app and by companion apps such as
-# Shelfmark, not by a download client.
+# Name of the ingest ("drop zone") subdirectory
+# Will be placed in the downloads root: usually /mnt/unionfs/downloads/
 calibre_web_nextgen_role_ingest_subfolder: "ingest"
 
-################################
-# A note on metadata.db and cloudplow
-################################
-#
-# calibre-web-nextgen keeps its library database, metadata.db, inside the
-# library folder itself, alongside the books - and writes to it in place,
-# which makes SQLite create metadata.db-wal / metadata.db-shm sidecar files
-# next to it the first time it's opened read/write. If your media library
-# sits on a cloud-tiered mount managed by cloudplow, its default excludes
-# only ever cover "*.db" itself, never these sidecars - so cloudplow's
-# periodic upload sweep can strand them on the cloud remote and every
-# subsequent write to the library will fail with "disk I/O error". If that
-# applies to you, add "*.db-wal", "*.db-shm", and "*.db-journal" to the
-# relevant remote's rclone_excludes in cloudplow's config. Note this edit
-# doesn't survive a cloudplow reinstall - Saltbox core generates cloudplow's
-# config from a template with the exclude list hardcoded, with no
-# settings-file variable exposed to extend it.
-#
-# (A local-only bind mount for metadata.db was investigated as a way to make
-# this role immune to the above regardless of cloudplow's config - it isn't
-# used here. calibre-web-nextgen's own locking model, and the fact that book
-# ingest shells out to the actual `calibredb` binary rather than writing
-# through this app's own code, both assume metadata.db lives at one single,
-# directly-accessible path. Splitting that path across a bind-mount shadow
-# fought those assumptions in ways that showed up as real, hard-to-predict
-# failures in testing, so it isn't worth it here - the cloudplow-level fix
-# above is the actual answer.)
+# Hardcover.app API token, used for the Hardcover metadata provider.
+# Get one at https://docs.hardcover.app/api/getting-started/
+calibre_web_nextgen_role_hardcover_token: ""
+
+# Disables WAL mode and switches file watching to polling, for library
+# locations on a network share (NFS/SMB) or another mount with weak file
+# locking. Accepts: true/false
+calibre_web_nextgen_role_network_share_mode: false
+
+# Number of reverse proxies in front of this app, for correct client IP
+# detection (rate limiting, session protection). Accepts: an integer
+calibre_web_nextgen_role_trusted_proxy_count: 1
+
+# ComicVine API key, used for the ComicVine metadata provider. Optional -
+# ComicVine works without one on a shared key, which can hit the rate limit.
+# Get one at https://comicvine.gamespot.com/api/
+calibre_web_nextgen_role_comicvine_api_key: ""
+
+# Loads user-supplied Calibre plugins (e.g. DeDRM, ACSM Input) from the
+# config volume at startup. Off by default because it runs third-party
+# plugin code inside the container. Accepts: true/false
+calibre_web_nextgen_role_calibre_user_plugins: false
 
 ################################
 # Paths
@@ -63,9 +55,10 @@ calibre_web_nextgen_role_ingest_subfolder: "ingest"
 calibre_web_nextgen_role_paths_folder: "{{ calibre_web_nextgen_name }}"
 calibre_web_nextgen_role_paths_location: "{{ server_appdata_path }}/{{ calibre_web_nextgen_role_paths_folder }}"
 calibre_web_nextgen_role_paths_media_location: "/mnt/unionfs/Media/{{ calibre_web_nextgen_role_media_subfolder }}"
-calibre_web_nextgen_role_paths_ingest_location: "{{ calibre_web_nextgen_role_paths_location }}/{{ calibre_web_nextgen_role_ingest_subfolder }}"
+calibre_web_nextgen_role_paths_ingest_location: "{{ downloads_root_path }}/{{ calibre_web_nextgen_role_ingest_subfolder }}"
 calibre_web_nextgen_role_paths_folders_list:
-  - "{{ calibre_web_nextgen_role_paths_location }}/config"
+  - "{{ calibre_web_nextgen_role_paths_location }}"
+  - "{{ server_local_folder_path }}/Media/{{ calibre_web_nextgen_role_media_subfolder }}"
   - "{{ calibre_web_nextgen_role_paths_ingest_location }}"
 
 ################################
@@ -115,14 +108,18 @@ calibre_web_nextgen_role_docker_envs_default:
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
   TZ: "{{ tz }}"
-  NETWORK_SHARE_MODE: "false"
+  HARDCOVER_TOKEN: "{{ lookup('role_var', '_hardcover_token', role='calibre_web_nextgen') }}"
+  NETWORK_SHARE_MODE: "{{ lookup('role_var', '_network_share_mode', role='calibre_web_nextgen') | string | lower }}"
+  TRUSTED_PROXY_COUNT: "{{ lookup('role_var', '_trusted_proxy_count', role='calibre_web_nextgen') }}"
+  COMICVINE_API_KEY: "{{ lookup('role_var', '_comicvine_api_key', role='calibre_web_nextgen') }}"
+  CWA_CALIBRE_USER_PLUGINS: "{{ lookup('role_var', '_calibre_user_plugins', role='calibre_web_nextgen') | string | lower }}"
 calibre_web_nextgen_role_docker_envs_custom: {}
 calibre_web_nextgen_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='calibre_web_nextgen')
                                           | combine(lookup('role_var', '_docker_envs_custom', role='calibre_web_nextgen')) }}"
 
 # Volumes
 calibre_web_nextgen_role_docker_volumes_default:
-  - "{{ lookup('role_var', '_paths_location', role='calibre_web_nextgen') }}/config:/config"
+  - "{{ lookup('role_var', '_paths_location', role='calibre_web_nextgen') }}:/config"
   - "{{ lookup('role_var', '_paths_media_location', role='calibre_web_nextgen') }}:/calibre-library"
   - "{{ lookup('role_var', '_paths_ingest_location', role='calibre_web_nextgen') }}:/cwa-book-ingest"
 calibre_web_nextgen_role_docker_volumes_custom: []

--- a/roles/calibre_web_nextgen/defaults/main.yml
+++ b/roles/calibre_web_nextgen/defaults/main.yml
@@ -84,11 +84,19 @@ calibre_web_nextgen_role_dns_proxy: "{{ dns_proxied }}"
 # Traefik
 ################################
 
-calibre_web_nextgen_role_traefik_sso_middleware: ""
+calibre_web_nextgen_role_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
 calibre_web_nextgen_role_traefik_middleware_default: "{{ traefik_default_middleware }},calibre-web-nextgen-kobo-sync-headers"
 calibre_web_nextgen_role_traefik_middleware_custom: ""
 calibre_web_nextgen_role_traefik_certresolver: "{{ traefik_default_certresolver }}"
 calibre_web_nextgen_role_traefik_enabled: true
+calibre_web_nextgen_role_traefik_api_enabled: true
+# Device/API sync endpoints, exempted from SSO: OPDS readers, Kobo e-readers
+# and KOReader can't complete an interactive Authelia login. They authenticate
+# to the app itself (basic auth / per-user sync token), so the UI stays behind
+# SSO while these keep working.
+calibre_web_nextgen_role_traefik_api_endpoint: "PathPrefix(`/opds`) || PathPrefix(`/kobo`) || PathPrefix(`/kobo_auth`)
+                                                || PathPrefix(`/api/v3`) || PathPrefix(`/api/UserStorage`) || PathPrefix(`/kosync`)"
+calibre_web_nextgen_role_traefik_api_middleware: "{{ traefik_default_middleware_api }},calibre-web-nextgen-kobo-sync-headers"
 
 ################################
 # Docker

--- a/roles/calibre_web_nextgen/defaults/main.yml
+++ b/roles/calibre_web_nextgen/defaults/main.yml
@@ -48,11 +48,11 @@ calibre_web_nextgen_role_trusted_proxy_count: "1"
 
 calibre_web_nextgen_role_paths_folder: "{{ calibre_web_nextgen_name }}"
 calibre_web_nextgen_role_paths_location: "{{ server_appdata_path }}/{{ calibre_web_nextgen_role_paths_folder }}"
-calibre_web_nextgen_role_paths_media_location: "/mnt/unionfs/Media/{{ calibre_web_nextgen_role_media_subfolder }}"
+calibre_web_nextgen_role_paths_media_location: "{{ server_local_folder_path }}/Media/{{ calibre_web_nextgen_role_media_subfolder }}"
 calibre_web_nextgen_role_paths_ingest_location: "{{ downloads_root_path }}/{{ calibre_web_nextgen_role_ingest_subfolder }}"
 calibre_web_nextgen_role_paths_folders_list:
   - "{{ calibre_web_nextgen_role_paths_location }}"
-  - "{{ server_local_folder_path }}/Media/{{ calibre_web_nextgen_role_media_subfolder }}"
+  - "{{ calibre_web_nextgen_role_paths_media_location }}"
   - "{{ calibre_web_nextgen_role_paths_ingest_location }}"
 
 ################################

--- a/roles/calibre_web_nextgen/defaults/main.yml
+++ b/roles/calibre_web_nextgen/defaults/main.yml
@@ -40,7 +40,7 @@ calibre_web_nextgen_role_network_share_mode: false
 calibre_web_nextgen_role_calibre_user_plugins: false
 
 # Number of reverse proxies in front of the app
-calibre_web_nextgen_role_trusted_proxy_count: 1
+calibre_web_nextgen_role_trusted_proxy_count: "1"
 
 ################################
 # Paths

--- a/roles/calibre_web_nextgen/defaults/main.yml
+++ b/roles/calibre_web_nextgen/defaults/main.yml
@@ -48,11 +48,11 @@ calibre_web_nextgen_role_trusted_proxy_count: "1"
 
 calibre_web_nextgen_role_paths_folder: "{{ calibre_web_nextgen_name }}"
 calibre_web_nextgen_role_paths_location: "{{ server_appdata_path }}/{{ calibre_web_nextgen_role_paths_folder }}"
-calibre_web_nextgen_role_paths_media_location: "{{ server_local_folder_path }}/Media/{{ calibre_web_nextgen_role_media_subfolder }}"
+calibre_web_nextgen_role_paths_media_location: "/mnt/unionfs/Media/{{ calibre_web_nextgen_role_media_subfolder }}"
 calibre_web_nextgen_role_paths_ingest_location: "{{ downloads_root_path }}/{{ calibre_web_nextgen_role_ingest_subfolder }}"
 calibre_web_nextgen_role_paths_folders_list:
   - "{{ calibre_web_nextgen_role_paths_location }}"
-  - "{{ calibre_web_nextgen_role_paths_media_location }}"
+  - "{{ server_local_folder_path }}/Media/{{ calibre_web_nextgen_role_media_subfolder }}"
   - "{{ calibre_web_nextgen_role_paths_ingest_location }}"
 
 ################################

--- a/roles/calibre_web_nextgen/tasks/main.yml
+++ b/roles/calibre_web_nextgen/tasks/main.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:            Sandbox: Calibre-Web-NextGen                        #
+# Author(s):        balogan                                             #
+# URL:              https://github.com/saltyorg/Sandbox                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('role_var', '_dns_record') }}"
+    dns_zone: "{{ lookup('role_var', '_dns_zone') }}"
+    dns_proxy: "{{ lookup('role_var', '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -27,6 +27,7 @@
     - { role: bookstack, tags: ['bookstack'] }
     - { role: calibre, tags: ['calibre'] }
     - { role: calibre_web, tags: ['calibre-web'] }
+    - { role: calibre_web_nextgen, tags: ['calibre-web-nextgen'] }
     - { role: changedetection, tags: ['changedetection'] }
     - { role: cherry, tags: ['cherry'] }
     - { role: cleanuparr, tags: ['cleanuparr'] }


### PR DESCRIPTION
# Description

For new roles please include:

- [x] Official full name of the app: Calibre-Web-NextGen
- [x] Summary of what the app is:

    > A community-maintained continuation of Calibre-Web-Automated (CWA) — the self-hosted eBook library that adds automatic file conversion, EPUB repair, metadata enrichment, and folder-based ingest automation on top of Calibre-Web. Started because CWA's upstream maintainer has slowed down accepting community fixes; ships fixes and features faster while staying fully compatible with CWA (switching back is always possible without losing anything).

- [x] Link to Docker Compose sample: https://github.com/new-usemame/Calibre-Web-NextGen/blob/main/docker-compose.yml
- [x] Link to homepage: https://calibrewebnextgen.com/
- [x] Link to releases page: https://github.com/new-usemame/Calibre-Web-NextGen/pkgs/container/calibre-web-nextgen
- [x] Link to documentation: https://github.com/new-usemame/Calibre-Web-NextGen/wiki
- [x] Link to primary community space (Discord server, GitHub Discussions, forum...): https://discord.gg/B8NXZmcp32
- [ ] This role does not require Saltbox-specific configuration instructions (the upstream documentation is sufficient)
- [x] I will create documentation after the role is merged.

One Saltbox-specific behaviour worth a docs page: if the media library sits on a cloud-tiered mount managed by cloudplow, its default `rclone_excludes` cover `*.db` but not the `metadata.db-wal` / `metadata.db-shm` / `metadata.db-journal` sidecar files SQLite creates once this app opens the library read/write. Left unaddressed, cloudplow's periodic sweep can strand those sidecars on the cloud remote and subsequent library writes fail with `disk I/O error`.

This is a cloudplow concern rather than a role concern, so the role does not try to work around it. Two follow-ups are planned rather than folded in here: a docs PR against `saltyorg/docs` covering it, and a PR against `saltyorg/Saltbox` adding the three sidecar patterns to the `rclone_excludes` list in `roles/cloudplow/templates/config.json.j2`, which is currently hardcoded with no override hook.

# How Has This Been Tested?

- [x] The underlying task flow (DNS record creation, directory creation, Traefik routing/labels, container creation with these volumes/envs) was run live, twice, via `sb install sandbox-calibre-web-nextgen --no-cache` against a real Calibre-Web-NextGen deployment with an existing library (~100 books, previously managed via a hand-written `docker-compose.yml` with an equivalent volume/env layout). Both runs produced a clean container startup log against the existing library and a real functional write through the app afterward (book ingest via the drop-zone folder, converted/repaired/imported successfully, metadata fetched from a configured provider) with no regressions.
- Review feedback has since changed the role in ways that go beyond what that run covered: the ingest folder moved to the downloads root, SSO was enabled with a second Traefik router exempting the device/sync endpoints, and the optional credential envs are now omitted when unset. Those changes have not been re-run live. They are covered by this repo's CI, which performs a real isolated install of the role on every PR, and by YAML validation plus `scripts/saltbox-defaults-linter.py` locally.
- The SSO exemption list was derived from the app's own blueprint registrations (`cps/main.py`, `cps/opds.py`, `cps/kobo.py`, `cps/kobo_auth.py`, `cps/readingservices.py`, `cps/progress_syncing/protocols/kosync.py`) rather than from documentation. Every exempted route carries its own in-app authentication (`@requires_kobo_auth`, `@requires_reading_services_auth_and_config`, `@requires_basic_auth_if_no_ano`), so the exemption does not leave those paths open. I do not own a Kobo device, so end-to-end device sync through Traefik is unverified.
- `ansible-lint` wasn't runnable in my local environment; relying on CI for that pass.

Please also note any relevant details for your test configuration. You can use the checkboxes below or delete them as you wish.

- [ ] This is not a test I performed
- [ ] I did not read the paragraph above this before checking this box
- [ ] I have now checked three boxes without reading any of the text
- [ ] I have decided to leave these meaningless checkboxes in my pull request as a demonstration that I did not read to the end.


