### PR TITLE
Add tofa role

### DIFF
--- a/roles/tofa/defaults/main.yml
+++ b/roles/tofa/defaults/main.yml
@@ -102,20 +102,17 @@ tofa_role_docker_ports: "{{ lookup('role_var', '_docker_ports_default', role='to
 # reached through the tofa relay.
 # ADVERTISED_LAN_IP additionally advertises a direct LAN address; it is only
 # reachable when the port is published, hence the open_main_ports gate.
-tofa_role_docker_envs_lan:
-  ADVERTISED_LAN_IP: "{{ lookup('role_var', '_lan_ip', role='tofa') }}"
 tofa_role_docker_envs_default:
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
   MEDIA_PATH: /mnt/unionfs/Media
   TZ: "{{ tz }}"
   TOFA_CUSTOM_ACCESS_URLS: "{{ lookup('role_var', '_web_url', role='tofa') }}"
+  ADVERTISED_LAN_IP: "{{ lookup('role_var', '_lan_ip', role='tofa')
+                      if ((lookup('role_var', '_lan_ip', role='tofa') | length > 0) and lookup('role_var', '_open_main_ports', role='tofa'))
+                      else omit }}"
 tofa_role_docker_envs_custom: {}
 tofa_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='tofa')
-                           | combine(lookup('role_var', '_docker_envs_lan', role='tofa')
-                                     if ((lookup('role_var', '_lan_ip', role='tofa') | length > 0)
-                                         and lookup('role_var', '_open_main_ports', role='tofa'))
-                                     else {})
                            | combine(lookup('role_var', '_docker_envs_custom', role='tofa')) }}"
 
 # Volumes

--- a/roles/tofa/defaults/main.yml
+++ b/roles/tofa/defaults/main.yml
@@ -23,6 +23,8 @@ tofa_role_open_main_ports: false
 # Useful to avoid traffic going through your WAN when hairpin NAT is not available
 # Requires tofa_role_open_main_ports to be enabled
 tofa_role_lan_ip: ""
+# Defines MEDIA_PATH ENV value
+tofa_role_media_path: "/mnt/unionfs/Media"
 
 ################################
 # Paths
@@ -97,7 +99,7 @@ tofa_role_docker_ports_ui:
 tofa_role_docker_ports_custom: []
 tofa_role_docker_ports: "{{ lookup('role_var', '_docker_ports_default', role='tofa')
                             + lookup('role_var', '_docker_ports_custom', role='tofa')
-                            + (tofa_role_docker_ports_ui
+                            + (lookup('role_var', '_docker_ports_ui', role='tofa')
                                if lookup('role_var', '_open_main_ports', role='tofa')
                                else []) }}"
 
@@ -105,7 +107,7 @@ tofa_role_docker_ports: "{{ lookup('role_var', '_docker_ports_default', role='to
 tofa_role_docker_envs_default:
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
-  MEDIA_PATH: /mnt/unionfs/Media
+  MEDIA_PATH: "{{ lookup('role_var', '_media_path', role='tofa') }}"
   TZ: "{{ tz }}"
   TOFA_CUSTOM_ACCESS_URLS: "{{ lookup('role_var', '_web_url', role='tofa') }}"
   TOFA_PORT: "{{ lookup('role_var', '_web_port', role='tofa') }}"

--- a/roles/tofa/defaults/main.yml
+++ b/roles/tofa/defaults/main.yml
@@ -110,7 +110,7 @@ tofa_role_docker_envs_default:
   MEDIA_PATH: "{{ lookup('role_var', '_media_path', role='tofa') }}"
   TZ: "{{ tz }}"
   TOFA_CUSTOM_ACCESS_URLS: "{{ lookup('role_var', '_web_url', role='tofa') }}"
-  TOFA_PORT: "{{ lookup('role_var', '_web_port', role='tofa') }}"
+  TOFA_PORT: "{{ lookup('role_var', '_web_port', role='tofa') | string }}"
   ADVERTISED_LAN_IP: "{{ lookup('role_var', '_lan_ip', role='tofa')
                       if ((lookup('role_var', '_lan_ip', role='tofa') | length > 0) and lookup('role_var', '_open_main_ports', role='tofa'))
                       else omit }}"

--- a/roles/tofa/defaults/main.yml
+++ b/roles/tofa/defaults/main.yml
@@ -62,6 +62,9 @@ tofa_role_traefik_api_endpoint: ""
 # Container
 tofa_role_docker_container: "{{ tofa_name }}"
 
+# GPU
+tofa_role_docker_gpu_enabled: true
+
 # Image
 tofa_role_docker_image_pull: true
 tofa_role_docker_image_repo: "ghcr.io/tofatv/tofa"

--- a/roles/tofa/defaults/main.yml
+++ b/roles/tofa/defaults/main.yml
@@ -41,10 +41,8 @@ tofa_role_paths_folders_list:
 
 tofa_role_web_subdomain: "{{ tofa_name }}"
 tofa_role_web_domain: "{{ user.domain }}"
-tofa_role_web_port: "{{ lookup('role_var', '_docker_ports_33333', role='tofa') }}"
-tofa_role_web_url: "https://{{ lookup('role_var', '_web_subdomain', role='tofa') + '.' + lookup('role_var', '_web_domain', role='tofa')
-                            if (lookup('role_var', '_web_subdomain', role='tofa') | length > 0)
-                            else lookup('role_var', '_web_domain', role='tofa') }}"
+tofa_role_web_port: "{{ tofa_port_assignment.ports.web }}"
+tofa_role_web_url: "{{ lookup('role_web', role='tofa', scheme='https') }}"
 
 ################################
 # DNS
@@ -61,10 +59,19 @@ tofa_role_dns_proxy: "{{ dns_proxied }}"
 tofa_role_traefik_sso_middleware: ""
 tofa_role_traefik_middleware_default: "{{ traefik_default_middleware }}"
 tofa_role_traefik_middleware_custom: ""
+tofa_role_traefik_middleware_default_api: "{{ traefik_default_middleware_api }}"
+tofa_role_traefik_middleware_custom_api: ""
 tofa_role_traefik_certresolver: "{{ traefik_default_certresolver }}"
 tofa_role_traefik_enabled: true
 tofa_role_traefik_api_enabled: false
 tofa_role_traefik_api_endpoint: ""
+
+################################
+# Ports
+################################
+
+tofa_role_port_web_low_bound: 33333
+tofa_role_port_web_high_bound: 33433
 
 ################################
 # Docker
@@ -83,13 +90,10 @@ tofa_role_docker_image_tag: "beta"
 tofa_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='tofa') }}:{{ lookup('role_var', '_docker_image_tag', role='tofa') }}"
 
 # Ports
-tofa_role_docker_ports_33333: "{{ port_lookup_33333.meta.port
-                               if (port_lookup_33333.meta.port is defined) and (port_lookup_33333.meta.port | trim | length > 0)
-                               else '33333' }}"
 tofa_role_docker_ports_default: []
 # Skip docs
 tofa_role_docker_ports_ui:
-  - "{{ lookup('role_var', '_docker_ports_33333', role='tofa') }}:{{ lookup('role_var', '_docker_ports_33333', role='tofa') }}"
+  - "{{ lookup('role_var', '_web_port', role='tofa') }}:{{ lookup('role_var', '_web_port', role='tofa') }}"
 tofa_role_docker_ports_custom: []
 tofa_role_docker_ports: "{{ lookup('role_var', '_docker_ports_default', role='tofa')
                             + lookup('role_var', '_docker_ports_custom', role='tofa')
@@ -98,20 +102,13 @@ tofa_role_docker_ports: "{{ lookup('role_var', '_docker_ports_default', role='to
                                else []) }}"
 
 # Envs
-# The container starts as root and drops to PUID:PGID itself, so appdata stays
-# owned by the Saltbox user rather than the image's baked-in uid.
-# TOFA_CUSTOM_ACCESS_URLS advertises the Traefik URL to clients as a direct
-# connection candidate; without it a bridge-networked server can only be
-# reached through the tofa relay.
-# ADVERTISED_LAN_IP additionally advertises a direct LAN address; it is only
-# reachable when the port is published, hence the open_main_ports gate.
 tofa_role_docker_envs_default:
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
   MEDIA_PATH: /mnt/unionfs/Media
   TZ: "{{ tz }}"
   TOFA_CUSTOM_ACCESS_URLS: "{{ lookup('role_var', '_web_url', role='tofa') }}"
-  TOFA_PORT: "{{ lookup('role_var', '_docker_ports_33333', role='tofa') }}"
+  TOFA_PORT: "{{ lookup('role_var', '_web_port', role='tofa') }}"
   ADVERTISED_LAN_IP: "{{ lookup('role_var', '_lan_ip', role='tofa')
                       if ((lookup('role_var', '_lan_ip', role='tofa') | length > 0) and lookup('role_var', '_open_main_ports', role='tofa'))
                       else omit }}"
@@ -120,22 +117,12 @@ tofa_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='tofa
                            | combine(lookup('role_var', '_docker_envs_custom', role='tofa')) }}"
 
 # Volumes
-# Media is reached through the global /mnt:/mnt:rslave mount (so unionfs
-# remounts propagate), which is why MEDIA_PATH above is a host path.
-# The transcode cache lives at <data>/cache/streams; binding it there is what
-# keeps segment churn on transcodes_path instead of the appdata disk.
 tofa_role_docker_volumes_default:
   - "{{ lookup('role_var', '_paths_location', role='tofa') }}:/data"
   - "{{ lookup('role_var', '_paths_transcodes_location', role='tofa') }}:/data/cache/streams"
 tofa_role_docker_volumes_custom: []
 tofa_role_docker_volumes: "{{ lookup('role_var', '_docker_volumes_default', role='tofa')
                               + lookup('role_var', '_docker_volumes_custom', role='tofa') }}"
-
-# Mounts
-tofa_role_docker_mounts_default: []
-tofa_role_docker_mounts_custom: []
-tofa_role_docker_mounts: "{{ lookup('role_var', '_docker_mounts_default', role='tofa')
-                             + lookup('role_var', '_docker_mounts_custom', role='tofa') }}"
 
 # Hostname
 tofa_role_docker_hostname: "{{ tofa_name }}"

--- a/roles/tofa/defaults/main.yml
+++ b/roles/tofa/defaults/main.yml
@@ -17,7 +17,7 @@ tofa_instances: ["tofa"]
 # Settings
 ################################
 
-# Do not enable globally if deploying multiple instances
+# Safe with multiple instances; each instance is assigned its own port
 tofa_role_open_main_ports: false
 # Adds the IP specified here to the advertised URLs tofa broadcasts to clients
 # Useful to avoid traffic going through your WAN when hairpin NAT is not available
@@ -41,7 +41,7 @@ tofa_role_paths_folders_list:
 
 tofa_role_web_subdomain: "{{ tofa_name }}"
 tofa_role_web_domain: "{{ user.domain }}"
-tofa_role_web_port: "33333"
+tofa_role_web_port: "{{ lookup('role_var', '_docker_ports_33333', role='tofa') }}"
 tofa_role_web_url: "https://{{ lookup('role_var', '_web_subdomain', role='tofa') + '.' + lookup('role_var', '_web_domain', role='tofa')
                             if (lookup('role_var', '_web_subdomain', role='tofa') | length > 0)
                             else lookup('role_var', '_web_domain', role='tofa') }}"
@@ -83,13 +83,13 @@ tofa_role_docker_image_tag: "beta"
 tofa_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='tofa') }}:{{ lookup('role_var', '_docker_image_tag', role='tofa') }}"
 
 # Ports
-# Host-side port for the main binding; give each instance its own
-# (e.g. tofa2_docker_ports_33333: "33334") to open ports on multiple instances.
-tofa_role_docker_ports_33333: "33333"
+tofa_role_docker_ports_33333: "{{ port_lookup_33333.meta.port
+                               if (port_lookup_33333.meta.port is defined) and (port_lookup_33333.meta.port | trim | length > 0)
+                               else '33333' }}"
 tofa_role_docker_ports_default: []
 # Skip docs
 tofa_role_docker_ports_ui:
-  - "{{ lookup('role_var', '_docker_ports_33333', role='tofa') }}:33333"
+  - "{{ lookup('role_var', '_docker_ports_33333', role='tofa') }}:{{ lookup('role_var', '_docker_ports_33333', role='tofa') }}"
 tofa_role_docker_ports_custom: []
 tofa_role_docker_ports: "{{ lookup('role_var', '_docker_ports_default', role='tofa')
                             + lookup('role_var', '_docker_ports_custom', role='tofa')
@@ -111,7 +111,8 @@ tofa_role_docker_envs_default:
   MEDIA_PATH: /mnt/unionfs/Media
   TZ: "{{ tz }}"
   TOFA_CUSTOM_ACCESS_URLS: "{{ lookup('role_var', '_web_url', role='tofa') }}"
-  ADVERTISED_LAN_IP: "{{ lookup('role_var', '_lan_ip', role='tofa') + ':' + lookup('role_var', '_docker_ports_33333', role='tofa')
+  TOFA_PORT: "{{ lookup('role_var', '_docker_ports_33333', role='tofa') }}"
+  ADVERTISED_LAN_IP: "{{ lookup('role_var', '_lan_ip', role='tofa')
                       if ((lookup('role_var', '_lan_ip', role='tofa') | length > 0) and lookup('role_var', '_open_main_ports', role='tofa'))
                       else omit }}"
 tofa_role_docker_envs_custom: {}

--- a/roles/tofa/defaults/main.yml
+++ b/roles/tofa/defaults/main.yml
@@ -1,0 +1,118 @@
+##########################################################################
+# Title:            Sandbox: tofa   | Default Variables                  #
+# Author(s):        gylli251                                             #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+tofa_name: tofa
+
+################################
+# Paths
+################################
+
+tofa_role_paths_folder: "{{ tofa_name }}"
+tofa_role_paths_location: "{{ server_appdata_path }}/{{ tofa_role_paths_folder }}"
+tofa_role_paths_transcodes_location: "{{ transcodes_path }}/{{ tofa_role_paths_folder }}"
+tofa_role_paths_folders_list:
+  - "{{ tofa_role_paths_location }}"
+  - "{{ tofa_role_paths_transcodes_location }}"
+
+################################
+# Web
+################################
+
+tofa_role_web_subdomain: "{{ tofa_name }}"
+tofa_role_web_domain: "{{ user.domain }}"
+tofa_role_web_port: "33333"
+tofa_role_web_url: "https://{{ lookup('role_var', '_web_subdomain', role='tofa') + '.' + lookup('role_var', '_web_domain', role='tofa')
+                            if (lookup('role_var', '_web_subdomain', role='tofa') | length > 0)
+                            else lookup('role_var', '_web_domain', role='tofa') }}"
+
+################################
+# DNS
+################################
+
+tofa_role_dns_record: "{{ lookup('role_var', '_web_subdomain', role='tofa') }}"
+tofa_role_dns_zone: "{{ lookup('role_var', '_web_domain', role='tofa') }}"
+tofa_role_dns_proxy: "{{ dns_proxied }}"
+
+################################
+# Traefik
+################################
+
+tofa_role_traefik_sso_middleware: ""
+tofa_role_traefik_middleware_default: "{{ traefik_default_middleware }}"
+tofa_role_traefik_middleware_custom: ""
+tofa_role_traefik_certresolver: "{{ traefik_default_certresolver }}"
+tofa_role_traefik_enabled: true
+tofa_role_traefik_api_enabled: false
+tofa_role_traefik_api_endpoint: ""
+
+################################
+# Docker
+################################
+
+# Container
+tofa_role_docker_container: "{{ tofa_name }}"
+
+# Image
+tofa_role_docker_image_pull: true
+tofa_role_docker_image_repo: "ghcr.io/tofatv/tofa"
+tofa_role_docker_image_tag: "beta"
+tofa_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='tofa') }}:{{ lookup('role_var', '_docker_image_tag', role='tofa') }}"
+
+# Envs
+# The container starts as root and drops to PUID:PGID itself, so appdata stays
+# owned by the Saltbox user rather than the image's baked-in uid.
+tofa_role_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  MEDIA_PATH: /mnt/unionfs/Media
+  TZ: "{{ tz }}"
+tofa_role_docker_envs_custom: {}
+tofa_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='tofa')
+                           | combine(lookup('role_var', '_docker_envs_custom', role='tofa')) }}"
+
+# Volumes
+# Media is reached through the global /mnt:/mnt:rslave mount (so unionfs
+# remounts propagate), which is why MEDIA_PATH above is a host path.
+# The transcode cache lives at <data>/cache/streams; binding it there is what
+# keeps segment churn on transcodes_path instead of the appdata disk.
+tofa_role_docker_volumes_default:
+  - "{{ lookup('role_var', '_paths_location', role='tofa') }}:/data"
+  - "{{ lookup('role_var', '_paths_transcodes_location', role='tofa') }}:/data/cache/streams"
+tofa_role_docker_volumes_custom: []
+tofa_role_docker_volumes: "{{ lookup('role_var', '_docker_volumes_default', role='tofa')
+                              + lookup('role_var', '_docker_volumes_custom', role='tofa') }}"
+
+# Mounts
+tofa_role_docker_mounts_default:
+  - target: /tmp
+    type: tmpfs
+tofa_role_docker_mounts_custom: []
+tofa_role_docker_mounts: "{{ lookup('role_var', '_docker_mounts_default', role='tofa')
+                             + lookup('role_var', '_docker_mounts_custom', role='tofa') }}"
+
+# Hostname
+tofa_role_docker_hostname: "{{ tofa_name }}"
+
+# Init
+tofa_role_docker_init: true
+
+# Networks
+tofa_role_docker_networks_alias: "{{ tofa_name }}"
+tofa_role_docker_networks_default: []
+tofa_role_docker_networks_custom: []
+tofa_role_docker_networks: "{{ docker_networks_common
+                               + lookup('role_var', '_docker_networks_default', role='tofa')
+                               + lookup('role_var', '_docker_networks_custom', role='tofa') }}"
+
+# Restart Policy
+tofa_role_docker_restart_policy: unless-stopped

--- a/roles/tofa/defaults/main.yml
+++ b/roles/tofa/defaults/main.yml
@@ -96,9 +96,7 @@ tofa_role_docker_volumes: "{{ lookup('role_var', '_docker_volumes_default', role
                               + lookup('role_var', '_docker_volumes_custom', role='tofa') }}"
 
 # Mounts
-tofa_role_docker_mounts_default:
-  - target: /tmp
-    type: tmpfs
+tofa_role_docker_mounts_default: []
 tofa_role_docker_mounts_custom: []
 tofa_role_docker_mounts: "{{ lookup('role_var', '_docker_mounts_default', role='tofa')
                              + lookup('role_var', '_docker_mounts_custom', role='tofa') }}"

--- a/roles/tofa/defaults/main.yml
+++ b/roles/tofa/defaults/main.yml
@@ -14,6 +14,17 @@
 tofa_name: tofa
 
 ################################
+# Settings
+################################
+
+# Do not enable globally if deploying multiple instances
+tofa_role_open_main_ports: false
+# Adds the IP specified here to the advertised URLs tofa broadcasts to clients
+# Useful to avoid traffic going through your WAN when hairpin NAT is not available
+# Requires tofa_role_open_main_ports to be enabled
+tofa_role_lan_ip: ""
+
+################################
 # Paths
 ################################
 
@@ -71,16 +82,40 @@ tofa_role_docker_image_repo: "ghcr.io/tofatv/tofa"
 tofa_role_docker_image_tag: "beta"
 tofa_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='tofa') }}:{{ lookup('role_var', '_docker_image_tag', role='tofa') }}"
 
+# Ports
+tofa_role_docker_ports_default: []
+# Skip docs
+tofa_role_docker_ports_ui:
+  - "33333:33333"
+tofa_role_docker_ports_custom: []
+tofa_role_docker_ports: "{{ lookup('role_var', '_docker_ports_default', role='tofa')
+                            + lookup('role_var', '_docker_ports_custom', role='tofa')
+                            + (tofa_role_docker_ports_ui
+                               if lookup('role_var', '_open_main_ports', role='tofa')
+                               else []) }}"
+
 # Envs
 # The container starts as root and drops to PUID:PGID itself, so appdata stays
 # owned by the Saltbox user rather than the image's baked-in uid.
+# TOFA_CUSTOM_ACCESS_URLS advertises the Traefik URL to clients as a direct
+# connection candidate; without it a bridge-networked server can only be
+# reached through the tofa relay.
+# ADVERTISED_LAN_IP additionally advertises a direct LAN address; it is only
+# reachable when the port is published, hence the open_main_ports gate.
+tofa_role_docker_envs_lan:
+  ADVERTISED_LAN_IP: "{{ lookup('role_var', '_lan_ip', role='tofa') }}"
 tofa_role_docker_envs_default:
   PUID: "{{ uid }}"
   PGID: "{{ gid }}"
   MEDIA_PATH: /mnt/unionfs/Media
   TZ: "{{ tz }}"
+  TOFA_CUSTOM_ACCESS_URLS: "{{ lookup('role_var', '_web_url', role='tofa') }}"
 tofa_role_docker_envs_custom: {}
 tofa_role_docker_envs: "{{ lookup('role_var', '_docker_envs_default', role='tofa')
+                           | combine(lookup('role_var', '_docker_envs_lan', role='tofa')
+                                     if ((lookup('role_var', '_lan_ip', role='tofa') | length > 0)
+                                         and lookup('role_var', '_open_main_ports', role='tofa'))
+                                     else {})
                            | combine(lookup('role_var', '_docker_envs_custom', role='tofa')) }}"
 
 # Volumes

--- a/roles/tofa/defaults/main.yml
+++ b/roles/tofa/defaults/main.yml
@@ -11,7 +11,7 @@
 # Basics
 ################################
 
-tofa_name: tofa
+tofa_instances: ["tofa"]
 
 ################################
 # Settings
@@ -83,10 +83,13 @@ tofa_role_docker_image_tag: "beta"
 tofa_role_docker_image: "{{ lookup('role_var', '_docker_image_repo', role='tofa') }}:{{ lookup('role_var', '_docker_image_tag', role='tofa') }}"
 
 # Ports
+# Host-side port for the main binding; give each instance its own
+# (e.g. tofa2_docker_ports_33333: "33334") to open ports on multiple instances.
+tofa_role_docker_ports_33333: "33333"
 tofa_role_docker_ports_default: []
 # Skip docs
 tofa_role_docker_ports_ui:
-  - "33333:33333"
+  - "{{ lookup('role_var', '_docker_ports_33333', role='tofa') }}:33333"
 tofa_role_docker_ports_custom: []
 tofa_role_docker_ports: "{{ lookup('role_var', '_docker_ports_default', role='tofa')
                             + lookup('role_var', '_docker_ports_custom', role='tofa')
@@ -108,7 +111,7 @@ tofa_role_docker_envs_default:
   MEDIA_PATH: /mnt/unionfs/Media
   TZ: "{{ tz }}"
   TOFA_CUSTOM_ACCESS_URLS: "{{ lookup('role_var', '_web_url', role='tofa') }}"
-  ADVERTISED_LAN_IP: "{{ lookup('role_var', '_lan_ip', role='tofa')
+  ADVERTISED_LAN_IP: "{{ lookup('role_var', '_lan_ip', role='tofa') + ':' + lookup('role_var', '_docker_ports_33333', role='tofa')
                       if ((lookup('role_var', '_lan_ip', role='tofa') | length > 0) and lookup('role_var', '_open_main_ports', role='tofa'))
                       else omit }}"
 tofa_role_docker_envs_custom: {}

--- a/roles/tofa/tasks/main.yml
+++ b/roles/tofa/tasks/main.yml
@@ -7,18 +7,10 @@
 #                   GNU General Public License v3.0                      #
 ##########################################################################
 ---
-- name: Add DNS record
-  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+- name: "Execute tofa roles"
+  ansible.builtin.include_tasks: main2.yml
   vars:
-    dns_record: "{{ lookup('role_var', '_dns_record') }}"
-    dns_zone: "{{ lookup('role_var', '_dns_zone') }}"
-    dns_proxy: "{{ lookup('role_var', '_dns_proxy') }}"
-
-- name: Remove existing Docker container
-  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
-
-- name: Create directories
-  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
-
-- name: Create Docker container
-  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"
+    tofa_name: "{{ instance }}"
+  with_items: "{{ tofa_instances }}"
+  loop_control:
+    loop_var: instance

--- a/roles/tofa/tasks/main.yml
+++ b/roles/tofa/tasks/main.yml
@@ -20,9 +20,5 @@
 - name: Create directories
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
 
-- name: Docker Devices Task
-  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/set_docker_devices_variable.yml"
-  when: use_intel or use_nvidia
-
 - name: Create Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/tofa/tasks/main.yml
+++ b/roles/tofa/tasks/main.yml
@@ -1,0 +1,28 @@
+##########################################################################
+# Title:            Sandbox: tofa                                        #
+# Author(s):        gylli251                                             #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('role_var', '_dns_record') }}"
+    dns_zone: "{{ lookup('role_var', '_dns_zone') }}"
+    dns_proxy: "{{ lookup('role_var', '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Docker Devices Task
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/set_docker_devices_variable.yml"
+  when: use_intel or use_nvidia
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/tofa/tasks/main2.yml
+++ b/roles/tofa/tasks/main2.yml
@@ -1,0 +1,24 @@
+##########################################################################
+# Title:            Sandbox: tofa                                        #
+# Author(s):        gylli251                                             #
+# URL:              https://github.com/saltyorg/Sandbox                  #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('role_var', '_dns_record') }}"
+    dns_zone: "{{ lookup('role_var', '_dns_zone') }}"
+    dns_proxy: "{{ lookup('role_var', '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/tofa/tasks/main2.yml
+++ b/roles/tofa/tasks/main2.yml
@@ -17,13 +17,23 @@
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 
+- name: Initialize or update port range low bound
+  ansible.builtin.set_fact:
+    tofa_port_range_low_bound: "{{ tofa_port_range_low_bound | default(33333) }}"
+  when: lookup('role_var', '_open_main_ports', role='tofa')
+
 - name: Get next available port within the range of '33333-33433'
   find_open_port:
-    low_bound: 33333
+    low_bound: "{{ tofa_port_range_low_bound }}"
     high_bound: 33433
     protocol: tcp
   register: port_lookup_33333
   ignore_errors: true
+  when: lookup('role_var', '_open_main_ports', role='tofa')
+
+- name: Update port range low bound for next iteration
+  ansible.builtin.set_fact:
+    tofa_port_range_low_bound: "{{ (lookup('role_var', '_docker_ports_33333', role='tofa') | int) + 1 }}"
   when: lookup('role_var', '_open_main_ports', role='tofa')
 
 - name: Create directories

--- a/roles/tofa/tasks/main2.yml
+++ b/roles/tofa/tasks/main2.yml
@@ -17,24 +17,17 @@
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 
-- name: Initialize or update port range low bound
-  ansible.builtin.set_fact:
-    tofa_port_range_low_bound: "{{ tofa_port_range_low_bound | default(33333) }}"
-  when: lookup('role_var', '_open_main_ports', role='tofa')
-
-- name: Get next available port within the range of '33333-33433'
-  find_open_port:
-    low_bound: "{{ tofa_port_range_low_bound }}"
-    high_bound: 33433
-    protocol: tcp
-  register: port_lookup_33333
-  ignore_errors: true
-  when: lookup('role_var', '_open_main_ports', role='tofa')
-
-- name: Update port range low bound for next iteration
-  ansible.builtin.set_fact:
-    tofa_port_range_low_bound: "{{ (lookup('role_var', '_docker_ports_33333', role='tofa') | int) + 1 }}"
-  when: lookup('role_var', '_open_main_ports', role='tofa')
+- name: Assign port
+  port_assignment:
+    base_path: "{{ server_appdata_path }}"
+    namespace: tofa
+    owner: "{{ tofa_name }}"
+    claims:
+      web:
+        low_bound: "{{ lookup('role_var', '_port_web_low_bound', role='tofa') }}"
+        high_bound: "{{ lookup('role_var', '_port_web_high_bound', role='tofa') }}"
+        protocols: ["tcp"]
+  register: tofa_port_assignment
 
 - name: Create directories
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"

--- a/roles/tofa/tasks/main2.yml
+++ b/roles/tofa/tasks/main2.yml
@@ -17,6 +17,15 @@
 - name: Remove existing Docker container
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 
+- name: Get next available port within the range of '33333-33433'
+  find_open_port:
+    low_bound: 33333
+    high_bound: 33433
+    protocol: tcp
+  register: port_lookup_33333
+  ignore_errors: true
+  when: lookup('role_var', '_open_main_ports', role='tofa')
+
 - name: Create directories
   ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
 

--- a/sandbox.yml
+++ b/sandbox.yml
@@ -161,6 +161,7 @@
     - { role: thelounge, tags: ['thelounge'] }
     - { role: threadfin, tags: ['threadfin'] }
     - { role: tika, tags: ['tika'] }
+    - { role: tofa, tags: ['tofa'] }
     - { role: tqm, tags: ['tqm'] }
     - { role: traccar, tags: ['traccar'] }
     - { role: traefik_robotstxt, tags: ['traefik-robotstxt'] }


### PR DESCRIPTION

# Description

For new roles please include:

- [x] Official full name of the app: tofa
- [x] Summary of what the app is:
 a self-hosted media server for streaming your own movie and TV library to web, mobile, and TV apps, with hardware-accelerated transcoding.

- [x] Link to Docker Compose sample: (inlined below, the repository is currently private during beta)

  ```yaml
  services:
    tofa:
      image: ghcr.io/tofatv/tofa:beta
      container_name: tofa
      init: true
      restart: unless-stopped
      network_mode: host        # tofa uses port 33333; embedded DB stays on 127.0.0.1
      volumes:
        - tofa-data:/data       # database, backups, cache, logs
        - /path/to/your/media:/media
      # Optional hardware transcoding (Intel/AMD):
      # devices:
      #   - /dev/dri:/dev/dri
  volumes:
    tofa-data:

- [x] Link to homepage: https://tofa.tv
- [x] Link to releases page: https://docs.tofa.tv/whats-new.html
- [x] Link to documentation: https://docs.tofa.tv
- [x] Link to primary community space: https://tofa.tv/discord
- [x] This role does not require Saltbox-specific configuration instructions (the upstream documentation is sufficient)

How Has This Been Tested?
Deployed the role on a Saltbox install and verified: container comes up healthy, appdata lands in /opt/tofa owned by the Saltbox user (the container starts as root and drops to PUID/PGID itself), media is reached via MEDIA_PATH=/mnt/unionfs/Media through the global /mnt mount, transcode segments land on transcodes_path via the /data/cache/streams bind, Traefik routing and DNS record creation work, and Intel/NVIDIA hardware transcoding works via the standard Saltbox devices task (the image detects /dev/dri group membership itself since 0.9.32, so no group_add entries are needed).
